### PR TITLE
fix(kimi-k25): emit images inline in tool-response content

### DIFF
--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -795,6 +795,7 @@ class KimiK25Renderer:
                     emit_special=emit_special,
                     emit_text=emit_text,
                     emit_ids=emit_ids,
+                    emit_image=emit_image,
                 )
             elif msg.get("content") is not None:
                 # User / other content branches — images allowed.
@@ -956,6 +957,7 @@ class KimiK25Renderer:
                     emit_special=emit_special,
                     emit_text=emit_text,
                     emit_ids=emit_ids,
+                    emit_image=emit_image,
                 )
             elif msg.get("content") is not None:
                 self._emit_content(
@@ -1168,6 +1170,7 @@ class KimiK25Renderer:
         emit_special,
         emit_text,
         emit_ids,
+        emit_image=None,
     ) -> None:
         """Emit tool-result body (after the role tag): ``## Return of {id}\\n``
         + content. No ``<|im_end|>``; caller emits that.
@@ -1175,12 +1178,24 @@ class KimiK25Renderer:
         The K2.5 template emits the ``## Return of …`` header unconditionally
         — when ``tool_call_id`` is missing the interpolation yields empty
         string and you get ``## Return of \\n``. We mirror that.
+
+        ``emit_image`` is threaded through to ``_emit_content`` so image parts
+        inside ``content`` lists (browser-agent screenshots, etc.) render as
+        ``<|media_begin|>image<|media_content|><|media_pad|><|media_end|>``
+        inline. Without it those parts are silently dropped.
         """
         tool_call_id = msg.get("tool_call_id") or ""
         emit_text(f"## Return of {tool_call_id}\n", msg_idx)
         content = msg.get("content")
         if content is not None:
-            self._emit_content(content, msg_idx, emit_special, emit_text, emit_ids)
+            self._emit_content(
+                content,
+                msg_idx,
+                emit_special,
+                emit_text,
+                emit_ids,
+                emit_image=emit_image,
+            )
 
     def _normalize_response_tokens(self, response: list[int]) -> list[int]:
         """Restore the synthetic ``<think>`` prefill if the sampler stripped it.

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -425,14 +425,14 @@ def _build_tool_image_cases(make_part, image):
 
 
 def _supports_tool_message_images(renderer) -> bool:
-    """True iff this renderer emits image placeholders inside ``<tool_response>``
-    blocks. As of writing, only ``Qwen35Renderer`` (and its subclasses, e.g.
-    ``Qwen36Renderer``) has that path wired up; other VLM renderers (Qwen3-VL,
-    Kimi K2.5, …) silently drop image parts in tool content. As they grow the
-    feature, this predicate becomes their inclusion gate."""
+    """True iff this renderer emits image placeholders inside tool-response
+    content. Renderers without the feature silently drop image parts in tool
+    content; as they grow the feature they get added here and the test starts
+    asserting against them."""
+    from renderers.kimi_k25 import KimiK25Renderer
     from renderers.qwen35 import Qwen35Renderer
 
-    return isinstance(renderer, Qwen35Renderer)
+    return isinstance(renderer, (Qwen35Renderer, KimiK25Renderer))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Extends the Qwen3.5 fix from #25 to ``KimiK25Renderer`` (which serves both Kimi K2.5 and K2.6).
- Threads ``emit_image`` from ``render()`` and ``bridge_to_next_turn()`` through ``_render_tool_body`` into ``_emit_content``, so images inside ``tool`` message content render inline instead of being silently dropped.
- Extends ``_supports_tool_message_images`` so ``test_tool_response_image_byte_parity`` exercises Kimi K2.5/K2.6.

## Why the existing tests didn't catch this
Two compounding gaps. First, ``_emit_content`` silently drops image parts when ``emit_image`` is ``None`` — that fallback was meant for assistant-body text rewriting but doubled as a backdoor for callers that simply forgot to plumb it (i.e. ``_render_tool_body``). Second, every existing multimodal test put images on ``user`` messages; nothing exercised the ``tool`` path. #25 is the first test that does — this PR extends its gate to flag (and now cover) Kimi.

## Stacking
Based on #25 (whose tests this PR uses to assert byte-parity). GitHub will auto-retarget the base to ``main`` once #25 merges.

## Test plan
- [x] ``pytest tests/test_multimodal.py::test_tool_response_image_byte_parity`` — both ``moonshotai/Kimi-K2.5`` and ``moonshotai/Kimi-K2.6`` PASS against the HF processor across all three cases (single tool image, multi-turn tool images, consecutive tools with mixed media + text-only).
- [x] Regression sweep: ``pytest tests/test_multimodal.py -k Kimi`` → 8/8 pass (3 pre-existing byte-parity / placeholders / bridge tests × 2 Kimi variants + 2 new tool-response tests).
- [x] Ruff lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)