### PR TITLE
fix(qwen3_vl): require truthy value in untyped image_part fallback

### DIFF
--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -70,9 +70,14 @@ def _is_image_part(item: Any) -> bool:
     t = item.get("type")
     if t in ("image", "image_url"):
         return True
-    # Permissive fallback: chat templates check ``'image' in content`` to
-    # accept loosely-shaped image parts, so mirror that.
-    return "image" in item or "image_url" in item
+    if t is not None:
+        return False
+    # Untyped fallback for loosely-shaped image parts. Require a truthy
+    # value: HF Arrow schema unification (Dataset.from_list over a list of
+    # heterogeneous content dicts) fills missing keys with None, so any
+    # text part round-tripped through a Dataset will have ``image_url: None``
+    # as a key. Mere key presence isn't enough.
+    return bool(item.get("image")) or bool(item.get("image_url"))
 
 
 def _is_video_part(item: Any) -> bool:
@@ -81,7 +86,9 @@ def _is_video_part(item: Any) -> bool:
     t = item.get("type")
     if t in ("video", "video_url"):
         return True
-    return "video" in item or "video_url" in item
+    if t is not None:
+        return False
+    return bool(item.get("video")) or bool(item.get("video_url"))
 
 
 def _load_pil_image(item: dict[str, Any]):

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -695,3 +695,40 @@ def test_qwen3_vl_renderer_exposes_image_modality():
     renderer = create_renderer(tokenizer, renderer="auto")
     assert isinstance(renderer, Qwen3VLRenderer)
     assert "image" in MULTIMODAL_MODELS[model]
+
+
+def test_is_image_part_treats_type_field_as_authoritative():
+    """``Dataset.from_list`` unifies the Arrow schema across the elements
+    of a list-typed column. A content list mixing text and image parts
+    round-trips with ``image_url: None`` added to every text part (and
+    ``text: None`` added to every image part). The classifier must treat
+    the ``type`` field as authoritative when present — falling back to
+    a key-presence check on ``image_url`` would misclassify the text
+    part and the renderer would later raise on ``_load_pil_image(None)``.
+    """
+    from renderers.qwen3_vl import _is_image_part, _is_video_part
+
+    # Typed parts classify by their ``type``.
+    assert _is_image_part(
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,XXX"}}
+    )
+    assert _is_image_part({"type": "image", "image": object()})
+    assert _is_video_part(
+        {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,XXX"}}
+    )
+
+    # Schema-unified text parts — typed as text, with a None zombie key
+    # for the sibling modality — must NOT classify as image / video.
+    schema_unified_text = {"type": "text", "text": "hello", "image_url": None}
+    assert not _is_image_part(schema_unified_text)
+    assert not _is_video_part(schema_unified_text)
+    schema_unified_text_with_video = {"type": "text", "text": "hi", "video_url": None}
+    assert not _is_video_part(schema_unified_text_with_video)
+
+    # Untyped fallback only fires when ``type`` is absent, and requires
+    # a truthy value (mere key presence isn't enough).
+    assert _is_image_part({"image_url": {"url": "data:..."}})
+    assert _is_image_part({"image": object()})
+    assert not _is_image_part({"image_url": None})
+    assert not _is_image_part({"image": None})
+    assert not _is_video_part({"video_url": None})


### PR DESCRIPTION
## Summary

`_is_image_part` / `_is_video_part` in `renderers/qwen3_vl.py` use a
permissive fallback (`return "image_url" in item`) that misfires after
a `Dataset.from_list` round-trip. Arrow schema unification adds an
`image_url: None` zombie key to every text part when the same content
list mixes text and image parts, so the fallback returns True for the
text part, the caller dispatches `emit_image`, and `_load_pil_image`
raises `TypeError: Unsupported image source 'NoneType'`.

Every rollout in an env that embeds a multimodal user prompt directly
in its dataset column (e.g. `tic-tac-toe`, where `visual_prompt = [
{"role": "user", "content": [text, image_url]}]` is part of every
dataset row) fails before reaching the model.

## Repro (no renderers state needed)

```python
from datasets import Dataset
row = {"prompt": [{"role": "user", "content": [
    {"type": "text", "text": "hi"},
    {"type": "image_url", "image_url": {"url": "data:image/png;base64,XXX"}},
]}]}
print(Dataset.from_list([row])[0]["prompt"][0]["content"][0])
# => {'image_url': None, 'text': 'hi', 'type': 'text'}
#               ^^^^^^^^^^^^^ Arrow unified the schema across the list

from renderers.qwen3_vl import _is_image_part
_is_image_part({"type": "text", "text": "hi", "image_url": None})
# => True   (misclassified — should be False)
```

## Fix

Make the `type` field authoritative when present:

```python
def _is_image_part(item):
    if not isinstance(item, dict): return False
    t = item.get("type")
    if t in ("image", "image_url"): return True
    if t is not None: return False                                    # ← new
    return bool(item.get("image")) or bool(item.get("image_url"))     # ← truthy, not key-presence
```

Same fix applied to `_is_video_part` symmetrically.

These helpers live in `renderers/qwen3_vl.py` but are imported by every
multimodal renderer in the package — `renderers/qwen35.py` (the
Qwen3.5 / Qwen3.6 family) and `renderers/kimi_k25.py` (Kimi K2.5) both
`from renderers.qwen3_vl import _is_image_part, _is_video_part`. So the
fix covers all three renderer families without touching their files.

## Test plan

- Adds `test_is_image_part_treats_type_field_as_authoritative` in
  `tests/test_multimodal.py`. Exercises both the schema-unified text
  case (the actual regression) and the untyped fallback's truthy-value
  requirement. Synthesizes the schema-unified content shape directly so
  the test doesn't depend on `datasets` as a test dep.
- Test passes locally.
- Verified end-to-end on `Qwen/Qwen3.5-2B` + the `tic-tac-toe` env via
  prime-rl: with the fix, the renderer correctly classifies tic-tac-toe's
  text+image initial prompt and the trainer runs through 8 RL steps with
  `mismatch_kl/max=0.00165`.

Fixes #40.