### PR TITLE
feat: add all 7 Qwen3.5 sizes to MODEL_RENDERER_MAP, autodetect think polarity

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -263,10 +263,23 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     "Qwen/Qwen3-32B": "qwen3",
     "Qwen/Qwen3-30B-A3B": "qwen3",
     "Qwen/Qwen3-235B-A22B": "qwen3",
-    # Qwen3.5.
+    # Qwen3.5. All seven sizes share the same renderer. The 4B / 9B /
+    # 35B-A3B / 122B-A10B / 397B-A17B chat template defaults
+    # ``enable_thinking=true`` (open ``<think>\n`` at the gen prompt);
+    # the smaller 0.8B / 2B variants flip the polarity (default
+    # ``enable_thinking=false``, empty ``<think>\n\n</think>\n\n``).
+    # ``Qwen35Renderer`` auto-detects polarity from the tokenizer's
+    # chat_template at construction, so all seven sizes are
+    # token-for-token parity-tested against their own
+    # ``apply_chat_template`` — including with
+    # ``add_generation_prompt=True``.
+    "Qwen/Qwen3.5-0.8B": "qwen3.5",
+    "Qwen/Qwen3.5-2B": "qwen3.5",
+    "Qwen/Qwen3.5-4B": "qwen3.5",
     "Qwen/Qwen3.5-9B": "qwen3.5",
     "Qwen/Qwen3.5-35B-A3B": "qwen3.5",
     "Qwen/Qwen3.5-122B-A10B": "qwen3.5",
+    "Qwen/Qwen3.5-397B-A17B": "qwen3.5",
     # Qwen3.6.
     "Qwen/Qwen3.6-35B-A3B": "qwen3.6",
     # Qwen3-VL.

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -48,6 +48,41 @@ _TOOLS_INSTRUCTIONS = (
 )
 
 
+def _detect_enable_thinking_default(tokenizer: PreTrainedTokenizer) -> bool:
+    """Probe the tokenizer's chat template to learn its ``enable_thinking``
+    default polarity at the generation-prompt boundary.
+
+    The Qwen3.5 family ships two template variants that differ only in the
+    polarity of the gated branch:
+
+    * Big sizes (4B / 9B / 35B-A3B / 122B-A10B / 397B-A17B) emit an open
+      ``<think>\\n`` by default and the empty ``<think>\\n\\n</think>\\n\\n``
+      block when ``enable_thinking`` is explicitly false.
+    * Small sizes (0.8B / 2B) flip the polarity — they emit the empty
+      block by default and the open ``<think>\\n`` only when
+      ``enable_thinking`` is explicitly true.
+
+    A one-shot ``apply_chat_template`` call with no flag and a minimal
+    user message reveals which variant is in use: the empty-block tail
+    ends with ``</think>``, the open-think tail does not. Failing the
+    probe (no chat_template, exotic config) falls back to the big-model
+    default of True, which matches every entry in
+    ``MODEL_RENDERER_MAP`` that routes to ``qwen3.5`` without explicit
+    polarity awareness.
+    """
+    try:
+        out = tokenizer.apply_chat_template(
+            [{"role": "user", "content": "x"}],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+    except Exception:
+        return True
+    if not isinstance(out, str):
+        return True
+    return not out.rstrip().endswith("</think>")
+
+
 class Qwen35Renderer:
     """Deterministic message → token renderer for Qwen3.5 models."""
 
@@ -55,11 +90,13 @@ class Qwen35Renderer:
         self,
         tokenizer: PreTrainedTokenizer,
         *,
-        enable_thinking: bool = True,
+        enable_thinking: bool | None = None,
         preserve_all_thinking: bool = False,
         preserve_thinking_between_tool_calls: bool = False,
     ):
         self._tokenizer = tokenizer
