### PR TITLE
feat: bind preserve_*_thinking at construction (drop _bind_preserve_defaults)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,36 @@ with pool.checkout() as r:
 
 Each slot owns its own tokenizer copy. Construction fans out across a thread pool.
 
+### Preserving past reasoning (constructor-only overrides)
+
+`create_renderer` and `create_renderer_pool` accept two flags:
+
+```python
+preserve_all_thinking: bool = False
+preserve_thinking_between_tool_calls: bool = False
+```
+
+Both are **constructor-only** — they configure the renderer instance once, are stored as `_preserve_all_thinking` / `_preserve_thinking_between_tool_calls` attributes for introspection, and are *not* accepted as call-site kwargs on `render` / `render_ids`. To run the same conversation through different configurations, build a different renderer (or a different pool).
+
+Defaults preserve byte-identity with each model's chat template. Flipping a flag at construction restores `reasoning_content` the template would otherwise drop:
+
+- `preserve_all_thinking=True` — every past assistant's reasoning is kept, including ones from prior tool cycles.
+- `preserve_thinking_between_tool_calls=True` — reasoning is kept on assistants in the in-flight A-T-...-A tool cycle when the template would drop them mid-cycle (a no-op for the current renderer line-up — every shipped renderer's template already keeps in-flight reasoning — but the override stays available for any future renderer that doesn't).
+
+**Why deviate from the template default?** The canonical case is *compaction*. A workflow that wants the model to summarize a long trajectory injects a `user` turn — something like *"Summarize the work so far so I can continue in a fresh context"* — and asks for a fresh assistant turn. As soon as that user turn lands, every prior assistant is in a "past cycle" by template-default rules, so its `reasoning_content` is dropped before the summarizer ever sees it. The model writes a summary based only on the surface answers it produced, not the reasoning it produced them with — usually noticeably worse.
+
+```python
+# Compaction prompt — keep reasoning_content visible end-to-end so the
+# summarizer doesn't lose the trajectory's "why".
+compactor = create_renderer(tok, renderer="auto", preserve_all_thinking=True)
+prompt_ids = compactor.render_ids(history + [{
+    "role": "user",
+    "content": "Summarise the work so far in 5 bullets.",
+}], add_generation_prompt=True)
+```
+
+These flags only ever *add* tokens vs the template default — they restore reasoning the template would have dropped, never strip reasoning the template would have kept. Bit-level parity with `apply_chat_template` (the suite that anchors §3 below) is unchanged when both flags are `False`.
+
 ---
 
 ## 2. The bridge (the core contract)
@@ -164,7 +194,9 @@ The `</parameter>\n` vanishes on re-render. Extension property broken at the clo
 
 ### d. Thinking stripped from non-latest assistant turns
 
-Some chat templates strip `<think>…</think>` blocks out of prior assistant turns when re-rendering history. The rollout's recorded stream has the thinking content; the next turn's re-rendered prompt does not. Applies across the Qwen3-series under certain message shapes.
+Some chat templates strip `<think>…</think>` blocks out of prior assistant turns when re-rendering history. The rollout's recorded stream has the thinking content; the next turn's re-rendered prompt does not. Applies across the Qwen3-series and GLM-series under certain message shapes.
+
+This is fine for the extension-property bridge (which never re-renders prior turns), but it does affect any *first-time* re-render — most notably **compaction**, where a trajectory is replayed from scratch with a new `user` turn asking the model to summarise. By template default, the prior assistants' reasoning is gone before the summariser sees it. Build the renderer with `create_renderer(..., preserve_all_thinking=True)` — see §1 *Preserving past reasoning (constructor-only overrides)* — to keep reasoning visible end-to-end on those flows.
 
 ### e. Max-seq-len truncation zeroing the anchor
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renderers"
-version = "0.1.8"
+version = "0.1.9"
 description = "Chat template renderers — deterministic message-to-token conversion for LLM training"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -139,17 +139,19 @@ class Renderer(Protocol):
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         """Render messages to token IDs with per-token message attribution.
 
-        ``preserve_all_thinking`` and ``preserve_thinking_between_tool_calls``
-        are *override* knobs — they only restore ``reasoning_content`` the
-        underlying chat template would drop, never strip thinking it emits.
-        Defaults are a no-op: rendered output stays byte-identical to the
-        original template behaviour. See ``should_preserve_past_thinking``
-        for the per-message classification.
+        Behaviour around historical ``reasoning_content`` is owned by the
+        renderer instance — the ``preserve_all_thinking`` and
+        ``preserve_thinking_between_tool_calls`` flags are constructor
+        kwargs, not call-site kwargs. To render with a different
+        configuration, build a different renderer (or different pool).
+        Defaults preserve byte-identity with each model's chat template;
+        flipping a flag at construction restores ``reasoning_content``
+        the template would otherwise drop. See
+        ``should_preserve_past_thinking`` for the per-message
+        classification.
         """
         ...
 
@@ -159,8 +161,6 @@ class Renderer(Protocol):
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         """Render messages to token IDs (without attribution metadata)."""
         ...
