### PR TITLE
fix(client): add Qwen35Renderer to _build_mm_features dispatch

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -224,6 +224,7 @@ def _build_mm_features(
     (``MultiModalData``) is already framework-agnostic and does not need
     to change. Don't pre-build the abstraction with one engine in tree.
     """
+    from renderers.qwen35 import Qwen35Renderer
     from renderers.qwen3_vl import Qwen3VLRenderer
 
     # Type dispatch only needs the renderer class. Pools expose
@@ -233,7 +234,10 @@ def _build_mm_features(
         renderer.renderer_cls if isinstance(renderer, RendererPool) else type(renderer)
     )
 
-    if issubclass(renderer_cls, Qwen3VLRenderer):
+    # Qwen3-VL and Qwen3.5 both ship ``pixel_values`` + ``image_grid_thw``
+    # via the shared Qwen2-VL field factory. ``spatial_merge_size=2`` is
+    # the family default and matches every Qwen-VL processor in tree.
+    if issubclass(renderer_cls, (Qwen3VLRenderer, Qwen35Renderer)):
         return _build_qwen_vl_features(mm_data, spatial_merge_size=2)
 
     raise NotImplementedError(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 
 import numpy as np
+import pytest
 
 from renderers.base import (
     ParsedResponse,
@@ -214,14 +215,25 @@ def test_generate_uses_prebuilt_prompt_ids_without_rendering():
 # ---------------------------------------------------------------------------
 
 
-def test_generate_serializes_multimodal_features_for_qwen3_vl():
+@pytest.mark.parametrize(
+    "model_id,renderer_class_path",
+    [
+        ("Qwen/Qwen3-VL-4B-Instruct", "renderers.qwen3_vl:Qwen3VLRenderer"),
+        ("Qwen/Qwen3.5-2B", "renderers.qwen35:Qwen35Renderer"),
+    ],
+    ids=["qwen3_vl", "qwen35"],
+)
+def test_generate_serializes_multimodal_features_for_qwen_vl_family(
+    model_id, renderer_class_path
+):
     """When the renderer emits ``MultiModalData``, ``generate`` translates
     it into vLLM's ``features`` payload (mm_hashes + mm_placeholders +
-    base64-encoded kwargs_data) and sticks it in the request body."""
-    import pytest as _pytest
+    base64-encoded kwargs_data) and sticks it in the request body. Covers
+    every renderer routed through ``_build_qwen_vl_features``."""
+    import importlib
 
-    _pytest.importorskip("torch")
-    _pytest.importorskip("vllm", reason="vllm needed for features serialization")
+    pytest.importorskip("torch")
+    pytest.importorskip("vllm", reason="vllm needed for features serialization")
 
     import torch as _torch
 
@@ -230,14 +242,16 @@ def test_generate_serializes_multimodal_features_for_qwen3_vl():
         PlaceholderRange,
         load_tokenizer,
     )
-    from renderers.qwen3_vl import Qwen3VLRenderer
 
-    # Build a minimal real Qwen3VLRenderer so type dispatch in
+    mod_name, cls_name = renderer_class_path.split(":")
+    renderer_cls = getattr(importlib.import_module(mod_name), cls_name)
+
+    # Build a minimal real renderer so type dispatch in
     # _build_mm_features hits the qwen branch. The tokenizer is only
     # touched in __init__ to grab special-token ids; render() / etc.
     # aren't called here because we pre-supply prompt_ids + mm_data.
-    tokenizer = load_tokenizer("Qwen/Qwen3-VL-4B-Instruct")
-    renderer = Qwen3VLRenderer(tokenizer)
+    tokenizer = load_tokenizer(model_id)
+    renderer = renderer_cls(tokenizer)
 
     # Two synthetic 1×2×2 images. Field factory expects pixel_values
     # shape ``(sum_HW, embed_dim)`` and grid_thw shape ``(N, 3)``; the


### PR DESCRIPTION
## Summary

`renderers.client._build_mm_features` dispatches by renderer class to
serialize a renderer-emitted `MultiModalData` into vLLM's
`/inference/v1/generate` features payload. Only `Qwen3VLRenderer` was
registered; `Qwen35Renderer` — which is also a `MultimodalRenderer` and
ships the same `pixel_values + image_grid_thw` payload — fell through
to `raise NotImplementedError(...)`. Every multimodal call routed
through a Qwen3.5 / Qwen3.6 model failed before reaching the engine.

## Fix

Add `Qwen35Renderer` to the existing `issubclass` check, reusing
`_build_qwen_vl_features` with the same `spatial_merge_size=2` default.
This matches the Qwen-VL family convention — every Qwen-VL image
processor in tree (Qwen2-VL, Qwen3-VL, Qwen3.5, Qwen3.6) ships with
`merge_size=2`, which is a vision-tower architectural parameter (set
at training time, not a runtime config).

## Test plan

- Parametrized the existing `test_generate_serializes_multimodal_features_for_qwen3_vl`
  to also cover `Qwen35Renderer`, mirroring the parametrize-over-models
  pattern in `test_bridge.py` and `test_roundtrip.py`. Both cases pass.
- Verified end-to-end against `Qwen/Qwen3.5-2B`: rendered a real
  multimodal prompt (`{user: [text, image_url]}`), confirmed the
  previously-failing `_build_mm_features(renderer, rendered.multi_modal_data)`
  now returns a valid features payload (`mm_hashes`, `mm_placeholders`,
  `kwargs_data` all populated as expected).

Fixes #39.