### PR TITLE
fix(parsing): schema-aware tool-arg coercion for XML-style parsers

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -297,8 +297,23 @@ class Renderer(Protocol):
         """Render messages to token IDs (without attribution metadata)."""
         ...
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
-        """Parse completion tokens back into a structured message."""
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
+        """Parse completion tokens back into a structured message.
+
+        ``tools`` is the same list passed to ``render`` for this turn.
+        XML-style formats (Qwen3.5, GLM, MiniMax, Laguna) render argument
+        values verbatim inside ``<arg_value>`` tags with no quoting, so
+        a value like ``true`` is ambiguous between bool and the string
+        ``"true"``. When ``tools`` is supplied, the parser consults each
+        parameter's declared JSON-schema type to preserve string args
+        verbatim. Without ``tools``, parsers fall back to the historical
+        ``json.loads``-with-text-fallback behavior.
+        """
         ...
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -150,7 +150,7 @@ async def generate(
     completion_ids = choice.get("token_ids") or []
 
     parsed = await _maybe_offload(
-        renderer, lambda: renderer.parse_response(completion_ids)
+        renderer, lambda: renderer.parse_response(completion_ids, tools=tools)
     )
 
     # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -221,7 +221,12 @@ class DeepSeekV3Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — args land in a ```json fence, schema not needed
+    ) -> ParsedResponse:
         return parse_deepseek_v3(
             self._tokenizer,
             token_ids,

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -167,7 +167,12 @@ class DefaultRenderer:
             messages, tools=tools, add_generation_prompt=add_generation_prompt
         )
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — DefaultRenderer relies on configured tool_parser, schema not consulted here
+    ) -> ParsedResponse:
         # 1. Extract tool calls while we still have token ids (most formats
         #    use special-token delimiters, so id-level matching is reliable).
         if self._tool_parser is not None:

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -214,7 +214,12 @@ class GLM45Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
         return parse_glm(
             self._tokenizer,
             token_ids,
@@ -227,6 +232,7 @@ class GLM45Renderer:
             arg_key_end_id=self._arg_key_end,
             arg_value_id=self._arg_value,
             arg_value_end_id=self._arg_value_end,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -226,7 +226,12 @@ class GLM5Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
         return parse_glm(
             self._tokenizer,
             token_ids,
@@ -239,6 +244,7 @@ class GLM5Renderer:
             arg_key_end_id=self._arg_key_end,
             arg_value_id=self._arg_value,
             arg_value_end_id=self._arg_value_end,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -307,7 +307,12 @@ class GptOssRenderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — harmony args land in a JSON object, schema not needed
+    ) -> ParsedResponse:
         return parse_gpt_oss(
             self._tokenizer,
             token_ids,

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -279,7 +279,12 @@ class KimiK2Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — section-JSON wire format quotes strings, schema not needed
+    ) -> ParsedResponse:
         return parse_kimi_k2(
             self._tokenizer,
             token_ids,

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -904,7 +904,12 @@ class KimiK25Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — section-JSON wire format quotes strings, schema not needed
+    ) -> ParsedResponse:
         stop_ids: set[int] = {self._im_end}
         if self._endoftext is not None:
             stop_ids.add(self._endoftext)

--- a/renderers/laguna_xs2.py
+++ b/renderers/laguna_xs2.py
@@ -238,7 +238,12 @@ class LagunaXS2Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
         return parse_laguna_xs2(
             self._tokenizer,
             token_ids,
@@ -247,6 +252,7 @@ class LagunaXS2Renderer:
             think_end_id=self._think_end,
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -223,7 +223,12 @@ class MiniMaxM2Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
         return parse_minimax(
             self._tokenizer,
             token_ids,
@@ -232,6 +237,7 @@ class MiniMaxM2Renderer:
             think_end_id=self._think_end,
             tool_call_id=self._tool_call_tok,
             tool_call_end_id=self._tool_call_end_tok,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -384,7 +384,12 @@ class Nemotron3Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — args land in a JSON object, schema not needed
+    ) -> ParsedResponse:
         stop_ids = {self._im_end}
         if self._endoftext is not None:
             stop_ids.add(self._endoftext)

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -17,8 +17,78 @@ failure) — see ``ToolCallParseStatus`` docstring for the rationale.
 from __future__ import annotations
 
 import json
+from typing import Any
 
-from renderers.base import ParsedResponse, ParsedToolCall, ToolCallParseStatus
+from renderers.base import ParsedResponse, ParsedToolCall, ToolCallParseStatus, ToolSpec
+
+
+# ── Schema-aware argument coercion ──────────────────────────────────
+#
+# XML-style tool-call formats render argument values verbatim inside
+# ``<arg_value>`` tags with no quoting. ``true`` and the string
+# ``"true"`` produce identical wire bytes; without the tool schema, the
+# parser has no signal to distinguish them and defaults to
+# ``json.loads`` (the historical behavior). When the caller passes
+# ``tools=[...]``, parsers consult the per-parameter declared type to
+# keep string args verbatim, matching vLLM / SGLang reference parsers.
+
+
+def _build_param_type_index(
+    tools: list[ToolSpec] | None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Map tool name → param name → param JSON-schema fragment.
+
+    Accepts both flat ``ToolSpec`` (``{name, description, parameters}``)
+    and the OpenAI envelope (``{"type": "function", "function": {...}}``)
+    so callers can pass either shape.
+    """
+    if not tools:
+        return {}
+    index: dict[str, dict[str, dict[str, Any]]] = {}
+    for tool in tools:
+        spec = tool.get("function", tool) if isinstance(tool, dict) else None
+        if not isinstance(spec, dict):
+            continue
+        name = spec.get("name")
+        if not isinstance(name, str):
+            continue
+        params = spec.get("parameters") or {}
+        props = params.get("properties") if isinstance(params, dict) else None
+        if isinstance(props, dict):
+            index[name] = {k: v for k, v in props.items() if isinstance(v, dict)}
+    return index
+
+
+def _coerce_arg_value(
+    text: str, param_schema: dict[str, Any] | None
+) -> tuple[Any, bool]:
+    """Coerce a raw ``<arg_value>`` body to its declared type.
+
+    Returns ``(value, used_json_fallback)``. The boolean is ``True`` only
+    when ``json.loads`` was attempted and raised, so the caller knows
+    whether to flag ``INVALID_JSON``. Returning a string verbatim
+    because the schema declared ``type: "string"`` is NOT a fallback.
+
+    Rule (matches vLLM / SGLang reference parsers):
+
+    - If the param's declared ``type`` is ``"string"`` (or single-element
+      ``["string"]``), return ``text`` verbatim — never ``json.loads``.
+    - Anything else (no schema, non-string scalar, object, array, or
+      union types that include non-string): try ``json.loads`` and fall
+      back to raw ``text`` on parse failure.
+
+    Union types that include ``"string"`` alongside other types still
+    attempt ``json.loads`` first so an explicit integer / bool can
+    parse; the string branch only wins as the fallback.
+    """
+    if param_schema is not None:
+        declared = param_schema.get("type")
+        if declared == "string" or declared == ["string"]:
+            return text, False
+    try:
+        return json.loads(text), False
+    except (json.JSONDecodeError, ValueError):
+        return text, True
 
 
 def _find(ids: list[int], target: int, start: int = 0) -> int:
@@ -160,6 +230,7 @@ def parse_qwen35(
     think_end_id: int,
     tool_call_id: int,
     tool_call_end_id: int,
+    tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
     """Parse Qwen3.5 completion tokens. XML-style tool calls, token-level thinking."""
     ids = _strip_stop_tokens(token_ids, stop_ids)
@@ -192,6 +263,7 @@ def parse_qwen35(
             tool_call_id,
             tool_call_end_id,
             section_offset=parse_offset + tc_start,
+            param_index=_build_param_type_index(tools),
         )
     else:
         content_text = _decode(tokenizer, ids).strip()
@@ -210,6 +282,7 @@ def _parse_xml_tool_calls(
     tc_end_id: int,
     *,
     section_offset: int,
+    param_index: dict[str, dict[str, dict[str, Any]]],
 ) -> list[ParsedToolCall]:
     """Parse Qwen3.5-style XML tool calls from token IDs."""
     import re
@@ -244,6 +317,7 @@ def _parse_xml_tool_calls(
                 continue
 
             name = name_match.group(1)
+            params = param_index.get(name, {})
             arguments: dict = {}
             any_json_fallback = False
             for pm in re.finditer(
@@ -251,11 +325,11 @@ def _parse_xml_tool_calls(
             ):
                 arg_name = pm.group(1)
                 arg_value = pm.group(2).strip()
-                try:
-                    arguments[arg_name] = json.loads(arg_value)
-                except (json.JSONDecodeError, ValueError):
-                    arguments[arg_name] = arg_value
-                    any_json_fallback = True
+                value, used_fallback = _coerce_arg_value(
+                    arg_value, params.get(arg_name)
+                )
+                arguments[arg_name] = value
+                any_json_fallback = any_json_fallback or used_fallback
             tool_calls.append(
                 ParsedToolCall(
                     raw=block_text,
@@ -291,6 +365,7 @@ def parse_glm(
     arg_key_end_id: int,
     arg_value_id: int,
     arg_value_end_id: int,
+    tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
     """Parse GLM completion tokens. Token-level thinking + arg_key/arg_value tool calls."""
     ids = _strip_stop_tokens(token_ids, stop_ids)
@@ -325,6 +400,7 @@ def parse_glm(
             arg_value_id,
             arg_value_end_id,
             section_offset=parse_offset + tc_start,
+            param_index=_build_param_type_index(tools),
         )
     else:
         content_text = _decode(tokenizer, ids).strip()
@@ -347,6 +423,7 @@ def _parse_glm_tool_calls(
     ave_id,
     *,
     section_offset: int,
+    param_index: dict[str, dict[str, dict[str, Any]]],
 ) -> list[ParsedToolCall]:
     """Parse GLM-style tool calls: name + arg_key/arg_value pairs, all by token ID."""
     tool_calls: list[ParsedToolCall] = []
@@ -375,6 +452,7 @@ def _parse_glm_tool_calls(
                 arguments: dict = {}
             else:
                 name = _decode(tokenizer, block[:first_ak]).strip()
+                params = param_index.get(name, {})
                 arguments = {}
                 j = first_ak
                 while j < len(block):
@@ -393,11 +471,11 @@ def _parse_glm_tool_calls(
                             structure_broke = True
                             break
                         val_text = _decode(tokenizer, block[av + 1 : ave]).strip()
-                        try:
-                            arguments[key] = json.loads(val_text)
-                        except (json.JSONDecodeError, ValueError):
-                            arguments[key] = val_text
-                            any_json_fallback = True
+                        value, used_fallback = _coerce_arg_value(
+                            val_text, params.get(key)
+                        )
+                        arguments[key] = value
+                        any_json_fallback = any_json_fallback or used_fallback
                         j = ave + 1
                     else:
                         j += 1
@@ -439,6 +517,7 @@ def parse_laguna_xs2(
     think_end_id: int,
     tool_call_id: int,
     tool_call_end_id: int,
+    tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
     """Parse Laguna-XS.2 completion tokens.
 
@@ -479,6 +558,7 @@ def parse_laguna_xs2(
             tool_call_id,
             tool_call_end_id,
             section_offset=parse_offset + tc_start,
+            param_index=_build_param_type_index(tools),
         )
     else:
         content_text = _decode(tokenizer, ids).strip("\n")
@@ -497,6 +577,7 @@ def _parse_laguna_xs2_tool_calls(
     tc_end_id: int,
     *,
     section_offset: int,
+    param_index: dict[str, dict[str, dict[str, Any]]],
 ) -> list[ParsedToolCall]:
     """Parse Laguna-XS.2 tool calls.
 
@@ -538,6 +619,7 @@ def _parse_laguna_xs2_tool_calls(
                 name = block_text.strip()
                 args_section = ""
 
+            params = param_index.get(name, {})
             arguments: dict = {}
             any_json_fallback = False
             for m in re.finditer(
@@ -547,11 +629,9 @@ def _parse_laguna_xs2_tool_calls(
             ):
                 k = m.group(1).strip()
                 v = m.group(2).strip()
-                try:
-                    arguments[k] = json.loads(v)
-                except (json.JSONDecodeError, ValueError):
-                    arguments[k] = v
-                    any_json_fallback = True
+                value, used_fallback = _coerce_arg_value(v, params.get(k))
+                arguments[k] = value
+                any_json_fallback = any_json_fallback or used_fallback
 
             if not name:
                 status = ToolCallParseStatus.MISSING_NAME
@@ -753,11 +833,13 @@ def parse_minimax(
     think_end_id: int,
     tool_call_id: int,
     tool_call_end_id: int,
+    tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
     """Parse MiniMax M2 completion tokens."""
     import re
 
     ids = _strip_stop_tokens(token_ids, stop_ids)
+    param_index = _build_param_type_index(tools)
 
     reasoning = None
     parse_offset = 0
@@ -820,6 +902,7 @@ def parse_minimax(
                     for invoke_match in invokes:
                         name = invoke_match.group(1)
                         body = invoke_match.group(2)
+                        params = param_index.get(name, {})
                         arguments: dict = {}
                         any_json_fallback = False
                         for pm in re.finditer(
@@ -829,11 +912,11 @@ def parse_minimax(
                         ):
                             pname = pm.group(1)
                             pval = pm.group(2).strip()
-                            try:
-                                arguments[pname] = json.loads(pval)
-                            except (json.JSONDecodeError, ValueError):
-                                arguments[pname] = pval
-                                any_json_fallback = True
+                            value, used_fallback = _coerce_arg_value(
+                                pval, params.get(pname)
+                            )
+                            arguments[pname] = value
+                            any_json_fallback = any_json_fallback or used_fallback
                         tool_calls.append(
                             ParsedToolCall(
                                 raw=block_text,

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -209,7 +209,12 @@ class Qwen3Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — hermes wire format quotes strings, schema not needed
+    ) -> ParsedResponse:
         return parse_qwen3(
             self._tokenizer,
             token_ids,

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -487,7 +487,12 @@ class Qwen35Renderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,
+    ) -> ParsedResponse:
         return parse_qwen35(
             self._tokenizer,
             token_ids,
@@ -496,6 +501,7 @@ class Qwen35Renderer:
             think_end_id=self._think_end,
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -506,7 +506,12 @@ class Qwen3VLRenderer:
             add_generation_prompt=add_generation_prompt,
         ).token_ids
 
-    def parse_response(self, token_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self,
+        token_ids: list[int],
+        *,
+        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — hermes wire format quotes strings, schema not needed
+    ) -> ParsedResponse:
         return parse_qwen3(
             self._tokenizer,
             token_ids,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,8 +29,12 @@ class _FakeRenderer:
     def get_stop_token_ids(self):
         return [99]
 
-    def parse_response(self, completion_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self, completion_ids: list[int], *, tools=None
+    ) -> ParsedResponse:
         assert completion_ids == [7, 8]
+        # Stores tools so tests can assert the client plumbed them through.
+        self._last_parse_tools = tools
         return ParsedResponse(
             content="done",
             reasoning_content="think",
@@ -85,11 +89,12 @@ class _FakeClient:
 
 def test_generate_builds_request_body_and_parses_response():
     client = _FakeClient()
+    renderer = _FakeRenderer()
 
     result = asyncio.run(
         generate(
             client=client,
-            renderer=_FakeRenderer(),
+            renderer=renderer,
             messages=[{"role": "user", "content": "hi"}],
             model="test-model",
             tools=[{"type": "function", "function": {"name": "echo"}}],
@@ -97,6 +102,12 @@ def test_generate_builds_request_body_and_parses_response():
             cache_salt="ckpt-42",
         )
     )
+
+    # The client must plumb `tools` through to parse_response so XML-style
+    # parsers can preserve declared-string args verbatim.
+    assert renderer._last_parse_tools == [
+        {"type": "function", "function": {"name": "echo"}}
+    ]
 
     assert len(client.calls) == 1
     # /inference/v1/generate is mounted at the server root, so we post to
@@ -136,7 +147,9 @@ def test_generate_builds_request_body_and_parses_response():
 class _MalformedToolRenderer(_FakeRenderer):
     """Returns only a malformed tool-call attempt — finish_reason must stay "stop"."""
 
-    def parse_response(self, completion_ids: list[int]) -> ParsedResponse:
+    def parse_response(
+        self, completion_ids: list[int], *, tools=None
+    ) -> ParsedResponse:
         return ParsedResponse(
             content="",
             reasoning_content=None,

--- a/tests/test_tool_arg_type_preservation.py
+++ b/tests/test_tool_arg_type_preservation.py
@@ -1,0 +1,131 @@
+"""Regression: XML-style tool parsers lose string type for JSON-looking values.
+
+When the model emits a tool call whose argument is a string that happens
+to look like JSON (e.g. ``"true"``, ``"42"``, ``"[1,2,3]"``), every
+XML-style parser (Qwen3.5, GLM, MiniMax, Laguna) re-parses the value via
+``json.loads`` and returns a bool / int / list instead of the original
+string. The chat template's ``<arg_value>X</arg_value>`` form has no
+quoting to distinguish the two on the wire, so the tool schema is the
+only disambiguating signal — and the renderer parsers don't see it.
+
+vLLM / SGLang's reference parsers (e.g. ``vllm/glm45_tool_parser.py``)
+overlay the tool schema to apply ``json.loads`` ONLY to parameters whose
+declared type is not ``string``. The renderers library currently does
+not; the JSON-/section-style parsers (Qwen3 hermes, Kimi K2, DeepSeek)
+sidestep the bug because their wire format quotes strings.
+
+These tests fail loudly against current main — they're the
+specification for the fix, not documentation of accepted behavior. CI
+should be red until ``parse_response`` is schema-aware.
+
+Originally raised by Robin (Poolside) on PR #21:
+
+    > Tool call parsing for all XML-like parsers may corrupt string
+    > parameter values if they happen to be valid JSON strings, e.g.
+    > "true" -> True (str -> bool), same for lists, objs etc. vLLM
+    > parsers "solve" this by passing the tools definition into the
+    > parsers.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from typing import Any
+
+import pytest
+
+
+# (HuggingFace model name, renderer name). Two controls (JSON-shaped
+# parsers that already preserve string types) + three XML-style parsers
+# that currently corrupt them. Laguna-XS.2 (PR #21) has the same bug;
+# add it here when it merges.
+_MODELS = [
+    ("Qwen/Qwen3-8B", "auto"),  # hermes JSON  — control, expected to pass
+    ("moonshotai/Kimi-K2-Instruct", "auto"),  # section JSON — control, expected to pass
+    ("Qwen/Qwen3.5-9B", "auto"),  # XML — currently fails
+    ("zai-org/GLM-5", "auto"),  # XML — currently fails
+    ("MiniMaxAI/MiniMax-M2.5", "auto"),  # XML — currently fails
+]
+
+
+@lru_cache(maxsize=None)
+def _load(model: str, renderer_name: str):
+    from renderers import create_renderer
+    from renderers.base import load_tokenizer
+
+    tok = load_tokenizer(model)
+    return tok, create_renderer(tok, renderer=renderer_name)
+
+
+def pytest_generate_tests(metafunc):
+    if "model" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "model,renderer_name",
+            _MODELS,
+            ids=[m for m, _ in _MODELS],
+        )
+
+
+@pytest.fixture
+def renderer(model, renderer_name):
+    return _load(model, renderer_name)[1]
+
+
+PROMPT = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Call f."},
+]
+
+
+# Each entry: a single-key arguments dict whose value is a STRING that
+# happens to be valid JSON of another type. The bug surfaces when the
+# parser silently coerces the string into the encoded type.
+JSON_LOOKING_STRING_ARGS = [
+    pytest.param({"flag": "true"}, id="string-bool"),
+    pytest.param({"n": "42"}, id="string-int"),
+    pytest.param({"x": "null"}, id="string-null"),
+    pytest.param({"x": "[1,2,3]"}, id="string-array"),
+    pytest.param({"x": '{"k": 1}'}, id="string-object"),
+]
+
+
+def _normalize_args(args: Any) -> Any:
+    """Mirror ``test_roundtrip._normalize_args`` — some parsers return a
+    JSON string, others a dict; compare by value."""
+    if isinstance(args, str):
+        try:
+            return json.loads(args)
+        except json.JSONDecodeError:
+            return args
+    return args
+
+
+def _extract_assistant_tokens(renderer, prompt, assistant_msg):
+    prompt_ids = renderer.render_ids(prompt, add_generation_prompt=False)
+    full_ids = renderer.render_ids(prompt + [assistant_msg])
+    return full_ids[len(prompt_ids) :]
+
+
+@pytest.mark.parametrize("args", JSON_LOOKING_STRING_ARGS)
+def test_string_arg_preserves_type(model, renderer_name, renderer, args):
+    """Tool-call args of declared type ``str`` must round-trip as ``str``,
+    not get re-parsed as bool/int/null/list/dict by the parser."""
+    msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "functions.f:0",
+                "function": {"name": "f", "arguments": args},
+            }
+        ],
+    }
+    completion_ids = _extract_assistant_tokens(renderer, PROMPT, msg)
+    parsed = renderer.parse_response(completion_ids)
+
+    assert parsed.tool_calls, f"{model}: parser returned no tool_calls"
+    got = _normalize_args(parsed.tool_calls[0].arguments)
+    assert got == args, (
+        f"{model}: tool-arg type drift — sent {args!r}, parser returned {got!r}"
+    )