@@ -356,9 +356,9 @@ def create_renderer_pool(
     ``create_renderer`` when the pool falls back to ``DefaultRenderer``.
 
     ``preserve_all_thinking`` and ``preserve_thinking_between_tool_calls``
-    are forwarded to ``create_renderer`` and bound as defaults on each
-    pooled instance — every ``render`` / ``render_ids`` call uses them
-    unless an explicit kwarg overrides at the call site.
+    are forwarded to each pooled renderer's constructor — every slot in
+    the pool shares one configuration. To run with a different
+    configuration, build a different pool.
     """
 
     def factory() -> Renderer:
@@ -400,15 +400,18 @@ def create_renderer(
                   have their own parsing wired in.
         reasoning_parser: Name of a reasoning parser registered in
                   ``renderers.parsers``. Only consumed by DefaultRenderer.
-        preserve_all_thinking: Bind as default for every ``render`` /
-                  ``render_ids`` call on the returned instance. Same
-                  semantics as the call-site kwarg of the same name —
-                  see ``Renderer.render`` and
-                  ``should_preserve_past_thinking``. Off by default
-                  (zero behaviour change).
-        preserve_thinking_between_tool_calls: Bind as default for every
-                  ``render`` / ``render_ids`` call on the returned
-                  instance. See ``Renderer.render`` for semantics.
+        preserve_all_thinking: Forwarded to the renderer's constructor.
+                  When ``True``, the instance restores ``reasoning_content``
+                  the chat template would otherwise drop on historical
+                  assistants — useful when a downstream pass (e.g.
+                  compaction prompts the model with a fresh ``user`` turn
+                  asking for a summary) would lose the trajectory's
+                  reasoning. See ``Renderer.render`` and
+                  ``should_preserve_past_thinking``.
+        preserve_thinking_between_tool_calls: Forwarded to the renderer's
+                  constructor. ``True`` keeps reasoning on in-flight
+                  tool-cycle assistants when the template would drop them.
+                  See ``Renderer.render`` for semantics.
     """
     _populate_registry()
 
@@ -418,6 +421,11 @@ def create_renderer(
     if reasoning_parser is not None:
         default_kwargs["reasoning_parser"] = reasoning_parser
 
+    preserve_kwargs: dict = {
+        "preserve_all_thinking": preserve_all_thinking,
+        "preserve_thinking_between_tool_calls": preserve_thinking_between_tool_calls,
+    }
+
     if renderer != "auto":
         cls = RENDERER_REGISTRY.get(renderer)
         if cls is None:
@@ -425,21 +433,15 @@ def create_renderer(
                 f"Unknown renderer {renderer!r}. Available: {', '.join(sorted(RENDERER_REGISTRY))}"
             )
         if renderer == "default":
-            instance = cls(tokenizer, **default_kwargs)
-        else:
-            if default_kwargs:
-                logger.info(
-                    "tool_parser / reasoning_parser are only consumed by "
-                    "DefaultRenderer; ignoring for renderer=%r which has "
-                    "built-in behavior.",
-                    renderer,
-                )
-            instance = cls(tokenizer)
-        return _bind_preserve_defaults(
-            instance,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
-        )
+            return cls(tokenizer, **default_kwargs, **preserve_kwargs)
+        if default_kwargs:
+            logger.info(
+                "tool_parser / reasoning_parser are only consumed by "
+                "DefaultRenderer; ignoring for renderer=%r which has "
+                "built-in behavior.",
+                renderer,
+            )
+        return cls(tokenizer, **preserve_kwargs)
 
     # Auto-detect from model name via exact match on the canonical HF id.
     # Fine-tunes and renamed checkpoints miss on purpose — their chat
@@ -449,11 +451,7 @@ def create_renderer(
     model_name = getattr(tokenizer, "name_or_path", "")
     renderer_name = MODEL_RENDERER_MAP.get(model_name)
     if renderer_name is not None:
-        return _bind_preserve_defaults(
-            RENDERER_REGISTRY[renderer_name](tokenizer),
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
-        )
+        return RENDERER_REGISTRY[renderer_name](tokenizer, **preserve_kwargs)
 
     # No match — fall back to default (apply_chat_template). For fine-tunes
     # with customized chat templates this is the *correct* choice, so we don't
@@ -464,76 +462,9 @@ def create_renderer(
         "reasoning_parser=<name> to enable structured output parsing.",
         model_name or "<unnamed tokenizer>",
     )
-    return _bind_preserve_defaults(
-        RENDERER_REGISTRY["default"](tokenizer, **default_kwargs),
-        preserve_all_thinking=preserve_all_thinking,
-        preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+    return RENDERER_REGISTRY["default"](
+        tokenizer, **default_kwargs, **preserve_kwargs
     )
-
-
-def _bind_preserve_defaults(
-    renderer: Renderer,
-    *,
-    preserve_all_thinking: bool,
-    preserve_thinking_between_tool_calls: bool,
-) -> Renderer:
-    """Bind ``preserve_*_thinking`` defaults onto a renderer instance.
-
-    When neither flag is set, returns ``renderer`` unchanged — zero-cost
-    no-op for the common path. Otherwise wraps ``render`` and
-    ``render_ids`` so every call defaults the kwargs to the bound values
-    while still letting an explicit call-site kwarg of ``True`` override
-    upward (the flags only ever add thinking, never strip it).
-
-    The two flags also become introspectable on the instance as
-    ``_preserve_all_thinking`` / ``_preserve_thinking_between_tool_calls``
-    so tests and downstream code can confirm what was bound.
-    """
-    renderer._preserve_all_thinking = preserve_all_thinking  # type: ignore[attr-defined]
-    renderer._preserve_thinking_between_tool_calls = (  # type: ignore[attr-defined]
-        preserve_thinking_between_tool_calls
-    )
-    if not (preserve_all_thinking or preserve_thinking_between_tool_calls):
-        return renderer
-
-    orig_render = renderer.render
-    orig_render_ids = renderer.render_ids
-
-    def render(
-        messages: list[Message],
-        *,
-        tools: list[ToolSpec] | None = None,
-        add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = preserve_all_thinking,
-        preserve_thinking_between_tool_calls: bool = preserve_thinking_between_tool_calls,
-    ) -> RenderedTokens:
-        return orig_render(
-            messages,
-            tools=tools,
-            add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
-        )
-
-    def render_ids(
-        messages: list[Message],
-        *,
-        tools: list[ToolSpec] | None = None,
-        add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = preserve_all_thinking,
-        preserve_thinking_between_tool_calls: bool = preserve_thinking_between_tool_calls,
-    ) -> list[int]:
-        return orig_render_ids(
-            messages,
-            tools=tools,
-            add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
-        )
-
-    renderer.render = render  # type: ignore[method-assign]
-    renderer.render_ids = render_ids  # type: ignore[method-assign]
-    return renderer
 
 
 # ---------------------------------------------------------------------------

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -462,9 +462,7 @@ def create_renderer(
         "reasoning_parser=<name> to enable structured output parsing.",
         model_name or "<unnamed tokenizer>",
     )
-    return RENDERER_REGISTRY["default"](
-        tokenizer, **default_kwargs, **preserve_kwargs
-    )
+    return RENDERER_REGISTRY["default"](tokenizer, **default_kwargs, **preserve_kwargs)
 
 
 # ---------------------------------------------------------------------------

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -45,9 +45,16 @@ class DeepSeekV3Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
+        # DeepSeek-V3's chat template always emits ``<think>{reasoning}</think>``
+        # when ``reasoning_content`` is provided — no drop, so the override
+        # flags are no-ops. Stored for introspection / Protocol parity only.
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         # ── BOS / EOS ────────────────────────────────────────────────
         self._bos = self._get_special_token(f"begin{_US}of{_US}sentence")
@@ -98,13 +105,7 @@ class DeepSeekV3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
-        # DeepSeek-V3's template always emits ``<think>{reasoning}</think>``
-        # when ``reasoning_content`` is provided — no drop, so the override
-        # flags are no-ops. Accepted for Protocol parity.
-        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -211,15 +212,11 @@ class DeepSeekV3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -54,7 +54,9 @@ class DeepSeekV3Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         # ── BOS / EOS ────────────────────────────────────────────────
         self._bos = self._get_special_token(f"begin{_US}of{_US}sentence")

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -93,14 +93,24 @@ class DefaultRenderer:
         *,
         tool_parser: str | ToolParser | None = None,
         reasoning_parser: str | ReasoningParser | None = None,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
         **chat_template_kwargs,
     ):
+        if preserve_all_thinking or preserve_thinking_between_tool_calls:
+            raise NotImplementedError(
+                "DefaultRenderer falls back to apply_chat_template and can't "
+                "selectively re-emit dropped reasoning_content. Configure a "
+                "model-specific renderer if you need preserve_*_thinking."
+            )
         self._tokenizer = tokenizer
         self._chat_template_kwargs = chat_template_kwargs
         self._tool_parser = _resolve_parser(tool_parser, tokenizer, get_tool_parser)
         self._reasoning_parser = _resolve_parser(
             reasoning_parser, tokenizer, get_reasoning_parser
         )
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
     @property
     def supports_tools(self) -> bool:
@@ -112,15 +122,7 @@ class DefaultRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
-        if preserve_all_thinking or preserve_thinking_between_tool_calls:
-            raise NotImplementedError(
-                "DefaultRenderer falls back to apply_chat_template and can't "
-                "selectively re-emit dropped reasoning_content. Configure a "
-                "model-specific renderer if you need preserve_*_thinking."
-            )
         # Incremental rendering to get per-token message attribution
         token_ids: list[int] = []
         message_indices: list[int] = []
@@ -158,15 +160,7 @@ class DefaultRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
-        if preserve_all_thinking or preserve_thinking_between_tool_calls:
-            raise NotImplementedError(
-                "DefaultRenderer falls back to apply_chat_template and can't "
-                "selectively re-emit dropped reasoning_content. Configure a "
-                "model-specific renderer if you need preserve_*_thinking."
-            )
         return self._apply(
             messages, tools=tools, add_generation_prompt=add_generation_prompt
         )

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -110,7 +110,9 @@ class DefaultRenderer:
             reasoning_parser, tokenizer, get_reasoning_parser
         )
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
     @property
     def supports_tools(self) -> bool:

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -60,7 +60,9 @@ class GLM45Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._gmask = self._token_id("[gMASK]")
         self._sop = self._token_id("<sop>")

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -54,9 +54,13 @@ class GLM45Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._gmask = self._token_id("[gMASK]")
         self._sop = self._token_id("<sop>")
@@ -115,8 +119,6 @@ class GLM45Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -169,8 +171,8 @@ class GLM45Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -203,15 +205,11 @@ class GLM45Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -66,7 +66,9 @@ class GLM5Renderer:
         self._enable_thinking = enable_thinking
         self._clear_thinking = clear_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._gmask = self._token_id("[gMASK]")
         self._sop = self._token_id("<sop>")

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -59,10 +59,14 @@ class GLM5Renderer:
         *,
         enable_thinking: bool = True,
         clear_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._clear_thinking = clear_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._gmask = self._token_id("[gMASK]")
         self._sop = self._token_id("<sop>")
@@ -132,8 +136,6 @@ class GLM5Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -183,8 +185,8 @@ class GLM5Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -217,15 +219,11 @@ class GLM5Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -127,6 +127,8 @@ class GptOssRenderer:
         conversation_start_date: str | None = None,
         knowledge_cutoff: str | None = None,
         model_identity: str | None = None,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         """Initialise the renderer.
 
@@ -154,6 +156,8 @@ class GptOssRenderer:
         )
         self._knowledge_cutoff = knowledge_cutoff
         self._model_identity = model_identity
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         # Cache special-token IDs for the bridge / generation-prompt path.
         self._start = self._token_id("<|start|>")
@@ -186,8 +190,6 @@ class GptOssRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -256,8 +258,8 @@ class GptOssRenderer:
                 should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
             )
             for hm in self._to_harmony_messages(
@@ -296,15 +298,11 @@ class GptOssRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -157,7 +157,9 @@ class GptOssRenderer:
         self._knowledge_cutoff = knowledge_cutoff
         self._model_identity = model_identity
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         # Cache special-token IDs for the bridge / generation-prompt path.
         self._start = self._token_id("<|start|>")

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -48,7 +48,9 @@ class KimiK2Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._im_user = self._token_id("<|im_user|>")
         self._im_assistant = self._token_id("<|im_assistant|>")

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -39,9 +39,16 @@ class KimiK2Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
+        # Kimi-K2's chat template doesn't read ``reasoning_content`` for
+        # past assistant turns, so the override flags are no-ops. Stored
+        # for introspection / Protocol parity only.
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._im_user = self._token_id("<|im_user|>")
         self._im_assistant = self._token_id("<|im_assistant|>")
@@ -105,13 +112,7 @@ class KimiK2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
-        # Kimi-K2's chat template does not read ``reasoning_content`` for
-        # past assistant turns — the model thinks via a prefilled ``<think>``
-        # in the generation prompt only. Override flags are no-ops.
-        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -269,15 +270,11 @@ class KimiK2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -513,9 +513,13 @@ class KimiK25Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         # Core structural tokens — all must be single special tokens in the vocab
         self._im_user = self._token_id("<|im_user|>")
@@ -572,8 +576,6 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         """Render messages to tokens, matching the K2.5 chat template.
 
@@ -648,8 +650,8 @@ class KimiK25Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant_body(
                     msg,
@@ -694,15 +696,11 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -519,7 +519,9 @@ class KimiK25Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         # Core structural tokens — all must be single special tokens in the vocab
         self._im_user = self._token_id("<|im_user|>")

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -60,9 +60,13 @@ class MiniMaxM2Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         default_system: str = _DEFAULT_SYSTEM,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._default_system = default_system
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._bos = self._token_id("]~!b[")
         self._role = self._token_id("]~b]")
@@ -106,8 +110,6 @@ class MiniMaxM2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -174,8 +176,8 @@ class MiniMaxM2Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     orig_idx,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -212,15 +214,11 @@ class MiniMaxM2Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -66,7 +66,9 @@ class MiniMaxM2Renderer:
         self._tokenizer = tokenizer
         self._default_system = default_system
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._bos = self._token_id("]~!b[")
         self._role = self._token_id("]~b]")

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -80,9 +80,13 @@ class Nemotron3Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         # Look up special token IDs from the tokenizer (not hardcoded).
         # <|endoftext|> is optional: Nemotron-3 Nano / Super tokenizers ship
@@ -215,8 +219,6 @@ class Nemotron3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -325,8 +327,8 @@ class Nemotron3Renderer:
                 preserve_thinking = msg_orig_idx >= 0 and should_preserve_past_thinking(
                     original_messages,
                     msg_orig_idx,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -373,15 +375,11 @@ class Nemotron3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -86,7 +86,9 @@ class Nemotron3Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         # Look up special token IDs from the tokenizer (not hardcoded).
         # <|endoftext|> is optional: Nemotron-3 Nano / Super tokenizers ship

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -55,7 +55,9 @@ class Qwen3Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._im_start = self._token_id("<|im_start|>")
         self._im_end = self._token_id("<|im_end|>")

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -49,9 +49,13 @@ class Qwen3Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._im_start = self._token_id("<|im_start|>")
         self._im_end = self._token_id("<|im_end|>")
@@ -95,8 +99,6 @@ class Qwen3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -164,8 +166,8 @@ class Qwen3Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -198,15 +200,11 @@ class Qwen3Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -56,9 +56,13 @@ class Qwen35Renderer:
         tokenizer: PreTrainedTokenizer,
         *,
         enable_thinking: bool = True,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         # Look up special token IDs from the tokenizer (not hardcoded)
         self._im_start = self._token_id("<|im_start|>")
@@ -147,8 +151,6 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -223,8 +225,8 @@ class Qwen35Renderer:
                 preserve_thinking = should_preserve_past_thinking(
                     messages,
                     i,
-                    preserve_all_thinking=preserve_all_thinking,
-                    preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+                    preserve_all_thinking=self._preserve_all_thinking,
+                    preserve_thinking_between_tool_calls=self._preserve_thinking_between_tool_calls,
                 )
                 self._render_assistant(
                     msg,
@@ -270,15 +272,11 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -62,7 +62,9 @@ class Qwen35Renderer:
         self._tokenizer = tokenizer
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         # Look up special token IDs from the tokenizer (not hardcoded)
         self._im_start = self._token_id("<|im_start|>")

--- a/renderers/qwen36.py
+++ b/renderers/qwen36.py
@@ -32,8 +32,15 @@ class Qwen36Renderer(Qwen35Renderer):
         *,
         enable_thinking: bool = True,
         preserve_thinking: bool = False,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
     ):
-        super().__init__(tokenizer, enable_thinking=enable_thinking)
+        super().__init__(
+            tokenizer,
+            enable_thinking=enable_thinking,
+            preserve_all_thinking=preserve_all_thinking,
+            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
+        )
         self._preserve_thinking = preserve_thinking
 
     def _should_render_thinking(self, msg_idx: int, last_query_index: int) -> bool:

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -55,7 +55,9 @@ class Qwen3VLRenderer:
         # for introspection / Protocol parity only.
         self._tokenizer = tokenizer
         self._preserve_all_thinking = preserve_all_thinking
-        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
+        self._preserve_thinking_between_tool_calls = (
+            preserve_thinking_between_tool_calls
+        )
 
         self._im_start = self._token_id("<|im_start|>")
         self._im_end = self._token_id("<|im_end|>")

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -43,8 +43,19 @@ _TOOLS_FOOTER = (
 class Qwen3VLRenderer:
     """Deterministic message to token renderer for Qwen3-VL models (text-only)."""
 
-    def __init__(self, tokenizer: PreTrainedTokenizer):
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizer,
+        *,
+        preserve_all_thinking: bool = False,
+        preserve_thinking_between_tool_calls: bool = False,
+    ):
+        # Qwen3-VL's chat template doesn't render ``<think>`` blocks for
+        # past assistant turns, so the override flags are no-ops. Stored
+        # for introspection / Protocol parity only.
         self._tokenizer = tokenizer
+        self._preserve_all_thinking = preserve_all_thinking
+        self._preserve_thinking_between_tool_calls = preserve_thinking_between_tool_calls
 
         self._im_start = self._token_id("<|im_start|>")
         self._im_end = self._token_id("<|im_end|>")
@@ -90,13 +101,7 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> RenderedTokens:
-        # Qwen3-VL chat template doesn't render <think> blocks for past
-        # assistant messages, so the override flags are no-ops here. We
-        # accept them for Protocol parity.
-        del preserve_all_thinking, preserve_thinking_between_tool_calls
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -180,15 +185,11 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
-        preserve_all_thinking: bool = False,
-        preserve_thinking_between_tool_calls: bool = False,
     ) -> list[int]:
         return self.render(
             messages,
             tools=tools,
             add_generation_prompt=add_generation_prompt,
-            preserve_all_thinking=preserve_all_thinking,
-            preserve_thinking_between_tool_calls=preserve_thinking_between_tool_calls,
         ).token_ids
 
     def parse_response(self, token_ids: list[int]) -> ParsedResponse:

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -147,7 +147,9 @@ def test_should_preserve_past_thinking_classification():
     )
 
 
-def test_preserve_flags_default_unchanged(model_name, tokenizer, renderer_name, renderer):
+def test_preserve_flags_default_unchanged(
+    model_name, tokenizer, renderer_name, renderer
+):
     # A renderer constructed with both flags explicitly ``False`` must
     # produce byte-identical output to one constructed with the defaults.
     bare = renderer.render_ids(CONVERSATION)
@@ -162,15 +164,17 @@ def test_preserve_flags_default_unchanged(model_name, tokenizer, renderer_name, 
     )
 
 
-def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer_name, renderer):
+def test_preserve_all_thinking_grows_or_no_op(
+    model_name, tokenizer, renderer_name, renderer
+):
     from renderers.default import DefaultRenderer
 
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
     default = renderer.render_ids(CONVERSATION)
-    preserved = _make(
-        tokenizer, renderer_name, preserve_all_thinking=True
-    ).render_ids(CONVERSATION)
+    preserved = _make(tokenizer, renderer_name, preserve_all_thinking=True).render_ids(
+        CONVERSATION
+    )
 
     if model_name in NO_OP_MODELS:
         assert preserved == default, (
@@ -185,7 +189,9 @@ def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer_na
         )
 
 
-def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, renderer_name, renderer):
+def test_preserve_between_tool_calls_strict_subset(
+    model_name, tokenizer, renderer_name, renderer
+):
     """``preserve_thinking_between_tool_calls`` is strictly weaker than
     ``preserve_all_thinking``: token count satisfies default <= between <= all."""
     from renderers.default import DefaultRenderer
