### PR TITLE
[DIAGNOSTIC - DO NOT MERGE] fix(load_tokenizer): default to use_fast=True

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -664,7 +664,11 @@ def load_tokenizer(model_name_or_path: str):
             trust_remote_code=True,
             revision=revision,
         )
-    return AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=False)
+    return AutoTokenizer.from_pretrained(
+        model_name_or_path,
+        trust_remote_code=False,
+        use_fast=True,
+    )
 
 
 def _populate_registry():

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -663,6 +663,7 @@ def load_tokenizer(model_name_or_path: str):
             model_name_or_path,
             trust_remote_code=True,
             revision=revision,
+            use_fast=True,
         )
     return AutoTokenizer.from_pretrained(
         model_name_or_path,

--- a/tests/test_load_tokenizer.py
+++ b/tests/test_load_tokenizer.py
@@ -50,11 +50,11 @@ def test_trusted_revisions_are_full_shas():
 
 @patch("transformers.AutoTokenizer.from_pretrained")
 def test_unlisted_model_loads_without_remote_code(mock_from_pretrained):
-    """Default path: trust_remote_code=False, no revision pin."""
+    """Default path: trust_remote_code=False, use_fast=True, no revision pin."""
     load_tokenizer("Qwen/Qwen3-0.6B")
     args, kwargs = mock_from_pretrained.call_args
     assert args == ("Qwen/Qwen3-0.6B",)
-    assert kwargs == {"trust_remote_code": False}
+    assert kwargs == {"trust_remote_code": False, "use_fast": True}
 
 
 @patch("transformers.AutoTokenizer.from_pretrained")
@@ -87,8 +87,9 @@ def test_unknown_path_falls_through_to_no_remote_code(mock_from_pretrained):
         load_tokenizer(name)
         args, kwargs = mock_from_pretrained.call_args
         assert args == (name,)
-        assert kwargs == {"trust_remote_code": False}, (
-            f"{name}: unlisted path leaked trust_remote_code=True"
+        assert kwargs == {"trust_remote_code": False, "use_fast": True}, (
+            f"{name}: unlisted path leaked trust_remote_code=True "
+            f"or dropped use_fast=True"
         )
 
 

--- a/tests/test_load_tokenizer.py
+++ b/tests/test_load_tokenizer.py
@@ -67,6 +67,7 @@ def test_kimi_loads_with_pinned_revision(mock_from_pretrained):
     assert kwargs == {
         "trust_remote_code": True,
         "revision": TRUSTED_REVISIONS["moonshotai/Kimi-K2.5"],
+        "use_fast": True,
     }
 
 


### PR DESCRIPTION
## Summary

`load_tokenizer` currently calls `AutoTokenizer.from_pretrained(model_name_or_path, trust_remote_code=False)` without specifying a backend. `AutoTokenizer` is a factory that picks between two backends:

- `TokenizersBackend` (Rust, fast) — the desired path.
- `PythonBackend` (pure Python) — has a latent crash in its `__init__`.

`PythonBackend.__init__` calls `_add_tokens(...)`, which calls `self.get_vocab()`. In `transformers/tokenization_utils_base.py:1439`:

```python
def get_vocab(self):
    raise NotImplementedError()
```

`PythonBackend` does **not** override this. So whenever HF silently falls back to the Python path, pool construction raises a bare `NotImplementedError` that surfaces to env workers as `ModelError() -> NotImplementedError()`.

## Reproduction

Observed in prime-rl rollouts on `PrimeIntellect/GLM-4.5-Air` with `trust_remote_code=False`:

- Intermittent at `batch_size=256, rollouts_per_example=8`.
- Reliable at `batch_size=512, rollouts_per_example=16`.

The identical `AutoTokenizer.from_pretrained` call returned `TokenizersBackend` on the head node and `PythonBackend` on the compute nodes — likely a race in HF's backend selection under concurrent first-time loads.

Stack:

```
RendererPool.__init__ -> factory() -> load_tokenizer()
  -> AutoTokenizer.from_pretrained(GLM-4.5-Air, trust_remote_code=False)
  -> tokenization_python.py:_add_tokens
  -> self.get_vocab()
  -> tokenization_utils_base.py:1439  raise NotImplementedError()
```

## Fix

Pass `use_fast=True` explicitly. This forces the Rust path. If fast tokenizer files are genuinely missing, `AutoTokenizer` raises a clear `OSError` instead of silently routing to the half-implemented Python class.

This is also a latent upstream bug in `transformers` (`PythonBackend._add_tokens -> get_vocab` is unreachable), but the renderers-side default is the right call regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)