### PR TITLE
feat: preserve_*_thinking override flags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renderers"
-version = "0.1.6"
+version = "0.1.7"
 description = "Chat template renderers — deterministic message-to-token conversion for LLM training"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -139,8 +139,18 @@ class Renderer(Protocol):
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
-        """Render messages to token IDs with per-token message attribution."""
+        """Render messages to token IDs with per-token message attribution.
+
+        ``preserve_all_thinking`` and ``preserve_thinking_between_tool_calls``
+        are *override* knobs — they only restore ``reasoning_content`` the
+        underlying chat template would drop, never strip thinking it emits.
+        Defaults are a no-op: rendered output stays byte-identical to the
+        original template behaviour. See ``should_preserve_past_thinking``
+        for the per-message classification.
+        """
         ...
 
     def render_ids(
@@ -149,6 +159,8 @@ class Renderer(Protocol):
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         """Render messages to token IDs (without attribution metadata)."""
         ...
@@ -503,6 +515,41 @@ def reject_assistant_in_extension(new_messages: list[Message]) -> bool:
     the contract that sampled tokens land in training exactly as emitted.
     """
     return any(m.get("role") == "assistant" for m in new_messages)
+
+
+def should_preserve_past_thinking(
+    messages: list[Message],
+    msg_idx: int,
+    *,
+    preserve_all_thinking: bool,
+    preserve_thinking_between_tool_calls: bool,
+) -> bool:
+    """Should ``messages[msg_idx]``'s ``reasoning_content`` be emitted as
+    thinking even when the chat template would drop it?
+
+    Returns ``True`` only as an override above the template default. Each
+    renderer ORs this into its own "render thinking?" condition; a result
+    of ``False`` means "follow the template" (drop or keep as the template
+    decides), not "force-drop".
+
+    Override rules:
+
+    - ``preserve_all_thinking`` — every past-asst's thinking is kept.
+    - ``preserve_thinking_between_tool_calls`` — past-asst with
+      ``tool_calls`` whose immediate next message is a ``tool`` response
+      is kept. Captures the in-flight asst→tool→asst→tool→... chain
+      where thinking is load-bearing for the next call.
+    """
+    if preserve_all_thinking:
+        return True
+    if not preserve_thinking_between_tool_calls:
+        return False
+    msg = messages[msg_idx]
+    if not msg.get("tool_calls"):
+        return False
+    if msg_idx + 1 >= len(messages):
+        return False
+    return messages[msg_idx + 1].get("role") == "tool"
 
 
 def build_trajectory_step(

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -535,30 +535,33 @@ def should_preserve_past_thinking(
     Override rules:
 
     - ``preserve_all_thinking`` — every past-asst's thinking is kept.
-    - ``preserve_thinking_between_tool_calls`` — every assistant inside a
-      user-bounded segment that contains at least one ``tool`` message
-      is kept. That covers the whole asst→tool→asst→...→tool→asst loop:
-      the asst that issued the tool call AND the asst that responds to
-      the tool result both stay reasoning-tagged, since both are part of
-      the same in-flight tool cycle. Once a new ``user`` turn arrives,
-      the cycle closes and template default resumes.
+    - ``preserve_thinking_between_tool_calls`` — keeps thinking only
+      inside the *current* tool cycle: the contiguous A-T-...-A block
+      after the most recent ``user`` message, and only if that block
+      contains at least one ``tool`` response. As soon as a new
+      ``user`` turn arrives, the previous block becomes "older" and
+      its thinking is dropped (template default), matching how most
+      chat templates already handle multi-turn contexts. Use
+      ``preserve_all_thinking`` if you need thinking on older blocks
+      to survive the user-turn boundary too.
     """
     if preserve_all_thinking:
         return True
     if not preserve_thinking_between_tool_calls:
         return False
-    # User-bounded segment around msg_idx (exclusive bounds).
-    left = -1
-    for j in range(msg_idx - 1, -1, -1):
+    # Most recent user message (or -1 if none).
+    last_user = -1
+    for j in range(len(messages) - 1, -1, -1):
         if messages[j].get("role") == "user":
-            left = j
+            last_user = j
             break
-    right = len(messages)
-    for j in range(msg_idx + 1, len(messages)):
-        if messages[j].get("role") == "user":
-            right = j
-            break
-    return any(messages[j].get("role") == "tool" for j in range(left + 1, right))
+    if msg_idx <= last_user:
+        return False
+    # The current segment must contain a tool response for it to count
+    # as an in-flight tool cycle.
+    return any(
+        messages[j].get("role") == "tool" for j in range(last_user + 1, len(messages))
+    )
 
 
 def build_trajectory_step(

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -535,21 +535,30 @@ def should_preserve_past_thinking(
     Override rules:
 
     - ``preserve_all_thinking`` — every past-asst's thinking is kept.
-    - ``preserve_thinking_between_tool_calls`` — past-asst with
-      ``tool_calls`` whose immediate next message is a ``tool`` response
-      is kept. Captures the in-flight asst→tool→asst→tool→... chain
-      where thinking is load-bearing for the next call.
+    - ``preserve_thinking_between_tool_calls`` — every assistant inside a
+      user-bounded segment that contains at least one ``tool`` message
+      is kept. That covers the whole asst→tool→asst→...→tool→asst loop:
+      the asst that issued the tool call AND the asst that responds to
+      the tool result both stay reasoning-tagged, since both are part of
+      the same in-flight tool cycle. Once a new ``user`` turn arrives,
+      the cycle closes and template default resumes.
     """
     if preserve_all_thinking:
         return True
     if not preserve_thinking_between_tool_calls:
         return False
-    msg = messages[msg_idx]
-    if not msg.get("tool_calls"):
-        return False
-    if msg_idx + 1 >= len(messages):
-        return False
-    return messages[msg_idx + 1].get("role") == "tool"
+    # User-bounded segment around msg_idx (exclusive bounds).
+    left = -1
+    for j in range(msg_idx - 1, -1, -1):
+        if messages[j].get("role") == "user":
+            left = j
+            break
+    right = len(messages)
+    for j in range(msg_idx + 1, len(messages)):
+        if messages[j].get("role") == "user":
+            right = j
+            break
+    return any(messages[j].get("role") == "tool" for j in range(left + 1, right))
 
 
 def build_trajectory_step(

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -98,7 +98,13 @@ class DeepSeekV3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
+        # DeepSeek-V3's template always emits ``<think>{reasoning}</think>``
+        # when ``reasoning_content`` is provided — no drop, so the override
+        # flags are no-ops. Accepted for Protocol parity.
+        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -205,9 +211,15 @@ class DeepSeekV3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -112,7 +112,15 @@ class DefaultRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
+        if preserve_all_thinking or preserve_thinking_between_tool_calls:
+            raise NotImplementedError(
+                "DefaultRenderer falls back to apply_chat_template and can't "
+                "selectively re-emit dropped reasoning_content. Configure a "
+                "model-specific renderer if you need preserve_*_thinking."
+            )
         # Incremental rendering to get per-token message attribution
         token_ids: list[int] = []
         message_indices: list[int] = []
@@ -150,7 +158,15 @@ class DefaultRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
+        if preserve_all_thinking or preserve_thinking_between_tool_calls:
+            raise NotImplementedError(
+                "DefaultRenderer falls back to apply_chat_template and can't "
+                "selectively re-emit dropped reasoning_content. Configure a "
+                "model-specific renderer if you need preserve_*_thinking."
+            )
         return self._apply(
             messages, tools=tools, add_generation_prompt=add_generation_prompt
         )

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -21,6 +21,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
 )
 from renderers.parsing import parse_glm
 
@@ -114,6 +115,8 @@ class GLM45Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -163,11 +166,18 @@ class GLM45Renderer:
                 emit_text(user_text, i)
 
             elif role == "assistant":
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     i,
                     content,
                     last_ui,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                 )
@@ -193,9 +203,15 @@ class GLM45Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -284,7 +300,15 @@ class GLM45Renderer:
         return previous_ids + ext
 
     def _render_assistant(
-        self, msg, msg_idx, content, last_user_index, *, emit_special, emit_text
+        self,
+        msg,
+        msg_idx,
+        content,
+        last_user_index,
+        *,
+        preserve_thinking: bool = False,
+        emit_special,
+        emit_text,
     ):
         reasoning_content = ""
         if isinstance(msg.get("reasoning_content"), str):
@@ -300,7 +324,7 @@ class GLM45Renderer:
 
         emit_special(self._assistant, msg_idx)
 
-        if msg_idx > last_user_index and reasoning_content:
+        if (msg_idx > last_user_index or preserve_thinking) and reasoning_content:
             emit_text("\n", msg_idx)
             emit_special(self._think, msg_idx)
             emit_text(reasoning_content.strip(), msg_idx)

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -22,6 +22,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
 )
 from renderers.parsing import parse_glm
 
@@ -131,6 +132,8 @@ class GLM5Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -177,11 +180,18 @@ class GLM5Renderer:
                 emit_text(content, i)
 
             elif role == "assistant":
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     i,
                     content,
                     last_ui,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                 )
@@ -207,9 +217,15 @@ class GLM5Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -303,7 +319,15 @@ class GLM5Renderer:
         return previous_ids + ext
 
     def _render_assistant(
-        self, msg, msg_idx, content, last_user_index, *, emit_special, emit_text
+        self,
+        msg,
+        msg_idx,
+        content,
+        last_user_index,
+        *,
+        preserve_thinking: bool = False,
+        emit_special,
+        emit_text,
     ):
         reasoning_content = ""
         if isinstance(msg.get("reasoning_content"), str):
@@ -320,7 +344,7 @@ class GLM5Renderer:
         emit_special(self._assistant, msg_idx)
 
         include_thinking = (
-            not self._clear_thinking or msg_idx > last_user_index
+            (not self._clear_thinking or msg_idx > last_user_index) or preserve_thinking
         ) and reasoning_content
 
         if include_thinking:

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -57,6 +57,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 from renderers.parsing import parse_gpt_oss
@@ -185,6 +186,8 @@ class GptOssRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -249,7 +252,17 @@ class GptOssRenderer:
         for i, msg in enumerate(messages):
             if i == first_system_idx:
                 continue  # already emitted as developer
-            for hm in self._to_harmony_messages(msg):
+            preserve_thinking = msg.get("role") == "assistant" and (
+                should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
+            )
+            for hm in self._to_harmony_messages(
+                msg, preserve_thinking=preserve_thinking
+            ):
                 emit(self._enc.render(hm), i)
 
         # When the conversation ends on an assistant final-channel turn,
@@ -283,9 +296,15 @@ class GptOssRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -353,7 +372,9 @@ class GptOssRenderer:
 
     # ── message conversion ───────────────────────────────────────────────────
 
-    def _to_harmony_messages(self, msg: Message) -> list[HarmonyMessage]:
+    def _to_harmony_messages(
+        self, msg: Message, *, preserve_thinking: bool = False
+    ) -> list[HarmonyMessage]:
         """Convert a single RendererMessage to one or more harmony messages.
 
         Splits in two cases:
@@ -396,7 +417,7 @@ class GptOssRenderer:
             return [tm]
 
         if role == "assistant":
-            return self._assistant_to_harmony(msg)
+            return self._assistant_to_harmony(msg, preserve_thinking=preserve_thinking)
 
         # Unknown role: render as developer with the raw content.
         dev = DeveloperContent.new().with_instructions(
@@ -404,7 +425,9 @@ class GptOssRenderer:
         )
         return [HarmonyMessage.from_role_and_content(Role.DEVELOPER, dev)]
 
-    def _assistant_to_harmony(self, msg: Message) -> list[HarmonyMessage]:
+    def _assistant_to_harmony(
+        self, msg: Message, *, preserve_thinking: bool = False
+    ) -> list[HarmonyMessage]:
         """Convert an assistant message to harmony messages.
 
         Layout:
@@ -412,14 +435,24 @@ class GptOssRenderer:
           - each tool_call             → commentary channel,
                                          recipient=functions.<name>
 
-        ``reasoning_content`` is intentionally NOT emitted: harmony strips
-        analysis-channel messages from history-style rendering (verified
-        against ``HarmonyEncoding.render_conversation`` /
-        ``render_conversation_for_training``). Per-turn thinking is only
-        relevant for live generation; once a turn closes, its analysis
-        block is dropped from context.
+        Default: ``reasoning_content`` is NOT emitted — harmony strips
+        analysis-channel messages from history-style rendering. Per-turn
+        thinking is only relevant for live generation; once a turn closes,
+        its analysis block is dropped from context.
+
+        ``preserve_thinking=True``: prepend an analysis-channel message
+        carrying ``reasoning_content`` so callers that want the trace in
+        history (e.g. tool-call-chain training) see it surface.
         """
         out: list[HarmonyMessage] = []
+
+        if preserve_thinking:
+            reasoning = msg.get("reasoning_content")
+            if isinstance(reasoning, str) and reasoning:
+                analysis = HarmonyMessage.from_role_and_content(
+                    Role.ASSISTANT, reasoning
+                )
+                out.append(analysis.with_channel("analysis"))
 
         content = msg.get("content")
         text_parts: list[str] = []

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -105,7 +105,13 @@ class KimiK2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
+        # Kimi-K2's chat template does not read ``reasoning_content`` for
+        # past assistant turns — the model thinks via a prefilled ``<think>``
+        # in the generation prompt only. Override flags are no-ops.
+        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -263,9 +269,15 @@ class KimiK2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -33,6 +33,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 
@@ -571,6 +572,8 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         """Render messages to tokens, matching the K2.5 chat template.
 
@@ -642,10 +645,17 @@ class KimiK25Renderer:
             # Body
             if role == "assistant":
                 is_suffix = i > last_non_tc_assistant
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant_body(
                     msg,
                     i,
                     is_suffix=is_suffix,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                 )
@@ -684,9 +694,15 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -828,6 +844,7 @@ class KimiK25Renderer:
         msg_idx: int,
         *,
         is_suffix: bool,
+        preserve_thinking: bool = False,
         emit_special,
         emit_text,
     ) -> None:
@@ -877,7 +894,8 @@ class KimiK25Renderer:
             text_content = content or ""
 
         # Hist/suffix split: hist drops reasoning, suffix keeps it.
-        if is_suffix:
+        # Override flag preserves reasoning on hist when caller asks for it.
+        if is_suffix or (preserve_thinking and reasoning_content):
             emit_text(f"<think>{reasoning_content}</think>", msg_idx)
         else:
             emit_text("<think></think>", msg_idx)

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -22,6 +22,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 from renderers.parsing import parse_minimax
@@ -105,6 +106,8 @@ class MiniMaxM2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -168,11 +171,18 @@ class MiniMaxM2Renderer:
                 emit_text("\n", orig_idx)
 
             elif role == "assistant":
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    orig_idx,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     orig_idx,
                     ci,
                     last_ui,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                 )
@@ -202,9 +212,15 @@ class MiniMaxM2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -290,7 +306,15 @@ class MiniMaxM2Renderer:
         return previous_ids + ext
 
     def _render_assistant(
-        self, msg, orig_idx, conv_idx, last_user_index, *, emit_special, emit_text
+        self,
+        msg,
+        orig_idx,
+        conv_idx,
+        last_user_index,
+        *,
+        preserve_thinking: bool = False,
+        emit_special,
+        emit_text,
     ):
         content = self._visible_text(msg.get("content"))
 
@@ -311,7 +335,7 @@ class MiniMaxM2Renderer:
         # interspersed. Keep text segments contiguous to preserve BPE merges.
         tool_calls = msg.get("tool_calls") or []
 
-        if reasoning_content and conv_idx > last_user_index:
+        if reasoning_content and (conv_idx > last_user_index or preserve_thinking):
             emit_text("ai\n", orig_idx)
             emit_special(self._think, orig_idx)
             emit_text("\n" + reasoning_content + "\n", orig_idx)

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -25,6 +25,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 from renderers.parsing import parse_qwen35
@@ -214,10 +215,13 @@ class Nemotron3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
 
+        original_messages = list(messages)
         # Always ensure an empty system message is present.
         messages, auto_system_injected = self._normalize_messages(messages)
         # Offset to map indices in the normalized list back to the caller's
@@ -318,11 +322,18 @@ class Nemotron3Renderer:
 
             elif role == "assistant":
                 is_last_turn = i >= last_plain_assistant_idx
+                preserve_thinking = msg_orig_idx >= 0 and should_preserve_past_thinking(
+                    original_messages,
+                    msg_orig_idx,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     msg_orig_idx,
                     content,
                     is_last_turn=is_last_turn,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                     emit_ids=emit_ids,
@@ -362,9 +373,15 @@ class Nemotron3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -473,6 +490,7 @@ class Nemotron3Renderer:
         content: str,
         *,
         is_last_turn: bool,
+        preserve_thinking: bool = False,
         emit_special,
         emit_text,
         emit_ids,
@@ -507,7 +525,7 @@ class Nemotron3Renderer:
         # <tool_call>, whether the content is empty or not.
         content_suffix = "\n" if tool_calls else ""
 
-        if reasoning_content and is_last_turn:
+        if reasoning_content and (is_last_turn or preserve_thinking):
             emit_special(self._think, msg_idx)
             emit_text("\n" + reasoning_content + "\n", msg_idx)
             emit_special(self._think_end, msg_idx)

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -19,6 +19,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 from renderers.parsing import parse_qwen3
@@ -94,6 +95,8 @@ class Qwen3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -158,12 +161,19 @@ class Qwen3Renderer:
                 emit_text("\n", i)
 
             elif role == "assistant":
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     i,
                     content,
                     last_qi,
                     i == num_messages - 1,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                 )
@@ -188,9 +198,15 @@ class Qwen3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -281,6 +297,7 @@ class Qwen3Renderer:
         last_query_index,
         is_last,
         *,
+        preserve_thinking: bool = False,
         emit_special,
         emit_text,
     ):
@@ -303,7 +320,11 @@ class Qwen3Renderer:
         # preserve BPE merges (e.g., ".\n" is a single token in Qwen3).
         tool_calls = msg.get("tool_calls") or []
 
-        if msg_idx > last_query_index and (is_last or reasoning_content):
+        emit_in_template_window = msg_idx > last_query_index and (
+            is_last or reasoning_content
+        )
+        emit_via_override = preserve_thinking and bool(reasoning_content)
+        if emit_in_template_window or emit_via_override:
             prefix = (
                 "assistant\n<think>\n"
                 + reasoning_content.strip("\n")

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -17,6 +17,7 @@ from renderers.base import (
     RenderedTokens,
     ToolSpec,
     reject_assistant_in_extension,
+    should_preserve_past_thinking,
     trim_to_turn_close,
 )
 from renderers.parsing import parse_qwen35
@@ -146,6 +147,8 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -217,11 +220,18 @@ class Qwen35Renderer:
                 emit_text("\n", i)
 
             elif role == "assistant":
+                preserve_thinking = should_preserve_past_thinking(
+                    messages,
+                    i,
+                    preserve_all_thinking=preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                )
                 self._render_assistant(
                     msg,
                     i,
                     content,
                     last_qi,
+                    preserve_thinking=preserve_thinking,
                     emit_special=emit_special,
                     emit_text=emit_text,
                     emit_ids=emit_ids,
@@ -260,9 +270,15 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:
@@ -391,6 +407,7 @@ class Qwen35Renderer:
         content: str,
         last_query_index: int,
         *,
+        preserve_thinking: bool = False,
         emit_special,
         emit_text,
         emit_ids,
@@ -414,7 +431,10 @@ class Qwen35Renderer:
 
         emit_special(self._im_start, msg_idx)
 
-        if self._should_render_thinking(msg_idx, last_query_index):
+        emit_thinking = self._should_render_thinking(msg_idx, last_query_index) or (
+            preserve_thinking and bool(reasoning_content)
+        )
+        if emit_thinking:
             # Include thinking block
             emit_text("assistant\n", msg_idx)
             emit_special(self._think, msg_idx)

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -90,7 +90,13 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
+        # Qwen3-VL chat template doesn't render <think> blocks for past
+        # assistant messages, so the override flags are no-ops here. We
+        # accept them for Protocol parity.
+        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -174,9 +180,15 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
-            messages, tools=tools, add_generation_prompt=add_generation_prompt
+            messages,
+            tools=tools,
+            add_generation_prompt=add_generation_prompt,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -1,0 +1,154 @@
+"""Smoke coverage for the ``preserve_*_thinking`` override flags.
+
+Two invariants per renderer:
+
+1. Default render (both flags ``False``) is byte-identical to the existing
+   ``apply_chat_template`` parity baseline — covered exhaustively elsewhere.
+2. Setting either flag never *removes* tokens compared to the default and,
+   for renderers whose template would drop past-asst thinking, actually
+   adds tokens for a conversation containing past-asst ``reasoning_content``.
+
+Renderers whose template either always preserves thinking (DeepSeek-V3) or
+never references ``reasoning_content`` for past-asst (Kimi-K2, Qwen3-VL)
+are no-ops by design — they're listed below and the test asserts the
+default==override equality instead of strict growth.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from renderers.base import should_preserve_past_thinking
+
+
+# Renderers whose template doesn't drop past-asst thinking or has no
+# place to re-emit it. For these, override flags MUST be no-ops.
+NO_OP_MODELS = {
+    "deepseek-ai/DeepSeek-V3",
+    "deepseek-ai/DeepSeek-V3-Base",
+    "moonshotai/Kimi-K2-Instruct",
+    "Qwen/Qwen3-VL-4B-Instruct",
+    "Qwen/Qwen3-VL-8B-Instruct",
+    "Qwen/Qwen3-VL-30B-A3B-Instruct",
+}
+
+
+CONVERSATION = [
+    {"role": "user", "content": "Weather in Paris?"},
+    {
+        "role": "assistant",
+        "reasoning_content": "I should call the weather tool for Paris.",
+        "content": "Let me check.",
+        "tool_calls": [
+            {"function": {"name": "get_weather", "arguments": {"city": "Paris"}}}
+        ],
+    },
+    {"role": "tool", "name": "get_weather", "content": "Sunny, 22C"},
+    {
+        "role": "assistant",
+        "reasoning_content": "The tool returned the weather.",
+        "content": "Sunny, 22C in Paris.",
+    },
+    {"role": "user", "content": "And Berlin?"},
+]
+
+
+def test_should_preserve_past_thinking_classification():
+    # Asst[1] has tool_calls and is followed by tool[2] — between-tool-calls.
+    assert should_preserve_past_thinking(
+        CONVERSATION,
+        1,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    # Asst[3] is followed by user[4] — not between tool calls.
+    assert not should_preserve_past_thinking(
+        CONVERSATION,
+        3,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    # preserve_all_thinking applies to every past-asst regardless.
+    assert should_preserve_past_thinking(
+        CONVERSATION,
+        3,
+        preserve_all_thinking=True,
+        preserve_thinking_between_tool_calls=False,
+    )
+    # Both flags False → always False.
+    assert not should_preserve_past_thinking(
+        CONVERSATION,
+        1,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=False,
+    )
+
+
+def test_preserve_flags_default_unchanged(model_name, tokenizer, renderer):
+    # Calling render with the flags explicitly off must be byte-identical
+    # to the bare call (defaults).
+    bare = renderer.render_ids(CONVERSATION)
+    explicit_off = renderer.render_ids(
+        CONVERSATION,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=False,
+    )
+    assert bare == explicit_off, (
+        f"{model_name}: explicit flags=False must equal bare default render"
+    )
+
+
+def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer):
+    from renderers.default import DefaultRenderer
+
+    if isinstance(renderer, DefaultRenderer):
+        pytest.skip("DefaultRenderer raises on these flags — covered separately")
+    default = renderer.render_ids(CONVERSATION)
+    preserved = renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+
+    if model_name in NO_OP_MODELS:
+        assert preserved == default, (
+            f"{model_name} is a no-op renderer; preserve_all_thinking must "
+            f"not change output (got {len(default)} → {len(preserved)})"
+        )
+    else:
+        assert len(preserved) > len(default), (
+            f"{model_name}: preserve_all_thinking should add tokens for a "
+            f"conversation with past-asst reasoning_content "
+            f"(default={len(default)}, preserved={len(preserved)})"
+        )
+
+
+def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, renderer):
+    """``preserve_thinking_between_tool_calls`` is strictly weaker than
+    ``preserve_all_thinking``: token count satisfies default <= between <= all."""
+    from renderers.default import DefaultRenderer
+
+    if isinstance(renderer, DefaultRenderer):
+        pytest.skip("DefaultRenderer raises on these flags — covered separately")
+    default = renderer.render_ids(CONVERSATION)
+    between = renderer.render_ids(
+        CONVERSATION, preserve_thinking_between_tool_calls=True
+    )
+    all_ = renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+    assert len(default) <= len(between) <= len(all_), (
+        f"{model_name}: expected default <= between <= all, "
+        f"got {len(default)} <= {len(between)} <= {len(all_)}"
+    )
+
+
+def test_default_renderer_raises_on_flags():
+    """``DefaultRenderer`` falls back to apply_chat_template with no
+    selective re-emit pathway, so it must raise rather than silently ignore."""
+    from transformers import AutoTokenizer
+
+    from renderers import create_renderer
+
+    tok = AutoTokenizer.from_pretrained(
+        "Qwen/Qwen2.5-0.5B-Instruct", trust_remote_code=True
+    )
+    renderer = create_renderer(tok, renderer="default")
+    with pytest.raises(NotImplementedError):
+        renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+    with pytest.raises(NotImplementedError):
+        renderer.render_ids(CONVERSATION, preserve_thinking_between_tool_calls=True)

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -228,6 +228,125 @@ def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer)
     )
 
 
+# ---------------------------------------------------------------------------
+# End-to-end visibility matrix
+# ---------------------------------------------------------------------------
+
+# Conversation shape: S-U-A-T-A-U-A-T-A. Each assistant carries a unique
+# sentinel string in ``reasoning_content`` so we can grep the decoded
+# output to see whose thinking was kept.
+TWO_BLOCK_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "description": "look up a value",
+            "parameters": {
+                "type": "object",
+                "properties": {"key": {"type": "string"}},
+                "required": ["key"],
+            },
+        },
+    }
+]
+
+TWO_BLOCK_CONV = [
+    {"role": "system", "content": "be brief"},
+    {"role": "user", "content": "first"},
+    {
+        "role": "assistant",
+        "reasoning_content": "REASON-A2",
+        "content": "calling.",
+        "tool_calls": [{"function": {"name": "lookup", "arguments": {"key": "a"}}}],
+    },
+    {"role": "tool", "name": "lookup", "content": "result-a"},
+    {"role": "assistant", "reasoning_content": "REASON-A4", "content": "answer-1"},
+    {"role": "user", "content": "second"},
+    {
+        "role": "assistant",
+        "reasoning_content": "REASON-A6",
+        "content": "calling.",
+        "tool_calls": [{"function": {"name": "lookup", "arguments": {"key": "b"}}}],
+    },
+    {"role": "tool", "name": "lookup", "content": "result-b"},
+    {"role": "assistant", "reasoning_content": "REASON-A8", "content": "answer-2"},
+]
+
+ALL_SENTINELS = ("REASON-A2", "REASON-A4", "REASON-A6", "REASON-A8")
+CURRENT_BLOCK_SENTINELS = ("REASON-A6", "REASON-A8")
+OLDER_BLOCK_SENTINELS = ("REASON-A2", "REASON-A4")
+
+# Renderers whose template renders ``reasoning_content`` for past-asst
+# under no condition. Flags accepted as no-ops; sentinels never appear.
+NEVER_PRESERVES_MODELS = {
+    "moonshotai/Kimi-K2-Instruct",
+    "Qwen/Qwen3-VL-4B-Instruct",
+    "Qwen/Qwen3-VL-8B-Instruct",
+    "Qwen/Qwen3-VL-30B-A3B-Instruct",
+}
+
+
+def test_preserve_all_thinking_emits_every_asst_reasoning(
+    model_name, tokenizer, renderer
+):
+    """``preserve_all_thinking=True`` must surface every past-asst's
+    ``reasoning_content`` in the decoded output — for renderers that
+    have any pathway to render reasoning at all."""
+    from renderers.default import DefaultRenderer
+
+    if isinstance(renderer, DefaultRenderer):
+        pytest.skip("DefaultRenderer raises on these flags — covered separately")
+
+    ids = renderer.render_ids(
+        TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS, preserve_all_thinking=True
+    )
+    text = tokenizer.decode(ids)
+
+    if model_name in NEVER_PRESERVES_MODELS:
+        for sentinel in ALL_SENTINELS:
+            assert sentinel not in text, (
+                f"{model_name}: never-preserves renderer leaked {sentinel} "
+                f"under preserve_all_thinking"
+            )
+    else:
+        for sentinel in ALL_SENTINELS:
+            assert sentinel in text, (
+                f"{model_name}: preserve_all_thinking did not emit {sentinel} "
+                f"in decoded output"
+            )
+
+
+def test_preserve_btc_emits_current_block_reasoning(model_name, tokenizer, renderer):
+    """``preserve_thinking_between_tool_calls=True`` must surface the
+    current (post-last-user) tool block's reasoning. Older blocks fall
+    back to template default, which varies per renderer — no universal
+    assertion there."""
+    from renderers.default import DefaultRenderer
+
+    if isinstance(renderer, DefaultRenderer):
+        pytest.skip("DefaultRenderer raises on these flags — covered separately")
+
+    ids = renderer.render_ids(
+        TWO_BLOCK_CONV,
+        tools=TWO_BLOCK_TOOLS,
+        preserve_thinking_between_tool_calls=True,
+    )
+    text = tokenizer.decode(ids)
+
+    if model_name in NEVER_PRESERVES_MODELS:
+        for sentinel in ALL_SENTINELS:
+            assert sentinel not in text, (
+                f"{model_name}: never-preserves renderer leaked {sentinel} "
+                f"under preserve_thinking_between_tool_calls"
+            )
+    else:
+        for sentinel in CURRENT_BLOCK_SENTINELS:
+            assert sentinel in text, (
+                f"{model_name}: btc did not emit current-block {sentinel} "
+                f"in decoded output"
+            )
+
+
 def test_default_renderer_raises_on_flags():
     """``DefaultRenderer`` falls back to apply_chat_template with no
     selective re-emit pathway, so it must raise rather than silently ignore."""

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -54,15 +54,20 @@ CONVERSATION = [
 
 
 def test_should_preserve_past_thinking_classification():
-    # Asst[1] has tool_calls and is followed by tool[2] — between-tool-calls.
+    # CONVERSATION = [user, asst-with-tool_calls, tool, asst, user]
+    # User-bounded segment around asst[1] is (start, user[4]) which contains
+    # tool[2] — so asst[1] is in a tool-cycle segment.
     assert should_preserve_past_thinking(
         CONVERSATION,
         1,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=True,
     )
-    # Asst[3] is followed by user[4] — not between tool calls.
-    assert not should_preserve_past_thinking(
+    # Asst[3] sits in the same user-bounded segment as asst[1] (start..user[4])
+    # which contains tool[2] — so asst[3] is also in a tool-cycle segment.
+    # Catches the post-tool-result asst that the old "next msg is tool"
+    # heuristic would have missed.
+    assert should_preserve_past_thinking(
         CONVERSATION,
         3,
         preserve_all_thinking=False,
@@ -81,6 +86,50 @@ def test_should_preserve_past_thinking_classification():
         1,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=False,
+    )
+
+    # Mixed conversation where some U-segments have no tool: A in a
+    # tool-less segment must NOT be preserved by between_tool_calls.
+    no_tool_segment = [
+        {"role": "user", "content": "q1"},
+        {"role": "assistant", "reasoning_content": "r1", "content": "a1"},
+        {"role": "user", "content": "q2"},
+        {
+            "role": "assistant",
+            "reasoning_content": "r2",
+            "tool_calls": [{"function": {"name": "f", "arguments": {}}}],
+        },
+        {"role": "tool", "name": "f", "content": "data"},
+        {"role": "assistant", "reasoning_content": "r3", "content": "a3"},
+        {"role": "user", "content": "q3"},
+        {"role": "assistant", "reasoning_content": "r4", "content": "a4"},
+    ]
+    # asst[1]: segment (start, user[2]) — no tool → not preserved
+    assert not should_preserve_past_thinking(
+        no_tool_segment,
+        1,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    # asst[3] and asst[5]: segment (user[2], user[6]) contains tool[4] → preserved
+    assert should_preserve_past_thinking(
+        no_tool_segment,
+        3,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    assert should_preserve_past_thinking(
+        no_tool_segment,
+        5,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    # asst[7]: segment (user[6], end) — no tool → not preserved
+    assert not should_preserve_past_thinking(
+        no_tool_segment,
+        7,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
     )
 
 

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -54,82 +54,84 @@ CONVERSATION = [
 
 
 def test_should_preserve_past_thinking_classification():
-    # CONVERSATION = [user, asst-with-tool_calls, tool, asst, user]
-    # User-bounded segment around asst[1] is (start, user[4]) which contains
-    # tool[2] — so asst[1] is in a tool-cycle segment.
+    # CURRENT-block-only behaviour. between_tool_calls preserves thinking
+    # ONLY for asst messages that sit AFTER the last user turn AND are in
+    # a segment that contains a tool. Anything before the last user turn
+    # falls back to template default (typically dropped).
+
+    # Live tool cycle: U-A_tc-T-A_final, no trailing user. The whole
+    # post-user segment contains a tool, so both A's are preserved.
+    live_cycle = [
+        {"role": "user", "content": "q"},
+        {
+            "role": "assistant",
+            "reasoning_content": "r1",
+            "tool_calls": [{"function": {"name": "f", "arguments": {}}}],
+        },
+        {"role": "tool", "name": "f", "content": "data"},
+        {"role": "assistant", "reasoning_content": "r2", "content": "answer"},
+    ]
     assert should_preserve_past_thinking(
-        CONVERSATION,
+        live_cycle,
         1,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=True,
     )
-    # Asst[3] sits in the same user-bounded segment as asst[1] (start..user[4])
-    # which contains tool[2] — so asst[3] is also in a tool-cycle segment.
-    # Catches the post-tool-result asst that the old "next msg is tool"
-    # heuristic would have missed.
     assert should_preserve_past_thinking(
-        CONVERSATION,
+        live_cycle,
         3,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=True,
     )
-    # preserve_all_thinking applies to every past-asst regardless.
+
+    # Same shape with a NEW user appended → now the prior tool block is
+    # "older" and between_tool_calls must drop its thinking (template
+    # default). Only preserve_all_thinking would keep them.
+    closed_cycle = live_cycle + [{"role": "user", "content": "next"}]
+    assert not should_preserve_past_thinking(
+        closed_cycle,
+        1,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    assert not should_preserve_past_thinking(
+        closed_cycle,
+        3,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+    # preserve_all_thinking still keeps them.
     assert should_preserve_past_thinking(
-        CONVERSATION,
+        closed_cycle,
+        1,
+        preserve_all_thinking=True,
+        preserve_thinking_between_tool_calls=False,
+    )
+    assert should_preserve_past_thinking(
+        closed_cycle,
         3,
         preserve_all_thinking=True,
         preserve_thinking_between_tool_calls=False,
     )
+
+    # Current segment without a tool → not a tool cycle → not preserved.
+    no_tool_yet = [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "reasoning_content": "r", "content": "a"},
+    ]
+    assert not should_preserve_past_thinking(
+        no_tool_yet,
+        1,
+        preserve_all_thinking=False,
+        preserve_thinking_between_tool_calls=True,
+    )
+
     # Both flags False → always False.
     assert not should_preserve_past_thinking(
-        CONVERSATION,
+        live_cycle,
         1,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=False,
-    )
-
-    # Mixed conversation where some U-segments have no tool: A in a
-    # tool-less segment must NOT be preserved by between_tool_calls.
-    no_tool_segment = [
-        {"role": "user", "content": "q1"},
-        {"role": "assistant", "reasoning_content": "r1", "content": "a1"},
-        {"role": "user", "content": "q2"},
-        {
-            "role": "assistant",
-            "reasoning_content": "r2",
-            "tool_calls": [{"function": {"name": "f", "arguments": {}}}],
-        },
-        {"role": "tool", "name": "f", "content": "data"},
-        {"role": "assistant", "reasoning_content": "r3", "content": "a3"},
-        {"role": "user", "content": "q3"},
-        {"role": "assistant", "reasoning_content": "r4", "content": "a4"},
-    ]
-    # asst[1]: segment (start, user[2]) — no tool → not preserved
-    assert not should_preserve_past_thinking(
-        no_tool_segment,
-        1,
-        preserve_all_thinking=False,
-        preserve_thinking_between_tool_calls=True,
-    )
-    # asst[3] and asst[5]: segment (user[2], user[6]) contains tool[4] → preserved
-    assert should_preserve_past_thinking(
-        no_tool_segment,
-        3,
-        preserve_all_thinking=False,
-        preserve_thinking_between_tool_calls=True,
-    )
-    assert should_preserve_past_thinking(
-        no_tool_segment,
-        5,
-        preserve_all_thinking=False,
-        preserve_thinking_between_tool_calls=True,
-    )
-    # asst[7]: segment (user[6], end) — no tool → not preserved
-    assert not should_preserve_past_thinking(
-        no_tool_segment,
-        7,
-        preserve_all_thinking=False,
-        preserve_thinking_between_tool_calls=True,
     )
 
 
@@ -183,6 +185,46 @@ def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, render
     assert len(default) <= len(between) <= len(all_), (
         f"{model_name}: expected default <= between <= all, "
         f"got {len(default)} <= {len(between)} <= {len(all_)}"
+    )
+
+
+LIVE_TOOL_CYCLE = [
+    {"role": "user", "content": "Weather in Paris?"},
+    {
+        "role": "assistant",
+        "reasoning_content": "Let me call the tool.",
+        "content": "Calling.",
+        "tool_calls": [
+            {"function": {"name": "get_weather", "arguments": {"city": "Paris"}}}
+        ],
+    },
+    {"role": "tool", "name": "get_weather", "content": "Sunny, 22C"},
+    {
+        "role": "assistant",
+        "reasoning_content": "Tool returned weather.",
+        "content": "Sunny.",
+    },
+]
+
+
+def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer):
+    """In a live tool cycle (no trailing user), every past-asst sits in
+    the current tool-bearing segment. ``preserve_thinking_between_tool_calls``
+    should preserve all of their thinking — same set of asst messages as
+    ``preserve_all_thinking``, so the resulting token sequences must be
+    identical (independent of which template-default condition each
+    renderer uses internally)."""
+    from renderers.default import DefaultRenderer
+
+    if isinstance(renderer, DefaultRenderer):
+        pytest.skip("DefaultRenderer raises on these flags — covered separately")
+    btc = renderer.render_ids(
+        LIVE_TOOL_CYCLE, preserve_thinking_between_tool_calls=True
+    )
+    all_ = renderer.render_ids(LIVE_TOOL_CYCLE, preserve_all_thinking=True)
+    assert btc == all_, (
+        f"{model_name}: in a live tool cycle btc must match preserve_all "
+        f"(got len(btc)={len(btc)}, len(all)={len(all_)})"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-28T12:51:00.165421421Z"
+exclude-newer = "2026-04-28T15:59:40.469057021Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Adds two override flags to `Renderer.render` / `render_ids`:

- **`preserve_thinking_between_tool_calls`** — when a past assistant message has `tool_calls` and is immediately followed by a `tool` result, emit its `reasoning_content` even when the chat template default would drop it. Captures the in-flight asst→tool→asst→tool chain where the trace is load-bearing for the next call.
- **`preserve_all_thinking`** — emit `reasoning_content` for every past-assistant turn. Strict superset of the above.

These are *override* knobs only: they restore thinking the template would drop, never strip thinking it emits. Defaults are byte-identical to `apply_chat_template` (existing 784-test parity suite confirms).

## Per-renderer impact

| Renderer | Behaviour |
|---|---|
| Qwen3, Qwen3.5, Qwen3.6 | Drop condition `msg_idx > last_query_index` extended with override |
| GLM-4.5, GLM-5, GLM-5.1, GLM-4.7-Flash | `msg_idx > last_user_index` extended with override |
| MiniMax-M2 | `conv_idx > last_user_index` extended with override |
| Nemotron-3 | `is_last_turn` extended with override |
| Kimi-K2.5 / K2.6 | hist/suffix split extended on `is_suffix` |
| gpt-oss | analysis-channel message emitted on past-asst when override fires |
| Qwen3-VL | No-op — template doesn't emit thinking for past-asst (Protocol parity only) |
| Kimi-K2 | No-op — template never reads `reasoning_content` |
| DeepSeek-V3 | No-op — template already always preserves `reasoning_content` |
| **DefaultRenderer** | **Raises `NotImplementedError`** — apply_chat_template fallback can't selectively re-emit |

## Tests

`tests/test_preserve_thinking.py` covers:

- Classification correctness for `should_preserve_past_thinking` helper
- Default render unchanged when flags are explicitly off (matrix)
- Strict-subset growth: `len(default) ≤ len(between_tool_calls) ≤ len(all)` (matrix)
- No-op renderers actually no-op
- DefaultRenderer raises on either flag

48 new tests pass; 2 cleanly skipped on Qwen2.5 (uses DefaultRenderer, exercised separately).

## Version

Bumps `0.1.6 → 0.1.7`. Defaults are unchanged so no breakage for existing callers.