--- a/tests/test_tool_arg_type_preservation.py
+++ b/tests/test_tool_arg_type_preservation.py
@@ -37,15 +37,15 @@ import pytest
 
 
 # (HuggingFace model name, renderer name). Two controls (JSON-shaped
-# parsers that already preserve string types) + three XML-style parsers
-# that currently corrupt them. Laguna-XS.2 (PR #21) has the same bug;
-# add it here when it merges.
+# parsers that already preserve string types) + four XML-style parsers
+# that currently corrupt them.
 _MODELS = [
     ("Qwen/Qwen3-8B", "auto"),  # hermes JSON  — control, expected to pass
     ("moonshotai/Kimi-K2-Instruct", "auto"),  # section JSON — control, expected to pass
     ("Qwen/Qwen3.5-9B", "auto"),  # XML — currently fails
     ("zai-org/GLM-5", "auto"),  # XML — currently fails
     ("MiniMaxAI/MiniMax-M2.5", "auto"),  # XML — currently fails
+    ("poolside/Laguna-XS.2", "auto"),  # XML — currently fails
 ]
 
 

--- a/tests/test_tool_arg_type_preservation.py
+++ b/tests/test_tool_arg_type_preservation.py
@@ -1,30 +1,19 @@
-"""Regression: XML-style tool parsers lose string type for JSON-looking values.
+"""Tool-arg string-type preservation across renderers.
 