@@ -196,9 +202,9 @@ def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, render
     between = _make(
         tokenizer, renderer_name, preserve_thinking_between_tool_calls=True
     ).render_ids(CONVERSATION)
-    all_ = _make(
-        tokenizer, renderer_name, preserve_all_thinking=True
-    ).render_ids(CONVERSATION)
+    all_ = _make(tokenizer, renderer_name, preserve_all_thinking=True).render_ids(
+        CONVERSATION
+    )
     assert len(default) <= len(between) <= len(all_), (
         f"{model_name}: expected default <= between <= all, "
         f"got {len(default)} <= {len(between)} <= {len(all_)}"
@@ -224,7 +230,9 @@ LIVE_TOOL_CYCLE = [
 ]
 
 
-def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer_name, renderer):
+def test_preserve_btc_on_live_cycle_matches_all(
+    model_name, tokenizer, renderer_name, renderer
+):
     """In a live tool cycle (no trailing user), every past-asst sits in
     the current tool-bearing segment. ``preserve_thinking_between_tool_calls``
     should preserve all of their thinking — same set of asst messages as
@@ -238,9 +246,9 @@ def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer_
     btc = _make(
         tokenizer, renderer_name, preserve_thinking_between_tool_calls=True
     ).render_ids(LIVE_TOOL_CYCLE)
-    all_ = _make(
-        tokenizer, renderer_name, preserve_all_thinking=True
-    ).render_ids(LIVE_TOOL_CYCLE)
+    all_ = _make(tokenizer, renderer_name, preserve_all_thinking=True).render_ids(
+        LIVE_TOOL_CYCLE
+    )
     assert btc == all_, (
         f"{model_name}: in a live tool cycle btc must match preserve_all "
         f"(got len(btc)={len(btc)}, len(all)={len(all_)})"
@@ -316,9 +324,9 @@ def test_preserve_all_thinking_emits_every_asst_reasoning(
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
 
-    ids = _make(
-        tokenizer, renderer_name, preserve_all_thinking=True
-    ).render_ids(TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS)
+    ids = _make(tokenizer, renderer_name, preserve_all_thinking=True).render_ids(
+        TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS
+    )
     text = tokenizer.decode(ids)
 
     if model_name in NEVER_PRESERVES_MODELS:

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -1,8 +1,13 @@
 """Smoke coverage for the ``preserve_*_thinking`` override flags.
 