+        if enable_thinking is None:
+            enable_thinking = _detect_enable_thinking_default(tokenizer)
         self._enable_thinking = enable_thinking
         self._preserve_all_thinking = preserve_all_thinking
         self._preserve_thinking_between_tool_calls = (

--- a/tests/test_qwen35_size_coverage.py
+++ b/tests/test_qwen35_size_coverage.py
@@ -1,0 +1,166 @@
+"""Qwen3.5 size coverage in ``MODEL_RENDERER_MAP``.
+
+Seven Qwen3.5 sizes route to ``Qwen35Renderer``. The 4B / 9B / 35B-A3B /
+122B-A10B / 397B-A17B sizes ship one chat template (default
+``enable_thinking=true``); the smaller 0.8B / 2B sizes ship the polarity-
+flipped variant (default ``enable_thinking=false`` → empty
+``<think>\\n\\n</think>\\n\\n`` at the gen-prompt boundary). The renderer
+detects polarity from the tokenizer's chat_template at construction, so
+both variants render byte-identical to their own
+``apply_chat_template``.
+
+These tests lock in (a) the exact set of Qwen3.5 sizes in the map and
+(b) byte parity for every one of them across representative
+conversations including the ``add_generation_prompt=True`` boundary
+where the polarity divergence shows up.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from renderers import Qwen35Renderer, create_renderer
+from renderers.base import MODEL_RENDERER_MAP, load_tokenizer
+
+
+_QWEN35_IN_MAP = {
+    "Qwen/Qwen3.5-0.8B",
+    "Qwen/Qwen3.5-2B",
+    "Qwen/Qwen3.5-4B",
+    "Qwen/Qwen3.5-9B",
+    "Qwen/Qwen3.5-35B-A3B",
+    "Qwen/Qwen3.5-122B-A10B",
+    "Qwen/Qwen3.5-397B-A17B",
+}
+
+
+def test_map_includes_expected_qwen35_sizes():
+    """Every parity-verified Qwen3.5 size routes to the ``qwen3.5`` renderer."""
+    for model in _QWEN35_IN_MAP:
+        assert MODEL_RENDERER_MAP.get(model) == "qwen3.5", (
+            f"{model}: expected to route to 'qwen3.5'"
+        )
+
+
+def test_no_other_qwen35_sizes_silently_added():
+    """Catches silent additions: any Qwen3.5 size in the map MUST be in
+    ``_QWEN35_IN_MAP`` so the parity barrage below covers it."""
+    listed_qwen35 = {
+        m
+        for m, r in MODEL_RENDERER_MAP.items()
+        if r == "qwen3.5" and m.startswith("Qwen/Qwen3.5-")
+    }
+    assert listed_qwen35 == _QWEN35_IN_MAP, (
+        f"Qwen3.5 entries in MODEL_RENDERER_MAP drifted from the parity "
+        f"matrix; map={sorted(listed_qwen35)} test={sorted(_QWEN35_IN_MAP)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Polarity auto-detection: 0.8B / 2B flip ``enable_thinking`` default.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "qwen35_model,expected_default",
+    [
+        ("Qwen/Qwen3.5-0.8B", False),
+        ("Qwen/Qwen3.5-2B", False),
+        ("Qwen/Qwen3.5-4B", True),
+        ("Qwen/Qwen3.5-9B", True),
+        ("Qwen/Qwen3.5-35B-A3B", True),
+        ("Qwen/Qwen3.5-122B-A10B", True),
+        ("Qwen/Qwen3.5-397B-A17B", True),
+    ],
+)
+def test_qwen35_enable_thinking_polarity_autodetected(qwen35_model, expected_default):
+    """The renderer's ``_enable_thinking`` resolves to the chat template's
+    own default when no explicit flag is passed — so big / small sizes
+    each match their own template at the gen-prompt boundary."""
+    tok = load_tokenizer(qwen35_model)
+    renderer = create_renderer(tok, renderer="qwen3.5")
+    assert isinstance(renderer, Qwen35Renderer)
+    assert renderer._enable_thinking is expected_default, (
+        f"{qwen35_model}: expected enable_thinking default {expected_default}, "
+        f"got {renderer._enable_thinking}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Byte parity for each in-map Qwen3.5 size.
+# ---------------------------------------------------------------------------
+
+
+_PARITY_CASES = [
+    pytest.param(
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi."},
+        ],
+        False,
+        id="system_user",
+    ),
+    pytest.param(
+        [
+            {"role": "system", "content": "You are a math tutor."},
+            {"role": "user", "content": "2+2?"},
+            {"role": "assistant", "content": "4"},
+        ],
+        False,
+        id="single_turn",
+    ),
+    pytest.param(
+        [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hi."},
+        ],
+        True,
+        id="with_gen_prompt",
+    ),
+    pytest.param(
+        [
+            {"role": "user", "content": "Solve."},
+            {
+                "role": "assistant",
+                "content": "42",
+                "reasoning_content": "Think hard.",
+            },
+            {"role": "user", "content": "Why?"},
+            {
+                "role": "assistant",
+                "content": "Because.",
+                "reasoning_content": "More thinking.",
+            },
+        ],
+        False,
+        id="with_reasoning",
+    ),
+]
+
+
+@pytest.mark.parametrize("qwen35_model", sorted(_QWEN35_IN_MAP))
+@pytest.mark.parametrize("messages,add_gen_prompt", _PARITY_CASES)
+def test_qwen35_size_parity_with_apply_chat_template(
+    qwen35_model, messages, add_gen_prompt
+):
+    """Each in-map Qwen3.5 size renders byte-identical to its own
+    ``apply_chat_template`` output. Locks in the property that lets us
+    share ``Qwen35Renderer`` across all seven sizes — the polarity
+    flip on 0.8B / 2B is absorbed by the constructor's auto-detect."""
+    tok = load_tokenizer(qwen35_model)
+    renderer = create_renderer(tok, renderer="qwen3.5")
+    assert isinstance(renderer, Qwen35Renderer)
+
+    ours = renderer.render_ids(messages, add_generation_prompt=add_gen_prompt)
+    theirs = list(
+        tok.apply_chat_template(
+            messages,
+            tokenize=True,
+            return_dict=False,
+            add_generation_prompt=add_gen_prompt,
+        )
+    )
+    assert ours == theirs, (
+        f"{qwen35_model}: Qwen35Renderer diverges from apply_chat_template "
+        f"(add_generation_prompt={add_gen_prompt})"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-30T14:50:41.80385783Z"
+exclude-newer = "2026-04-30T16:49:35.881373563Z"
 exclude-newer-span = "P7D"
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds **all seven Qwen3.5 sizes** to `MODEL_RENDERER_MAP`: `0.8B`, `2B`, `4B`, `9B`, `35B-A3B`, `122B-A10B`, `397B-A17B` (previously only the middle three were listed).
- Teaches `Qwen35Renderer` to **autodetect the `enable_thinking` default** from the tokenizer's chat template at construction.
- Bumps version `0.1.7` → `0.1.8`.

### Why

Qwen3.5 ships two chat-template variants that differ only in the polarity of the gen-prompt branch:

| Variant | Sizes | Default at gen prompt |
|---|---|---|
| Big-default-on | 4B / 9B / 35B-A3B / 122B-A10B / 397B-A17B | `<think>\n` (thinking on) |
| Small-default-off | 0.8B / 2B | `<think>\n\n</think>\n\n` (empty block) |

The previous `Qwen35Renderer` hardcoded `enable_thinking=True`, which matched the big-default variant but not the small one — so 0.8B / 2B couldn't be added to the map without silently breaking byte parity at `add_generation_prompt=True`.

### Implementation

`Qwen35Renderer.__init__(... enable_thinking: bool | None = None)`:
- When `None` (the new default), runs a one-shot `tokenizer.apply_chat_template(...)` probe and reads the polarity off the resulting tail (`</think>` ⇒ default off).
- Explicit `enable_thinking=True/False` still wins — autodetect only fires when the caller omits the flag.
- Probe failures fall back to `True` (matches the big-default majority).

### Tests

New `tests/test_qwen35_size_coverage.py` (37 cases):

1. **Map shape** — exactly the seven listed sizes route to `qwen3.5`; catches silent additions.
2. **Polarity autodetect** — each of the 7 sizes resolves to its expected default (big → True, small → False) when constructed without an explicit flag.
3. **Byte parity barrage** — for each of the 7 sizes × 4 representative conversations (system+user, single-turn, gen-prompt, with reasoning), `Qwen35Renderer.render_ids` matches `apply_chat_template` token-for-token.

Full suite: `937 passed, 48 skipped, 1 xfailed`.

## Test plan

- [x] `pytest tests/test_qwen35_size_coverage.py` — 37 cases pass
- [x] Full suite (`pytest tests/ --ignore=tests/test_client.py`) — 937 pass, no regressions
- [x] Pre-commit hooks (ruff check + format) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)