### PR TITLE
feat: scope trust_remote_code to Kimi-K2 family with pinned revisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "renderers"
-version = "0.1.6"
+version = "0.1.7"
 description = "Chat template renderers — deterministic message-to-token conversion for LLM training"
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -299,6 +299,57 @@ MODEL_RENDERER_MAP: dict[str, str] = {
 }
 
 
+# Models whose tokenizer requires ``trust_remote_code=True`` AND a pinned
+# revision. Empirical audit (2026-05-07) confirms only the Moonshot
+# Kimi-K2 family ships an ``auto_map.AutoTokenizer`` entry that runs
+# repo-supplied Python on every ``AutoTokenizer.from_pretrained`` call —
+# every other model in ``MODEL_RENDERER_MAP`` loads cleanly without it.
+#
+# Pinning the revision keeps the trust narrow: even with
+# ``trust_remote_code=True``, transformers downloads / executes the
+# tokenizer Python from this exact commit only. A future malicious push
+# to the Moonshot HF repo doesn't auto-propagate to anyone using
+# ``create_renderer_pool``. Bump these SHAs deliberately, with review.
+TRUSTED_REVISIONS: dict[str, str] = {
+    "moonshotai/Kimi-K2-Instruct": "fd1984e2b7a3350dbf7305fe73a4ede25c14de50",
+    "moonshotai/Kimi-K2.5": "4d01dfe0332d63057c186e0b262165819efb6611",
+    "moonshotai/Kimi-K2.6": "2755962d07cb42aa2d988a35bcb65cd4a9c2de82",
+}
+
+
+def load_tokenizer(model_name_or_path: str):
+    """Load a tokenizer with the renderers-package security policy.
+
+    Default: ``trust_remote_code=False`` — the safe choice for every
+    model in ``MODEL_RENDERER_MAP`` *except* the Kimi-K2 family.
+
+    Models listed in ``TRUSTED_REVISIONS`` load with
+    ``trust_remote_code=True`` AND ``revision=<pinned sha>`` — required
+    because their tokenizer config has an ``auto_map.AutoTokenizer``
+    entry pointing at a repo-supplied Python class
+    (``tokenization_kimi.TikTokenTokenizer``). Pinning the revision
+    means transformers executes only the reviewed commit's code, not
+    whatever ``HEAD`` points at when the call fires.
+
+    Unknown / fine-tuned model paths fall through to
+    ``trust_remote_code=False``. Callers who legitimately need to load
+    a custom-code tokenizer outside this allow-list should call
+    ``AutoTokenizer.from_pretrained`` themselves and pass the result to
+    ``create_renderer`` (which doesn't load tokenizers — only
+    ``create_renderer_pool`` does).
+    """
+    from transformers import AutoTokenizer
+
+    revision = TRUSTED_REVISIONS.get(model_name_or_path)
+    if revision is not None:
+        return AutoTokenizer.from_pretrained(
+            model_name_or_path,
+            trust_remote_code=True,
+            revision=revision,
+        )
+    return AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=False)
+
+
 def _populate_registry():
     if RENDERER_REGISTRY:
         return