+Flags are constructor-only (``create_renderer(..., preserve_all_thinking=True)``)
+and stored as instance attributes — there is no call-site ``render`` /
+``render_ids`` override. Each test that wants a non-default flag builds
+a fresh renderer for that configuration via ``_make`` below.
+
 Two invariants per renderer:
 
-1. Default render (both flags ``False``) is byte-identical to the existing
+1. Default render (no flags) is byte-identical to the existing
    ``apply_chat_template`` parity baseline — covered exhaustively elsewhere.
 2. Setting either flag never *removes* tokens compared to the default and,
    for renderers whose template would drop past-asst thinking, actually
@@ -18,7 +23,14 @@ from __future__ import annotations
 
 import pytest
 
+from renderers import create_renderer
 from renderers.base import should_preserve_past_thinking
+
+
+def _make(tokenizer, renderer_name, **flags):
+    """Build a fresh renderer with the given preserve_*_thinking flags
+    bound at construction. Reuses the cached tokenizer fixture."""
+    return create_renderer(tokenizer, renderer=renderer_name, **flags)
 
 
 # Renderers whose template doesn't drop past-asst thinking or has no
@@ -135,27 +147,30 @@ def test_should_preserve_past_thinking_classification():
     )
 
 
-def test_preserve_flags_default_unchanged(model_name, tokenizer, renderer):
-    # Calling render with the flags explicitly off must be byte-identical
-    # to the bare call (defaults).
+def test_preserve_flags_default_unchanged(model_name, tokenizer, renderer_name, renderer):
+    # A renderer constructed with both flags explicitly ``False`` must
+    # produce byte-identical output to one constructed with the defaults.
     bare = renderer.render_ids(CONVERSATION)
