### PR TITLE
feat: switch client to vLLM 0.20 /inference/v1/generate

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renderers"
-version = "0.1.5"
+version = "0.1.6"
 description = "Chat template renderers — deterministic message-to-token conversion for LLM training"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -1,8 +1,7 @@
-"""Renderer-based verifiers client.
+"""Renderer-based generate client for vLLM 0.20's /inference/v1/generate.
 
-All tokenization happens client-side via a Renderer:
-    messages → Renderer.render_ids() → token IDs → vLLM /v1/generate → completion tokens
-    completion tokens → Renderer.parse_response() → structured message back to verifiers
+    messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
+    → completion tokens → Renderer.parse_response() → structured message
 
 When a RendererPool is passed instead of a single Renderer, the sync tokenization
 and parsing work is offloaded to threads for parallel execution across rollouts.
@@ -22,15 +21,10 @@ from openai import AsyncOpenAI, BadRequestError
 
 from renderers.base import Message, Renderer, RendererPool, ToolSpec
 
-# Logs the (per-message length, total prompt length) on every vLLM /generate
-# call at DEBUG, and the same plus the response text on a 4xx at WARNING.
-# Lets us post-mortem overlong-prompt rejections without re-running.
-_request_logger = logging.getLogger("verifiers.renderer_client.completions_request")
+_request_logger = logging.getLogger("renderers.client")
 
 
 async def _run_pooled(pool: RendererPool, fn):
-    """Check out a renderer, run *fn(renderer)* in a thread, return result."""
-
     def _work():
         with pool.checkout() as r:
             return fn(r)
@@ -38,19 +32,29 @@ async def _run_pooled(pool: RendererPool, fn):
     return await asyncio.to_thread(_work)
 
 
