### PR TITLE
feat: renderer emits numpy, not torch

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -263,8 +263,15 @@ def _build_qwen_vl_features(
 
     image_items = mm_data.mm_items.get("image") or []
     if image_items:
-        pixel_values = torch.cat([it["pixel_values"] for it in image_items], dim=0)
-        image_grid_thw = torch.cat([it["image_grid_thw"] for it in image_items], dim=0)
+        # mm_items now ship numpy arrays (the renderer is torch-free);
+        # convert at this vLLM-glue boundary where torch is already a
+        # hard dependency.
+        pixel_values = torch.cat(
+            [torch.as_tensor(it["pixel_values"]) for it in image_items], dim=0
+        )
+        image_grid_thw = torch.cat(
+            [torch.as_tensor(it["image_grid_thw"]) for it in image_items], dim=0
+        )
         hf_inputs = BatchFeature(
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}
         )

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -621,7 +621,7 @@ class KimiK25Renderer:
         img_proc = proc.image_processor
         # Kimi's vision processor takes a media-dict shape, not raw PIL.
         media_item = {"type": "image", "image": pil}
-        out = img_proc.preprocess([media_item], return_tensors="pt")
+        out = img_proc.preprocess([media_item], return_tensors="np")
         # Patch count via the processor's own calculator (matches the
         # model's per-patch attention count); kept for debugging.
         num_patches = int(img_proc.media_tokens_calculator(media_item))

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -182,7 +182,7 @@ class Qwen35Renderer:
             out, num_image_tokens = cached
             return pil, out, num_image_tokens, h
         proc = self._get_processor()
-        out = proc.image_processor(images=[pil], return_tensors="pt")
+        out = proc.image_processor(images=[pil], return_tensors="np")
         grid_thw = out["image_grid_thw"][0]
         merge_size = proc.image_processor.merge_size
         num_image_tokens = int(grid_thw.prod()) // (merge_size * merge_size)

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -357,7 +357,7 @@ class Qwen3VLRenderer:
             out, num_image_tokens = cached
             return pil, out, num_image_tokens, h
         proc = self._get_processor()
-        out = proc.image_processor(images=[pil], return_tensors="pt")
+        out = proc.image_processor(images=[pil], return_tensors="np")
         grid_thw = out["image_grid_thw"][0]
         merge_size = proc.image_processor.merge_size
         num_image_tokens = int(grid_thw.prod()) // (merge_size * merge_size)


### PR DESCRIPTION
## Summary

HF processors return torch by default; multimodal renderers were passing those tensors through to ``mm_items``, which leaked torch into the renderer's data model and forced downstream transport layers (verifiers — which doesn't declare torch as a dep) to handle torch tensors.

Switch all three multimodal processors (Qwen3-VL, Qwen3.5/3.6, Kimi-K2.5) to ``return_tensors=\"np\"``. ``mm_items[i][\"pixel_values\"]`` and friends now ship numpy arrays. Renderer is torch-free; downstream consumers (vLLM-glue helper in ``client.py``, trainer in prime-rl) convert via ``torch.from_numpy`` / ``torch.as_tensor`` at their boundary, where torch is already a hard dependency.

## Why

Architectural cleanup: the renderer shouldn't know about tensorization. numpy is the lowest-common-denominator format that's already a dep of every realistic consumer (HF, torch, vLLM, jax) and is natively serializable by verifiers' msgpack encoder. This lets verifiers drop its torch handling branch (companion PR opens shortly).

## What changes

- ``Qwen3VLRenderer._process_image`` — ``return_tensors=\"pt\"`` → ``\"np\"``
- ``Qwen35Renderer._process_image`` — same
- ``KimiK25Renderer._process_image`` — same
- ``client._build_qwen_vl_features`` — wrap numpy items in ``torch.as_tensor`` before ``torch.cat`` / ``BatchFeature``. Torch is already imported here (the vLLM payload encoder is a torch-required code path).
- Bump 0.1.7 → 0.1.8.

## Test plan

- [x] Full renderer suite green (980 passed, 49 skipped, 1 xfailed)
- [x] Multimodal byte-parity vs HF processor unchanged (compares ``input_ids``, not pixel arrays)
- [ ] Companion verifiers PR drops torch branch from ``msgpack_encoder`` and bumps to ``renderers>=0.1.8``
- [ ] prime-rl bumps ``renderers>=0.1.8``; trainer-side ``decode_tensor_payload`` already handles the encoded wire format identically (numpy/torch source produces the same ``__torch_tensor__``-tagged payload)