-    explicit_off = renderer.render_ids(
-        CONVERSATION,
+    explicit_off = _make(
+        tokenizer,
+        renderer_name,
         preserve_all_thinking=False,
         preserve_thinking_between_tool_calls=False,
-    )
+    ).render_ids(CONVERSATION)
     assert bare == explicit_off, (
         f"{model_name}: explicit flags=False must equal bare default render"
     )
 
 
-def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer):
+def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer_name, renderer):
     from renderers.default import DefaultRenderer
 
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
     default = renderer.render_ids(CONVERSATION)
-    preserved = renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+    preserved = _make(
+        tokenizer, renderer_name, preserve_all_thinking=True
+    ).render_ids(CONVERSATION)
 
     if model_name in NO_OP_MODELS:
         assert preserved == default, (
@@ -170,7 +185,7 @@ def test_preserve_all_thinking_grows_or_no_op(model_name, tokenizer, renderer):
         )
 
 
-def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, renderer):
+def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, renderer_name, renderer):
     """``preserve_thinking_between_tool_calls`` is strictly weaker than
     ``preserve_all_thinking``: token count satisfies default <= between <= all."""
     from renderers.default import DefaultRenderer
@@ -178,10 +193,12 @@ def test_preserve_between_tool_calls_strict_subset(model_name, tokenizer, render
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
     default = renderer.render_ids(CONVERSATION)
-    between = renderer.render_ids(
-        CONVERSATION, preserve_thinking_between_tool_calls=True
-    )
-    all_ = renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+    between = _make(
+        tokenizer, renderer_name, preserve_thinking_between_tool_calls=True
+    ).render_ids(CONVERSATION)
+    all_ = _make(
+        tokenizer, renderer_name, preserve_all_thinking=True
+    ).render_ids(CONVERSATION)
     assert len(default) <= len(between) <= len(all_), (
         f"{model_name}: expected default <= between <= all, "
         f"got {len(default)} <= {len(between)} <= {len(all_)}"
@@ -207,7 +224,7 @@ LIVE_TOOL_CYCLE = [
 ]
 
 
-def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer):
+def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer_name, renderer):
     """In a live tool cycle (no trailing user), every past-asst sits in
     the current tool-bearing segment. ``preserve_thinking_between_tool_calls``
     should preserve all of their thinking — same set of asst messages as
@@ -218,10 +235,12 @@ def test_preserve_btc_on_live_cycle_matches_all(model_name, tokenizer, renderer)
 
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
-    btc = renderer.render_ids(
-        LIVE_TOOL_CYCLE, preserve_thinking_between_tool_calls=True
-    )
-    all_ = renderer.render_ids(LIVE_TOOL_CYCLE, preserve_all_thinking=True)
+    btc = _make(
+        tokenizer, renderer_name, preserve_thinking_between_tool_calls=True
+    ).render_ids(LIVE_TOOL_CYCLE)
+    all_ = _make(
+        tokenizer, renderer_name, preserve_all_thinking=True
+    ).render_ids(LIVE_TOOL_CYCLE)
     assert btc == all_, (
         f"{model_name}: in a live tool cycle btc must match preserve_all "
         f"(got len(btc)={len(btc)}, len(all)={len(all_)})"
@@ -287,7 +306,7 @@ NEVER_PRESERVES_MODELS = {
 
 
 def test_preserve_all_thinking_emits_every_asst_reasoning(
-    model_name, tokenizer, renderer
+    model_name, tokenizer, renderer_name, renderer
 ):
     """``preserve_all_thinking=True`` must surface every past-asst's
     ``reasoning_content`` in the decoded output — for renderers that