-When the model emits a tool call whose argument is a string that happens
-to look like JSON (e.g. ``"true"``, ``"42"``, ``"[1,2,3]"``), every
-XML-style parser (Qwen3.5, GLM, MiniMax, Laguna) re-parses the value via
-``json.loads`` and returns a bool / int / list instead of the original
-string. The chat template's ``<arg_value>X</arg_value>`` form has no
-quoting to distinguish the two on the wire, so the tool schema is the
-only disambiguating signal — and the renderer parsers don't see it.
+XML-style chat templates (Qwen3.5, GLM, MiniMax, Laguna) render tool-call
+argument values verbatim inside ``<arg_value>X</arg_value>`` tags with
+no quoting, so a value of ``true`` could be either a bool or the string
+``"true"``. Without the tool schema, the parser has no signal to choose
+between them and defaults to ``json.loads`` — which silently corrupts
+string args that look like JSON.
 
-vLLM / SGLang's reference parsers (e.g. ``vllm/glm45_tool_parser.py``)
-overlay the tool schema to apply ``json.loads`` ONLY to parameters whose
-declared type is not ``string``. The renderers library currently does
-not; the JSON-/section-style parsers (Qwen3 hermes, Kimi K2, DeepSeek)
-sidestep the bug because their wire format quotes strings.
+This test passes the tool schema to ``parse_response`` so the parser can
+preserve declared-string params verbatim, matching vLLM / SGLang's
+reference parsers (e.g. ``vllm/glm45_tool_parser.py``). The hermes-JSON
+(Qwen3) and section-JSON (Kimi K2) parsers sidestep the bug because
+their wire format quotes strings; both serve as controls.
 