-async def completions_request(
+async def generate(
+    *,
     client: AsyncOpenAI,
     renderer: Renderer | RendererPool,
     messages: list[Message],
     model: str,
-    tools: list[ToolSpec] | None = None,
     prompt_ids: list[int] | None = None,
-    **sampling_args: Any,
+    tools: list[ToolSpec] | None = None,
+    sampling_params: dict[str, Any] | None = None,
+    cache_salt: str | None = None,
+    priority: int | None = None,
+    extra_headers: dict[str, str] | None = None,
 ) -> dict[str, Any]:
-    """Render messages to tokens, call vLLM /v1/generate, return parsed result.
+    """Tokenize messages, call vLLM /inference/v1/generate, parse the response.
 
-    Returns a dict with: prompt_ids, completion_ids, completion_logprobs,
-    content, reasoning_content, tool_calls, finish_reason, usage, routed_experts.
+    ``sampling_params`` is forwarded to vLLM verbatim. Two fields are always
+    set by us and override caller values: ``stop_token_ids`` (from the
+    renderer) and ``logprobs=1`` (we always emit completion_logprobs). Pass
+    ``prompt_ids`` to skip rendering and use a prebuilt token sequence.
+
+    Returns a dict with: request_id, prompt_ids, completion_ids,
+    completion_logprobs, content, reasoning_content, tool_calls,
+    finish_reason, routed_experts.
     """
     if tools and not getattr(renderer, "supports_tools", True):
         raise ValueError(
@@ -60,74 +64,44 @@ async def completions_request(
 
     pool = renderer if isinstance(renderer, RendererPool) else None
 
-    # -- Prepare: tokenize prompt --
     def _prepare(r: Renderer):
-        prepared_prompt_ids = (
+        ids = (
             list(prompt_ids)
             if prompt_ids is not None
             else r.render_ids(messages, tools=tools, add_generation_prompt=True)
         )
-        stop_token_ids = r.get_stop_token_ids()
-        return prepared_prompt_ids, stop_token_ids
+        return ids, r.get_stop_token_ids()
 
     if pool is not None:
         prompt_ids, stop_token_ids = await _run_pooled(pool, _prepare)
     else:
         prompt_ids, stop_token_ids = _prepare(renderer)
 
-    # -- Build request body --
+    sp: dict[str, Any] = dict(sampling_params or {})
+    sp["stop_token_ids"] = stop_token_ids
+    sp["logprobs"] = 1
+    sp.setdefault("skip_special_tokens", False)
+
     body: dict[str, Any] = {
         "model": model,
-        "prompt_token_ids": prompt_ids,
-        "stop_token_ids": stop_token_ids,
+        "token_ids": prompt_ids,
+        "sampling_params": sp,
     }
+    if cache_salt is not None:
+        body["cache_salt"] = cache_salt
+    if priority is not None:
+        body["priority"] = priority
 
-    # Top-level keys accepted by vLLM /generate's GenerateRequest schema. We
-    # forward anything the caller set, mirroring the OpenAI chat-completions
-    # client (which splats ``sampling_args`` into the SDK call). ``cache_salt``
-    # is set by prime-rl's orchestrator per ckpt_step to invalidate stale
-    # prefix-cache KV after each policy update — without forwarding it, vLLM
-    # silently reuses KV computed with older weights → mismatch_kl drifts up
-    # over training.
-    _GENERATE_KEYS = (
-        "temperature",
-        "top_p",
-        "top_k",
-        "min_p",
-        "seed",
-        "n",
-        "repetition_penalty",
-        "min_tokens",
-        "prompt_logprobs",
-        "priority",
-        "cache_salt",
-    )
-    for key in _GENERATE_KEYS:
-        if key in sampling_args and sampling_args[key] is not None:
-            body[key] = sampling_args[key]
-
-    max_tokens = sampling_args.get("max_completion_tokens") or sampling_args.get(
-        "max_tokens"
-    )
-    if max_tokens is not None:
-        body["max_tokens"] = max_tokens
-
-    # Fallback for callers using the OpenAI-SDK convention of stuffing
-    # vLLM-specific args under ``extra_body``.
-    extra_body = sampling_args.get("extra_body") or {}
-    for key in _GENERATE_KEYS:
-        if key not in body and key in extra_body and extra_body[key] is not None:
-            body[key] = extra_body[key]
-
-    # Pass through caller-supplied HTTP headers (auth, tracing, etc.) to vLLM.
-    extra_headers = sampling_args.get("extra_headers") or {}
-
-    # -- Send to vLLM --
+    # /inference/v1/generate is mounted at the server root, not under /v1
+    # like the OpenAI-compatible endpoints. Build an absolute URL so the
+    # AsyncOpenAI client doesn't prepend its automatic /v1.
+    base = str(client.base_url).rstrip("/").removesuffix("/v1")
+    endpoint = f"{base}/inference/v1/generate"
     _request_logger.debug(
-        "vllm /generate: prompt_len=%d messages=%d max_tokens=%s",
+        "POST %s prompt_len=%d max_tokens=%s",
+        endpoint,
         len(prompt_ids),
-        len(messages),
-        max_tokens,
+        sp.get("max_tokens"),
     )
     post_kwargs: dict[str, Any] = {
         "cast_to": cast(Any, dict[str, Any]),
@@ -136,19 +110,17 @@ async def completions_request(
     if extra_headers:
         post_kwargs["options"] = cast(Any, {"headers": extra_headers})
     try:
-        data = await client.post("/generate", **post_kwargs)
+        data = await client.post(endpoint, **post_kwargs)
     except BadRequestError as exc:
         _log_overlong_prompt_diagnostic(
             prompt_ids=prompt_ids,
             messages=messages,
-            max_tokens=max_tokens,
+            max_tokens=sp.get("max_tokens"),
             exc=exc,
         )
         raise
-    choices = data.get("choices") or [{}]
-    choice = choices[0]
 
-    # -- Parse completion tokens --
+    choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
 
     if pool is not None:
@@ -156,11 +128,11 @@ async def completions_request(
     else:
         parsed = renderer.parse_response(completion_ids)
 
-    completion_logprobs = [
-        float(lp) if lp is not None else 0.0 for lp in choice.get("logprobs") or []
-    ]
+    # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}
+    raw_logprobs = choice.get("logprobs") or {}
+    content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
+    completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
 
-    # Extract routed experts
     routed_experts = None
     raw_re = choice.get("routed_experts")
     if isinstance(raw_re, dict) and "data" in raw_re and "shape" in raw_re:
@@ -170,20 +142,17 @@ async def completions_request(
             .tolist()
         )
 
-    # vLLM's /v1/generate only knows about the raw generate loop, so it
-    # returns finish_reason in {"stop","length",…} — never "tool_calls",
-    # which is a chat-completions concept. When we extract tool calls
-    # client-side from the tokens, promote "stop" → "tool_calls" so
-    # OpenAI-compatible agent loops (AI SDK, opencode) continue past the
-    # tool turn instead of treating the response as final output.
+    # /inference/v1/generate returns finish_reason in {"stop","length",...} —
+    # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
+    # when we extracted tool calls client-side, so OpenAI-compatible agent
+    # loops continue past the tool turn instead of treating the response as
+    # final.
     finish_reason = choice.get("finish_reason")
     if parsed.tool_calls and finish_reason == "stop":
         finish_reason = "tool_calls"
 
     return {
-        "id": data.get("id") or "",
-        "created": data.get("created") or 0,
-        "model": data.get("model") or "",
+        "request_id": data.get("request_id") or "",
         "prompt_ids": list(prompt_ids),
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
@@ -191,7 +160,6 @@ async def completions_request(
         "reasoning_content": parsed.reasoning_content,
         "tool_calls": parsed.tool_calls,
         "finish_reason": finish_reason,
-        "usage": data.get("usage"),
         "routed_experts": routed_experts,
     }
 
@@ -206,8 +174,7 @@ def _log_overlong_prompt_diagnostic(
     """Log a structured snapshot when vLLM rejects with 4xx — usually overlong.
 
     Captures total prompt length, per-message role + character count, and
-    the first chunk of the response body. Lets us post-mortem WHICH rollout
-    blew the context window without rerunning.
+    the first chunk of the response body.
     """
     body_text = ""
     response = getattr(exc, "response", None)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,10 @@
+import asyncio
 import base64
 
 import numpy as np
-import pytest
 
 from renderers.base import ParsedResponse
-from renderers.client import completions_request
+from renderers.client import generate
 
 
 class _FakeRenderer:
@@ -36,19 +36,32 @@ class _FakeRenderer:
 
 
 class _FakeClient:
+    """Mocks AsyncOpenAI's `.post()`. The renderer client builds an absolute
+    URL off ``client.base_url``, so we expose one that includes the /v1 suffix
+    the OpenAI SDK normally appends."""
+
     def __init__(self):
         self.calls = []
+        self.base_url = "http://fake-host:8000/v1"
 
-    async def post(self, path, *, cast_to=dict, body=None):
-        self.calls.append({"path": path, "cast_to": cast_to, "body": body})
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
         routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
         return {
-            "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+            "request_id": "gen-test",
             "choices": [
                 {
+                    "index": 0,
                     "token_ids": [7, 8],
-                    "logprobs": [-0.1, -0.2],
-                    "finish_reason": "tool_calls",
+                    "logprobs": {
+                        "content": [
+                            {"token": "token_id:7", "logprob": -0.1},
+                            {"token": "token_id:8", "logprob": -0.2},
+                        ]
+                    },
+                    "finish_reason": "stop",
                     "routed_experts": {
                         "data": base64.b85encode(routed_experts.tobytes()).decode(
                             "ascii"
@@ -60,35 +73,42 @@ class _FakeClient:
         }
 
 
-@pytest.mark.asyncio
-async def test_completions_request_builds_generate_body_and_parses_response():
+def test_generate_builds_request_body_and_parses_response():
     client = _FakeClient()
 
-    result = await completions_request(
-        client=client,
-        renderer=_FakeRenderer(),
-        messages=[{"role": "user", "content": "hi"}],
-        model="test-model",
-        tools=[{"type": "function", "function": {"name": "echo"}}],
-        temperature=0.3,
-        max_completion_tokens=7,
-        extra_body={"min_tokens": 2},
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={"temperature": 0.3, "max_tokens": 7, "min_tokens": 2},
+            cache_salt="ckpt-42",
+        )
     )
 
     assert len(client.calls) == 1
-    assert client.calls[0]["path"] == "/generate"
+    # /inference/v1/generate is mounted at the server root, so we post to
+    # an absolute URL stripped of the OpenAI SDK's automatic /v1 prefix.
+    assert client.calls[0]["path"] == "http://fake-host:8000/inference/v1/generate"
     assert client.calls[0]["body"] == {
         "model": "test-model",
-        "prompt_token_ids": [1, 2, 3],
-        "stop_token_ids": [99],
-        "temperature": 0.3,
-        "max_tokens": 7,
-        "min_tokens": 2,
+        "token_ids": [1, 2, 3],
+        "cache_salt": "ckpt-42",
+        "sampling_params": {
+            "temperature": 0.3,
+            "max_tokens": 7,
+            "min_tokens": 2,
+            "stop_token_ids": [99],
+            "logprobs": 1,
+            "skip_special_tokens": False,
+        },
     }
+    # finish_reason promoted from "stop" → "tool_calls" because the renderer
+    # extracted tool calls client-side.
     assert result == {
-        "id": "",
-        "created": 0,
-        "model": "",
+        "request_id": "gen-test",
         "prompt_ids": [1, 2, 3],
         "completion_ids": [7, 8],
         "completion_logprobs": [-0.1, -0.2],
@@ -103,7 +123,6 @@ async def test_completions_request_builds_generate_body_and_parses_response():
             }
         ],
         "finish_reason": "tool_calls",
-        "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
         "routed_experts": [[[1]], [[2]]],
     }
 
@@ -113,17 +132,18 @@ class _NoRenderRenderer(_FakeRenderer):
         raise AssertionError("prebuilt prompt ids should skip render_ids")
 
 
-@pytest.mark.asyncio
-async def test_completions_request_uses_prebuilt_prompt_ids_without_rendering():
+def test_generate_uses_prebuilt_prompt_ids_without_rendering():
     client = _FakeClient()
 
-    result = await completions_request(
-        client=client,
-        renderer=_NoRenderRenderer(),
-        messages=[{"role": "user", "content": "hi"}],
-        model="test-model",
-        prompt_ids=[11, 12, 13],
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=_NoRenderRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            prompt_ids=[11, 12, 13],
+        )
     )
 
-    assert client.calls[0]["body"]["prompt_token_ids"] == [11, 12, 13]
+    assert client.calls[0]["body"]["token_ids"] == [11, 12, 13]
     assert result["prompt_ids"] == [11, 12, 13]

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-28T12:43:11.512475282Z"
+exclude-newer = "2026-04-28T12:51:00.165421421Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

vLLM 0.20 ships a unified tokens-in / tokens-out endpoint at `/inference/v1/generate` that supersedes the bespoke `/v1/generate` handler the prior client targeted. Migrate `renderers.client` onto the new endpoint and shed the OpenAI-chat-completions DNA accumulated in the old `completions_request`.

This is the renderers-side companion to the verifiers PR ([PrimeIntellect-ai/verifiers#1282](https://github.com/PrimeIntellect-ai/verifiers/pull/1282)) and the prime-rl PR ([PrimeIntellect-ai/prime-rl#2408](https://github.com/PrimeIntellect-ai/prime-rl/pull/2408)). Lifted from verifiers#1282's `packages/renderers/` now that renderers lives in its own repo.

## What changed

`renderers.client.generate()` (was `completions_request`):

- **Structured `sampling_params: dict`** forwarded to vLLM verbatim. No more `extra_body` fallback, `_SAMPLING_KEYS` allowlist, or `max_completion_tokens ↔ max_tokens` aliasing — those are OpenAI-SDK habits that don't apply here.
- **Top-level `cache_salt` / `priority` / `extra_headers`** as named args (matching the wire shape; no rummaging through `extra_body`).
- **Lean result dict**: drops `id`/`created`/`model`/`usage` (ChatCompletion-shaped fillers — the endpoint returns none of them); emits `request_id` (the field `/inference/v1/generate` actually returns) plus the renderer fields (content, reasoning_content, tool_calls, finish_reason, prompt/completion_ids, completion_logprobs, routed_experts).
- `stop_token_ids` (from the renderer) and `logprobs=1` are forced by us; everything else flows through.

Kept: the `finish_reason: stop → tool_calls` promotion when the renderer extracts tool calls client-side (downstream agent loops genuinely depend on it), the `AsyncOpenAI` transport (auth + retries), and the overlong-prompt 4xx diagnostic.

## Version bump

0.1.5 → 0.1.6. The wire format change is a break against v0.1.5 (which targets the legacy `/generate` route). Tag `renderers-v0.1.6` once merged so the publish workflow (when added) picks it up.

## Test plan

- [x] `tests/test_client.py` rewritten against the lean API; passes locally (`uv run pytest tests/test_client.py`).
- [x] Full test suite: 784 passed, 43 skipped, 1 xfailed.
- [x] `ruff format` / `ruff check` clean.
- [x] `ty check renderers` exits 0 (51 advisories surfaced as warnings, no errors).
- [x] e2e renderer rollout against a live vllm 0.20 server (verifiers#1282 + prime-rl#2408 pinned to this client): 20-step `multi_reverse_text` RL run, 2688 calls to `/inference/v1/generate`, eval Avg@4 = 0.83.