@@ -297,9 +316,9 @@ def test_preserve_all_thinking_emits_every_asst_reasoning(
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
 
-    ids = renderer.render_ids(
-        TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS, preserve_all_thinking=True
-    )
+    ids = _make(
+        tokenizer, renderer_name, preserve_all_thinking=True
+    ).render_ids(TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS)
     text = tokenizer.decode(ids)
 
     if model_name in NEVER_PRESERVES_MODELS:
@@ -316,7 +335,9 @@ def test_preserve_all_thinking_emits_every_asst_reasoning(
             )
 
 
-def test_preserve_btc_emits_current_block_reasoning(model_name, tokenizer, renderer):
+def test_preserve_btc_emits_current_block_reasoning(
+    model_name, tokenizer, renderer_name, renderer
+):
     """``preserve_thinking_between_tool_calls=True`` must surface the
     current (post-last-user) tool block's reasoning. Older blocks fall
     back to template default, which varies per renderer — no universal
@@ -326,11 +347,9 @@ def test_preserve_btc_emits_current_block_reasoning(model_name, tokenizer, rende
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on these flags — covered separately")
 
-    ids = renderer.render_ids(
-        TWO_BLOCK_CONV,
-        tools=TWO_BLOCK_TOOLS,
-        preserve_thinking_between_tool_calls=True,
-    )
+    ids = _make(
+        tokenizer, renderer_name, preserve_thinking_between_tool_calls=True
+    ).render_ids(TWO_BLOCK_CONV, tools=TWO_BLOCK_TOOLS)
     text = tokenizer.decode(ids)
 
     if model_name in NEVER_PRESERVES_MODELS:
@@ -349,88 +368,52 @@ def test_preserve_btc_emits_current_block_reasoning(model_name, tokenizer, rende
 
 def test_default_renderer_raises_on_flags():
     """``DefaultRenderer`` falls back to apply_chat_template with no
-    selective re-emit pathway, so it must raise rather than silently ignore."""
+    selective re-emit pathway, so constructing one with either flag set
+    must raise — fail fast, before any render is attempted."""
     from transformers import AutoTokenizer
-
-    from renderers import create_renderer
 
     tok = AutoTokenizer.from_pretrained(
         "Qwen/Qwen2.5-0.5B-Instruct", trust_remote_code=True
     )
-    renderer = create_renderer(tok, renderer="default")
+    # No flags → constructs cleanly.
+    create_renderer(tok, renderer="default")
+    # Either flag set → raises at construction.
     with pytest.raises(NotImplementedError):
-        renderer.render_ids(CONVERSATION, preserve_all_thinking=True)
+        create_renderer(tok, renderer="default", preserve_all_thinking=True)
     with pytest.raises(NotImplementedError):
-        renderer.render_ids(CONVERSATION, preserve_thinking_between_tool_calls=True)
+        create_renderer(
+            tok, renderer="default", preserve_thinking_between_tool_calls=True
+        )
 
 
 # ---------------------------------------------------------------------------
-# Construction-time defaults via create_renderer(...) kwargs
+# Construction-time configuration is discoverable via instance attributes
 # ---------------------------------------------------------------------------
 
 
-def test_create_renderer_binds_preserve_all_thinking_default(
-    model_name, renderer_name, tokenizer
-):
-    """``create_renderer(..., preserve_all_thinking=True)`` should make a
-    bare ``render_ids`` call behave as if the flag were passed explicitly."""
-    from renderers import create_renderer
+def test_create_renderer_records_flag_state(model_name, renderer_name, tokenizer):
+    """Each renderer exposes the bound flag state via ``_preserve_*``
+    attributes — useful for downstream code (pool cache keys, logging,
+    test assertions) that needs to confirm what was constructed."""
     from renderers.default import DefaultRenderer
 
-    bound = create_renderer(
-        tokenizer,
-        renderer=renderer_name,
-        preserve_all_thinking=True,
-    )
-    if isinstance(bound, DefaultRenderer):
-        with pytest.raises(NotImplementedError):
-            bound.render_ids(CONVERSATION)
-        return
+    bare = create_renderer(tokenizer, renderer=renderer_name)
+    assert bare._preserve_all_thinking is False
+    assert bare._preserve_thinking_between_tool_calls is False
 
-    bound_ids = bound.render_ids(CONVERSATION)
-    unbound = create_renderer(tokenizer, renderer=renderer_name)
-    explicit_ids = unbound.render_ids(CONVERSATION, preserve_all_thinking=True)
-    assert bound_ids == explicit_ids, (
-        f"{model_name}: bound default must equal explicit kwarg "
-        f"(bound={len(bound_ids)}, explicit={len(explicit_ids)})"
-    )
-    assert bound._preserve_all_thinking is True
-    assert bound._preserve_thinking_between_tool_calls is False
+    if not isinstance(bare, DefaultRenderer):
+        # DefaultRenderer raises at construction with either flag set —
+        # covered by ``test_default_renderer_raises_on_flags``.
+        all_on = create_renderer(
+            tokenizer, renderer=renderer_name, preserve_all_thinking=True
+        )
+        assert all_on._preserve_all_thinking is True
+        assert all_on._preserve_thinking_between_tool_calls is False
 
-
-def test_create_renderer_no_flags_is_zero_cost(renderer_name, tokenizer):
-    """When no flags are bound, attributes record the False bindings and
-    ``render_ids`` is unchanged from the underlying impl."""
-    from renderers import create_renderer
-
-    r = create_renderer(tokenizer, renderer=renderer_name)
-    assert r._preserve_all_thinking is False
-    assert r._preserve_thinking_between_tool_calls is False
-
-
-def test_create_renderer_btc_default_matches_explicit(
-    model_name, renderer_name, tokenizer
-):
-    """``preserve_thinking_between_tool_calls`` bound at construction
-    must match the explicit-kwarg call."""
-    from renderers import create_renderer
-    from renderers.default import DefaultRenderer
-
-    bound = create_renderer(
-        tokenizer,
-        renderer=renderer_name,
-        preserve_thinking_between_tool_calls=True,
-    )
-    if isinstance(bound, DefaultRenderer):
-        with pytest.raises(NotImplementedError):
-            bound.render_ids(CONVERSATION)
-        return
-
-    bound_ids = bound.render_ids(CONVERSATION)
-    unbound = create_renderer(tokenizer, renderer=renderer_name)
-    explicit_ids = unbound.render_ids(
-        CONVERSATION, preserve_thinking_between_tool_calls=True
-    )
-    assert bound_ids == explicit_ids, (
-        f"{model_name}: bound btc default must equal explicit kwarg"
-    )
+        btc_on = create_renderer(
+            tokenizer,
+            renderer=renderer_name,
+            preserve_thinking_between_tool_calls=True,
+        )
+        assert btc_on._preserve_all_thinking is False
+        assert btc_on._preserve_thinking_between_tool_calls is True

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-29T23:15:43.863476826Z"
+exclude-newer = "2026-04-30T13:28:05.184262475Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Moves \`preserve_all_thinking\` / \`preserve_thinking_between_tool_calls\` from \`render\` / \`render_ids\` call-site kwargs to **constructor-only** kwargs on every renderer. Each renderer stores them as \`_preserve_all_thinking\` / \`_preserve_thinking_between_tool_calls\` instance attributes and consults them internally via \`should_preserve_past_thinking\`.

Kills the method-monkey-patching \`_bind_preserve_defaults\` helper from #4: with construction-time configuration there is nothing left to bind after the fact. \`Renderer.render\` / \`render_ids\` signatures shrink back to their pre-#3 shape.

## Why

In real downstream usage (\`verifiers.RendererClient\`, prime-rl's \`RendererConfig\`), the flags are config-time, not per-render — bound once at pool creation, never changed per render. Call-site kwargs were over-engineered for that shape, and the wrapper that made them work hid the real method signature from type-checkers and IDE tooling.

"Renderer = configuration" is cleaner: build a different renderer (or pool) when you want a different configuration.

## What changed

- \`renderers/base.py\`: drop \`_bind_preserve_defaults\`; \`create_renderer\` / \`create_renderer_pool\` forward the flags directly to the constructor. \`Renderer\` Protocol's \`render\` / \`render_ids\` no longer expose the flags.
- Every concrete renderer (\`glm5\`, \`glm45\`, \`qwen3\`, \`qwen35\`, \`qwen36\`, \`qwen3_vl\`, \`minimax_m2\`, \`nemotron3\`, \`kimi_k2\`, \`kimi_k25\`, \`gpt_oss\`, \`deepseek_v3\`, \`default\`): accept the flags in \`__init__\`, store as attrs, drop them from render signatures.
- \`DefaultRenderer\` raises \`NotImplementedError\` at **construction** now (fail-fast) rather than at first render call.
- README §1: new *"Preserving past reasoning (constructor-only overrides)"* subsection with a worked compaction example motivating why someone would flip \`preserve_all_thinking=True\` (a user-turn summariser would otherwise lose all of the trajectory's reasoning).
- README §3.d: cross-link to the constructor-only override.
- Tests: rewrite to build per-flag renderers (no more call-site kwargs).
- Bump 0.1.8 → 0.1.9.

## Test plan

- [x] \`pytest tests/\` — 893 passed, 48 skipped, 1 xfailed locally (no parity regressions).
- [x] \`tests/test_preserve_thinking.py\` covers: byte-identical default render, monotonic token-count growth under \`preserve_all_thinking=True\` (or no-op for renderers whose template never preserves), strict-subset relation \`default ≤ btc ≤ all\`, sentinel-visibility on the two-block fixture, \`DefaultRenderer\` raising at construction.
- [x] \`should_preserve_past_thinking\` helper unaffected — same signature, same semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)