### PR TITLE
ci: add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,77 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to release (e.g. renderers-v0.1.6)'
+        required: true
+        type: string
+  push:
+    tags:
+      - "renderers-v*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout tagged release (dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ inputs.tag }}
+
+      - name: Checkout tagged release (push)
+        if: github.event_name != 'workflow_dispatch'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: release
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSHED_REF: ${{ github.ref_name }}
+          INPUT_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || '' }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            TAG="$INPUT_TAG"
+          else
+            TAG="$PUSHED_REF"
+          fi
+
+          case "$TAG" in
+            renderers-v*) ;;
+            *)
+              echo "Release tags must be prefixed with 'renderers-v' (received '$TAG')" >&2
+              exit 1
+              ;;
+          esac
+
+          VERSION="${TAG#renderers-v}"
+          FILE_VERSION=$(python - <<'PY'
+          import tomllib
+          from pathlib import Path
+          with Path('pyproject.toml').open('rb') as f:
+              data = tomllib.load(f)
+          print(data['project']['version'])
+          PY
+          )
+
+          if [ "$FILE_VERSION" != "$VERSION" ]; then
+            echo "Version mismatch: tag requests '$VERSION' but pyproject.toml defines '$FILE_VERSION'" >&2
+            exit 1
+          fi
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build renderers
+        run: uv build
+
+      - name: Publish to PyPI
+        env:
+          PYPI_RENDERERS_TOKEN: ${{ secrets.PYPI_RENDERERS_TOKEN }}
+        run: uv publish --token "$PYPI_RENDERERS_TOKEN" dist/*


### PR DESCRIPTION
## Summary

Add a publish workflow that ships renderers to PyPI on push of a `renderers-v*` tag (or via manual `workflow_dispatch`). Validates the tag's version against `pyproject.toml`'s `project.version` before building, then `uv build` + `uv publish`.

Ported from [PrimeIntellect-ai/verifiers's `publish-renderers.yml`](https://github.com/PrimeIntellect-ai/verifiers/blob/main/.github/workflows/publish-renderers.yml) — paths adjusted since renderers is no longer a verifiers monorepo subpath. Same `PYPI_RENDERERS_TOKEN` secret name as before.

## What's needed before first release

- Configure the `PYPI_RENDERERS_TOKEN` secret on this repo (PyPI → Account settings → API tokens → scope to `renderers`).
- Tag and push `renderers-v0.1.6` once #1 is merged to release the lean `generate()` API.

## Companion cleanup

PrimeIntellect-ai/verifiers#1282 will delete the duplicate workflow from verifiers in the same change that pins to this repo.