-These tests fail loudly against current main — they're the
-specification for the fix, not documentation of accepted behavior. CI
-should be red until ``parse_response`` is schema-aware.
-
-Originally raised by Robin (Poolside) on PR #21:
-
-    > Tool call parsing for all XML-like parsers may corrupt string
-    > parameter values if they happen to be valid JSON strings, e.g.
-    > "true" -> True (str -> bool), same for lists, objs etc. vLLM
-    > parsers "solve" this by passing the tools definition into the
-    > parsers.
+Originally raised by Robin (Poolside) on PR #21.
 """
 
 from __future__ import annotations
@@ -36,16 +25,16 @@ from typing import Any
 import pytest
 
 
-# (HuggingFace model name, renderer name). Two controls (JSON-shaped
-# parsers that already preserve string types) + four XML-style parsers
-# that currently corrupt them.
+# (HuggingFace model name, renderer name). Two JSON-shaped controls
+# (string types already preserved by the wire format) + four XML-style
+# parsers that rely on the schema to preserve them.
 _MODELS = [
-    ("Qwen/Qwen3-8B", "auto"),  # hermes JSON  — control, expected to pass
-    ("moonshotai/Kimi-K2-Instruct", "auto"),  # section JSON — control, expected to pass
-    ("Qwen/Qwen3.5-9B", "auto"),  # XML — currently fails
-    ("zai-org/GLM-5", "auto"),  # XML — currently fails
-    ("MiniMaxAI/MiniMax-M2.5", "auto"),  # XML — currently fails
-    ("poolside/Laguna-XS.2", "auto"),  # XML — currently fails
+    ("Qwen/Qwen3-8B", "auto"),  # hermes JSON  — control
+    ("moonshotai/Kimi-K2-Instruct", "auto"),  # section JSON — control
+    ("Qwen/Qwen3.5-9B", "auto"),  # XML
+    ("zai-org/GLM-5", "auto"),  # XML
+    ("MiniMaxAI/MiniMax-M2.5", "auto"),  # XML
+    ("poolside/Laguna-XS.2", "auto"),  # XML
 ]
 
 
@@ -78,15 +67,34 @@ PROMPT = [
 ]
 
 
-# Each entry: a single-key arguments dict whose value is a STRING that
-# happens to be valid JSON of another type. The bug surfaces when the
-# parser silently coerces the string into the encoded type.
+# Each case: a single ``x`` argument whose value is a STRING that
+# happens to be valid JSON of another type. With a schema declaring
+# ``x: string``, the parser must return the string verbatim.
 JSON_LOOKING_STRING_ARGS = [
-    pytest.param({"flag": "true"}, id="string-bool"),
-    pytest.param({"n": "42"}, id="string-int"),
+    pytest.param({"x": "true"}, id="string-bool"),
+    pytest.param({"x": "42"}, id="string-int"),
     pytest.param({"x": "null"}, id="string-null"),
     pytest.param({"x": "[1,2,3]"}, id="string-array"),
     pytest.param({"x": '{"k": 1}'}, id="string-object"),
+]
+
+
+# Tool schema with the single string-typed parameter exercised by every
+# case above. Passed to both ``render`` (so the system prompt declares
+# the tool) and ``parse_response`` (so the parser preserves the type).
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "description": "Test tool with one string parameter.",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "string"}},
+                "required": ["x"],
+            },
+        },
+    }
 ]
 
 
@@ -101,9 +109,9 @@ def _normalize_args(args: Any) -> Any:
     return args
 
 
-def _extract_assistant_tokens(renderer, prompt, assistant_msg):
-    prompt_ids = renderer.render_ids(prompt, add_generation_prompt=False)
-    full_ids = renderer.render_ids(prompt + [assistant_msg])
+def _extract_assistant_tokens(renderer, prompt, assistant_msg, *, tools=None):
+    prompt_ids = renderer.render_ids(prompt, tools=tools, add_generation_prompt=False)
+    full_ids = renderer.render_ids(prompt + [assistant_msg], tools=tools)
     return full_ids[len(prompt_ids) :]
 
 
@@ -121,8 +129,8 @@ def test_string_arg_preserves_type(model, renderer_name, renderer, args):
             }
         ],
     }
-    completion_ids = _extract_assistant_tokens(renderer, PROMPT, msg)
-    parsed = renderer.parse_response(completion_ids)
+    completion_ids = _extract_assistant_tokens(renderer, PROMPT, msg, tools=TOOLS)
+    parsed = renderer.parse_response(completion_ids, tools=TOOLS)
 
     assert parsed.tool_calls, f"{model}: parser returned no tool_calls"
     got = _normalize_args(parsed.tool_calls[0].arguments)


### PR DESCRIPTION
## Summary

XML-style chat templates (Qwen3.5, GLM-5/4.5, MiniMax-M2, Laguna) render tool-call argument values verbatim inside `<arg_value>X</arg_value>` (or `<parameter>X</parameter>`) tags with **no quoting**. A value of `true` and the string `"true"` produce identical wire bytes — without the tool schema, the parser has no signal to choose between them and defaults to `json.loads`, silently corrupting string args that happen to look like JSON. This PR plumbs the schema in and preserves the type.

Raised by Robin (Poolside) on #21.

## Changes

**API change** — additive, backwards-compatible:

```python
class Renderer(Protocol):
    def parse_response(
        self,
        token_ids: list[int],
        *,
        tools: list[ToolSpec] | None = None,   # ← new
    ) -> ParsedResponse: ...
```

When `tools=None` (the historical default), behavior is unchanged. When `tools` is supplied, the four XML-style parsers consult each parameter's declared JSON-schema `type` and preserve declared-`string` params verbatim. Matches vLLM / SGLang reference parsers (`glm45_tool_parser.py`, `hermes_tool_parser.py`).

**Helpers** added to `renderers/parsing.py`:

- `_build_param_type_index(tools)` — accepts either flat `ToolSpec` or OpenAI envelope `{"type":"function","function":{…}}`, returns `{tool_name: {param_name: schema_fragment}}`.
- `_coerce_arg_value(text, schema) -> (value, used_json_fallback)` — declared-string → text verbatim; anything else → try `json.loads`, fall back to text. The bool lets callers flag `INVALID_JSON` only on genuine parse failures (not on schema-driven string preservation).

**Parsers updated** (with `tools` plumbing): `parse_qwen35`, `parse_glm`, `parse_minimax`, `parse_laguna_xs2`.

**Parsers that accept-but-ignore** `tools` (their wire formats quote strings, so schema isn't needed): Qwen3 hermes, Qwen3-VL, DeepSeek-V3, Kimi K2, Kimi K2.5, Nemotron3, gpt-oss harmony, Default.

**Client** (`renderers/client.py`): `generate()` already accepted `tools`; now forwards it through to `parse_response` so HTTP callers get schema-aware parsing automatically.

## Downstream callers

Anything outside this repo that calls `renderer.parse_response(token_ids)` needs a one-line update to opt into schema-aware parsing:

```python
parsed = renderer.parse_response(completion_ids, tools=tools)
```

Existing callers keep working unchanged (default `tools=None` preserves the historical behavior).

## Test outcome

| Model | Parser shape | Before | After |
|---|---|---|---|
| `Qwen/Qwen3-8B` | hermes JSON | ✅ 5/5 | ✅ 5/5 |
| `moonshotai/Kimi-K2-Instruct` | section JSON | ✅ 5/5 | ✅ 5/5 |
| `Qwen/Qwen3.5-9B` | XML | ❌ 0/5 | ✅ 5/5 |
| `zai-org/GLM-5` | XML | ❌ 0/5 | ✅ 5/5 |
| `MiniMaxAI/MiniMax-M2.5` | XML | ❌ 0/5 | ✅ 5/5 |
| `poolside/Laguna-XS.2` | XML | ❌ 0/5 | ✅ 5/5 |

## Test plan

- [x] `uv run pytest tests/test_tool_arg_type_preservation.py` → 30 passed
- [x] `uv run pytest tests/` (full suite) → 1067 passed, 49 skipped, 1 xfailed, 0 failed
- [x] `uv run ruff check renderers/ tests/` clean
- [x] `uv run ruff format --check renderers/ tests/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