@@ -359,14 +410,14 @@ def create_renderer_pool(
     are forwarded to each pooled renderer's constructor — every slot in
     the pool shares one configuration. To run with a different
     configuration, build a different pool.
+
+    Tokenizers load via ``load_tokenizer`` — see its docstring for the
+    ``trust_remote_code`` policy (default off; Moonshot Kimi-K2 family
+    opts in with a pinned ``revision``).
     """
 
     def factory() -> Renderer:
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_name_or_path, trust_remote_code=True
-        )
+        tokenizer = load_tokenizer(tokenizer_name_or_path)
         return create_renderer(
             tokenizer,
             renderer=renderer,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,9 @@ The same barrage of tests runs against every pair.
 import os
 
 import pytest
-from transformers import AutoTokenizer
 
 from renderers import create_renderer
+from renderers.base import load_tokenizer
 
 # (HuggingFace model name, renderer name or "auto")
 #
@@ -42,7 +42,7 @@ _cache: dict[str, tuple] = {}
 def _load(model_name: str, renderer_name: str):
     key = f"{model_name}:{renderer_name}"
     if key not in _cache:
-        tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        tokenizer = load_tokenizer(model_name)
         renderer = create_renderer(tokenizer, renderer=renderer_name)
         _cache[key] = (tokenizer, renderer)
     return _cache[key]

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -39,11 +39,10 @@ _BRIDGE_MODELS = [
 
 @lru_cache(maxsize=None)
 def _load(model_name: str, renderer_name: str):
-    from transformers import AutoTokenizer
-
     from renderers import create_renderer
+    from renderers.base import load_tokenizer
 
-    tok = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    tok = load_tokenizer(model_name)
     return tok, create_renderer(tok, renderer=renderer_name)
 
 

--- a/tests/test_load_tokenizer.py
+++ b/tests/test_load_tokenizer.py
@@ -1,0 +1,118 @@
+"""Unit tests for ``renderers.base.load_tokenizer`` security policy.
+
+The renderers package centralises ``trust_remote_code`` handling here:
+default off, opt-in only for the Moonshot Kimi-K2 family, and even then
+pinned to a reviewed revision so a future malicious push to the upstream
+repo doesn't auto-propagate.
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+from renderers.base import TRUSTED_REVISIONS, load_tokenizer
+
+
+# ---------------------------------------------------------------------------
+# Allow-list shape
+# ---------------------------------------------------------------------------
+
+
+def test_trusted_revisions_only_kimi_family():
+    """Only the Moonshot Kimi-K2 family is allowed to run repo-supplied
+    Python at ``from_pretrained`` time. Adding a new entry here means
+    the renderers package is opting into arbitrary-code execution for
+    that model — should require deliberate review."""
+    assert set(TRUSTED_REVISIONS) == {
+        "moonshotai/Kimi-K2-Instruct",
+        "moonshotai/Kimi-K2.5",
+        "moonshotai/Kimi-K2.6",
+    }
+
+
+def test_trusted_revisions_are_full_shas():
+    """Every pinned revision must be a 40-char hex sha — never a branch
+    name like ``main`` or ``HEAD``, which would defeat the purpose by
+    auto-resolving to whatever ``HEAD`` points at."""
+    sha_re = re.compile(r"^[0-9a-f]{40}$")
+    for model, rev in TRUSTED_REVISIONS.items():
+        assert sha_re.fullmatch(rev), (
+            f"{model}: revision {rev!r} is not a 40-char hex sha — "
+            f"branch names / tags can drift, only commit shas pin behaviour."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Call-shape: which kwargs reach AutoTokenizer.from_pretrained?
+# ---------------------------------------------------------------------------
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_unlisted_model_loads_without_remote_code(mock_from_pretrained):
+    """Default path: trust_remote_code=False, no revision pin."""
+    load_tokenizer("Qwen/Qwen3-0.6B")
+    args, kwargs = mock_from_pretrained.call_args
+    assert args == ("Qwen/Qwen3-0.6B",)
+    assert kwargs == {"trust_remote_code": False}
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_kimi_loads_with_pinned_revision(mock_from_pretrained):
+    """Kimi-K2 family: trust_remote_code=True, revision pinned to the
+    sha listed in TRUSTED_REVISIONS — never a branch name."""
+    load_tokenizer("moonshotai/Kimi-K2.5")
+    args, kwargs = mock_from_pretrained.call_args
+    assert args == ("moonshotai/Kimi-K2.5",)
+    assert kwargs == {
+        "trust_remote_code": True,
+        "revision": TRUSTED_REVISIONS["moonshotai/Kimi-K2.5"],
+    }
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
+def test_unknown_path_falls_through_to_no_remote_code(mock_from_pretrained):
+    """Unknown / fine-tuned model paths — including ``moonshotai/Kimi-K2*``
+    look-alikes that aren't in the allow-list — must fall through to
+    ``trust_remote_code=False``. No prefix matching, no fuzzy fallback.
+    Callers who legitimately need a custom-code tokenizer outside the
+    allow-list call ``AutoTokenizer.from_pretrained`` themselves."""
+    cases = [
+        "some-org/random-finetune",
+        "moonshotai/Kimi-K3",  # hypothetical future, NOT in allow-list
+        "/local/path/to/tokenizer",
+    ]
+    for name in cases:
+        mock_from_pretrained.reset_mock()
+        load_tokenizer(name)
+        args, kwargs = mock_from_pretrained.call_args
+        assert args == (name,)
+        assert kwargs == {"trust_remote_code": False}, (
+            f"{name}: unlisted path leaked trust_remote_code=True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Smoke: real tokenizer loads behave as expected
+# ---------------------------------------------------------------------------
+
+
+def test_load_tokenizer_real_qwen_works_without_remote_code():
+    """End-to-end: an unlisted model loads successfully without
+    trust_remote_code. Qwen tokenizers don't ship custom Python."""
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
+    assert tok is not None
+    # Smoke: the tokenizer can encode a basic string.
+    ids = tok.encode("hello", add_special_tokens=False)
+    assert len(ids) > 0
+
+
+def test_load_tokenizer_real_kimi_uses_pinned_revision():
+    """End-to-end: Kimi-K2.5 loads via the pinned-revision path. The
+    parity tests already exercise this path — this test pins the
+    contract that ``load_tokenizer`` is the only sanctioned entry
+    point for the trusted-revision allow-list."""
+    tok = load_tokenizer("moonshotai/Kimi-K2.5")
+    assert tok is not None
+    ids = tok.encode("hello", add_special_tokens=False)
+    assert len(ids) > 0

--- a/tests/test_message_indices.py
+++ b/tests/test_message_indices.py
@@ -95,13 +95,10 @@ def test_kimi_k2_unknown_role_message_indices():
     with the post-normalisation index ``i=2`` — out of range for a
     caller list of length 2.
     """
-    from transformers import AutoTokenizer
-
     from renderers import create_renderer
+    from renderers.base import load_tokenizer
 
-    tok = AutoTokenizer.from_pretrained(
-        "moonshotai/Kimi-K2-Instruct", trust_remote_code=True
-    )
+    tok = load_tokenizer("moonshotai/Kimi-K2-Instruct")
     renderer = create_renderer(tok, renderer="auto")
 
     msgs = [

--- a/tests/test_parse_response.py
+++ b/tests/test_parse_response.py
@@ -7,14 +7,12 @@ Runs against every (model, renderer) pair.
 from functools import lru_cache
 
 from renderers import create_renderer
-from transformers import AutoTokenizer
+from renderers.base import load_tokenizer
 
 
 @lru_cache
 def _qwen3_vl():
-    tokenizer = AutoTokenizer.from_pretrained(
-        "Qwen/Qwen3-VL-4B-Instruct", trust_remote_code=True
-    )
+    tokenizer = load_tokenizer("Qwen/Qwen3-VL-4B-Instruct")
     renderer = create_renderer(tokenizer, renderer="auto")
     return tokenizer, renderer
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from transformers import AutoTokenizer
 
+from renderers.base import load_tokenizer
 from renderers.parsers import (
     REASONING_PARSERS,
     TOOL_PARSERS,
@@ -24,7 +24,7 @@ def test_registries_nonempty():
 
 
 def test_unknown_parser_errors():
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     with pytest.raises(ValueError, match="Unknown tool_parser"):
         get_tool_parser("does-not-exist", tok)
     with pytest.raises(ValueError, match="Unknown reasoning_parser"):
@@ -33,7 +33,7 @@ def test_unknown_parser_errors():
 
 def test_qwen3_tool_parser_roundtrip():
     """Tokenize a Hermes-style tool call, parse it back out."""
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     parser = get_tool_parser("qwen3", tok)
     assert isinstance(parser, Qwen3ToolParser)
 
@@ -50,7 +50,7 @@ def test_qwen3_tool_parser_roundtrip():
 
 
 def test_qwen3_tool_parser_no_tool_call():
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     parser = get_tool_parser("qwen3", tok)
     ids = tok.encode("just plain text response", add_special_tokens=False)
     content_ids, tool_calls = parser.extract(list(ids))
@@ -59,7 +59,7 @@ def test_qwen3_tool_parser_no_tool_call():
 
 
 def test_think_reasoning_parser_extracts_block():
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     parser = get_reasoning_parser("think", tok)
     assert isinstance(parser, ThinkTextReasoningParser)
     reasoning, content = parser.extract("<think>let me think</think>the answer")
@@ -68,7 +68,7 @@ def test_think_reasoning_parser_extracts_block():
 
 
 def test_think_reasoning_parser_no_block():
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     parser = get_reasoning_parser("think", tok)
     reasoning, content = parser.extract("no reasoning here")
     assert reasoning is None
@@ -79,7 +79,7 @@ def test_default_renderer_uses_parsers():
     """DefaultRenderer + parsers should extract tool calls and reasoning."""
     from renderers import create_renderer
 
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     renderer = create_renderer(
         tok, renderer="default", tool_parser="qwen3", reasoning_parser="think"
     )
@@ -98,7 +98,7 @@ def test_default_renderer_without_parsers_is_backward_compatible():
     """Without parsers, DefaultRenderer still does basic <think> extraction."""
     from renderers import create_renderer
 
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3-0.6B")
     renderer = create_renderer(tok, renderer="default")
     assert renderer.supports_tools is False
 

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -378,11 +378,9 @@ def test_default_renderer_raises_on_flags():
     """``DefaultRenderer`` falls back to apply_chat_template with no
     selective re-emit pathway, so constructing one with either flag set
     must raise — fail fast, before any render is attempted."""
-    from transformers import AutoTokenizer
+    from renderers.base import load_tokenizer
 
-    tok = AutoTokenizer.from_pretrained(
-        "Qwen/Qwen2.5-0.5B-Instruct", trust_remote_code=True
-    )
+    tok = load_tokenizer("Qwen/Qwen2.5-0.5B-Instruct")
     # No flags → constructs cleanly.
     create_renderer(tok, renderer="default")
     # Either flag set → raises at construction.
@@ -437,11 +435,10 @@ def test_glm5_constructor_rejects_clear_thinking():
     superseded by the renderer-agnostic ``preserve_all_thinking`` override
     and must no longer be accepted by the constructor — its default-True
     semantics are now baked into the render gate."""
-    from transformers import AutoTokenizer
-
+    from renderers.base import load_tokenizer
     from renderers.glm5 import GLM5Renderer
 
-    tok = AutoTokenizer.from_pretrained("zai-org/GLM-5", trust_remote_code=True)
+    tok = load_tokenizer("zai-org/GLM-5")
     with pytest.raises(TypeError):
         GLM5Renderer(tok, clear_thinking=True)  # type: ignore[call-arg]
     with pytest.raises(TypeError):
@@ -454,10 +451,9 @@ def test_qwen36_constructor_rejects_preserve_thinking():
     ``preserve_all_thinking`` override and must no longer be accepted by
     the constructor — its default-False semantics are now inherited from
     Qwen3.5's render gate."""
-    from transformers import AutoTokenizer
-
+    from renderers.base import load_tokenizer
     from renderers.qwen36 import Qwen36Renderer
 
-    tok = AutoTokenizer.from_pretrained("Qwen/Qwen3.6-35B-A3B", trust_remote_code=True)
+    tok = load_tokenizer("Qwen/Qwen3.6-35B-A3B")
     with pytest.raises(TypeError):
         Qwen36Renderer(tok, preserve_thinking=True)  # type: ignore[call-arg]

--- a/tests/test_render_ids.py
+++ b/tests/test_render_ids.py
@@ -11,7 +11,7 @@ template. See ``test_gpt_oss_harmony_parity.py`` for harmony parity coverage.
 from functools import lru_cache
 
 from renderers import create_renderer
-from transformers import AutoTokenizer
+from renderers.base import load_tokenizer
 
 
 def _expected(tokenizer, messages, **kwargs):
@@ -337,9 +337,7 @@ def test_multi_step_tool_cycle(model_name, tokenizer, renderer):
 
 @lru_cache
 def _qwen3_vl():
-    tokenizer = AutoTokenizer.from_pretrained(
-        "Qwen/Qwen3-VL-4B-Instruct", trust_remote_code=True
-    )
+    tokenizer = load_tokenizer("Qwen/Qwen3-VL-4B-Instruct")
     renderer = create_renderer(tokenizer, renderer="auto")
     return tokenizer, renderer
 
@@ -354,9 +352,7 @@ def test_qwen3_vl_auto_renderer():
 
 @lru_cache
 def _kimi_k25():
-    tokenizer = AutoTokenizer.from_pretrained(
-        "moonshotai/Kimi-K2.5", trust_remote_code=True
-    )
+    tokenizer = load_tokenizer("moonshotai/Kimi-K2.5")
     renderer = create_renderer(tokenizer, renderer="auto")
     return tokenizer, renderer
 
@@ -369,9 +365,7 @@ def test_kimi_k2_inline_think_tags_render_verbatim():
     splitting out ``<think>...</think>`` and then discarded the extracted
     reasoning, producing tokens that disagreed with ``apply_chat_template``.
     """
-    tokenizer = AutoTokenizer.from_pretrained(
-        "moonshotai/Kimi-K2-Instruct", trust_remote_code=True
-    )
+    tokenizer = load_tokenizer("moonshotai/Kimi-K2-Instruct")
     renderer = create_renderer(tokenizer, renderer="auto")
     msgs = [
         {"role": "user", "content": "hi"},

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -50,11 +50,10 @@ _ROUNDTRIP_MODELS = [
 
 @lru_cache(maxsize=None)
 def _load_renderer(model_name: str, renderer_name: str):
-    from transformers import AutoTokenizer
-
     from renderers import create_renderer
+    from renderers.base import load_tokenizer
 
-    tok = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    tok = load_tokenizer(model_name)
     return tok, create_renderer(tok, renderer=renderer_name)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-30T14:04:35.440405774Z"
+exclude-newer = "2026-04-30T14:50:41.80385783Z"
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -1007,7 +1007,7 @@ wheels = [
 
 [[package]]
 name = "renderers"
-version = "0.1.6"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Centralise tokenizer loading through a new \`renderers.base.load_tokenizer\` helper. Default: \`trust_remote_code=False\`. Opt-in only for the Moonshot Kimi-K2 family, and even then with \`revision\` pinned to a reviewed sha so a future malicious push to the upstream repo cannot auto-propagate to anyone calling \`create_renderer_pool\`.

## Why

Empirical audit of every model in \`MODEL_RENDERER_MAP\`:

| family | needs \`trust_remote_code\`? |
|--|--|
| Qwen3 / 3.5 / 3.6 / 3-VL | no |
| Qwen2.5 (DefaultRenderer fixture) | no |
| GLM-5 / 5.1 / 4.7-Flash / 4.5-Air | no |
| MiniMax-M2 / M2.5 | no |
| DeepSeek-V3 / V3-Base | no |
| Nemotron-3 Nano / Super | no |
| GPT-OSS 20b / 120b | no |
| **Kimi-K2-Instruct / K2.5 / K2.6** | **YES** |

Only 3 of 32 entries actually need it. The previous unconditional \`trust_remote_code=True\` in \`create_renderer_pool\` granted arbitrary-Python-on-\`from_pretrained\` for every supported model.

The Kimi requirement is real: \`tokenizer_config.json\` has \`auto_map.AutoTokenizer = ["tokenization_kimi.TikTokenTokenizer", null]\`, which makes transformers download and \`import\` a 353-line tiktoken wrapper shipped in-repo. Pinning the \`revision\` keeps the trust narrow — even with \`trust_remote_code=True\`, transformers executes the tokenizer Python from that exact commit only.

## Pinned revisions (current as of 2026-05-07)

\`\`\`
moonshotai/Kimi-K2-Instruct: fd1984e2b7a3350dbf7305fe73a4ede25c14de50
moonshotai/Kimi-K2.5:        4d01dfe0332d63057c186e0b262165819efb6611
moonshotai/Kimi-K2.6:        2755962d07cb42aa2d988a35bcb65cd4a9c2de82
\`\`\`

Bumping requires deliberate review of the upstream diff.

## Changes

- \`renderers/base.py\`: add \`TRUSTED_REVISIONS\` allow-list and \`load_tokenizer\` helper; \`create_renderer_pool\`'s factory uses it.
- \`tests/conftest.py\` + every test that loaded tokenizers directly (\`test_bridge\`, \`test_message_indices\`, \`test_parse_response\`, \`test_parsers\`, \`test_preserve_thinking\`, \`test_render_ids\`, \`test_roundtrip\`): route through \`load_tokenizer\`. No more ad-hoc \`trust_remote_code=True\`.
- \`tests/test_load_tokenizer.py\` (new, 7 tests): unit-tests the policy itself — allow-list shape (Kimi-only), revision is a 40-char sha (rejects branch names like \`main\`), \`AutoTokenizer.from_pretrained\` call shape per model class, unknown paths fall through to no-trust, real Qwen + Kimi smoke loads.
- Bump 0.1.6 → 0.1.7.

## Downstream

- **verifiers / prime-rl**: do not need code changes. They build pools via \`create_renderer_pool(...)\` — the tokenizer loading is internal. Once this lands they bump the renderers pin and inherit the safer default for free.
- **Callers loading tokenizers themselves**: if anything in the wider org calls \`AutoTokenizer.from_pretrained(model, trust_remote_code=True)\` directly, they keep doing what they're doing — this PR doesn't restrict the transformers API, it just makes \`renderers\` the principled-default entry point.

## Test plan

- [x] \`pytest tests/\` — 902 passed, 48 skipped, 1 xfailed (no parity regressions; +7 are the new policy tests).
- [x] All trust_remote_code call sites in tests/ + renderers/ removed except inside \`load_tokenizer\` itself.
- [x] Pre-commit / ruff format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)