### PR TITLE
feat(client): pre-flight overflow check with auto-discovery

### DIFF
--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -36,6 +36,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     trim_to_turn_close,
 )
+from renderers.client import OverlongPromptError
 from renderers.deepseek_v3 import DeepSeekV3Renderer
 from renderers.default import DefaultRenderer
 from renderers.glm5 import GLM5Renderer
@@ -69,6 +70,7 @@ __all__ = [
     "MultiModalData",
     "MultimodalRenderer",
     "Nemotron3Renderer",
+    "OverlongPromptError",
     "ParsedResponse",
     "ParsedToolCall",
     "PlaceholderRange",

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -14,10 +14,11 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+from collections.abc import Mapping
 from typing import Any, cast
 
 import numpy as np
-from openai import AsyncOpenAI, BadRequestError
+from openai import AsyncOpenAI
 
 from renderers.base import (
     Message,
@@ -29,6 +30,79 @@ from renderers.base import (
 )
 
 _request_logger = logging.getLogger("renderers.client")
+
+
+class OverlongPromptError(Exception):
+    """The rendered prompt exceeds the engine's context window.
+
+    Raised by :func:`generate` when the rendered token sequence is strictly
+    longer than the resolved cap — either an explicit ``max_prompt_len`` the
+    caller passed in, or the engine's ``max_model_len`` discovered via
+    ``GET /v1/models``. Caught client-side before the engine ever sees the
+    request, so callers route the failure to a deterministic policy (skip /
+    truncate / count) instead of round-tripping through an engine 4xx.
+
+    Named after the corresponding ``verifiers.errors.OverlongPromptError``;
+    the two are distinct classes (different package hierarchies) but the
+    concept is the same and downstream clients translate one to the other.
+    """
+
+    def __init__(self, *, prompt_len: int, max_prompt_len: int) -> None:
+        self.prompt_len = prompt_len
+        self.max_prompt_len = max_prompt_len
+        super().__init__(
+            f"Prompt length ({prompt_len}) exceeds maximum "
+            f"context length ({max_prompt_len})."
+        )
+
+
+# Per-process cache of resolved engine context-length caps, keyed by
+# ``(base_url, model)``. ``None`` is the "we asked the engine and it didn't
+# tell us" sentinel — distinct from "key missing" (haven't asked yet). The
+# lock serializes the first lookup per key; cache hits avoid the lock.
+_max_prompt_len_cache: dict[tuple[str, str], int | None] = {}
+_max_prompt_len_lock = asyncio.Lock()
+
+
+async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None:
+    """Discover ``max_model_len`` from the engine via ``GET /v1/models``.
+
+    OpenAI-API-compatible engines expose model metadata at this endpoint;
+    vLLM extends its ``ModelCard`` with a ``max_model_len`` field. Engines
+    that don't (SGLang as of this writing, third-party gateways, etc.) get
+    a cached ``None`` and the pre-flight overflow check silently disables —
+    callers fall back to whatever reactive handling they have for engine
+    4xx, which the verifiers ``@handle_openai_overlong_prompt`` decorator
+    already supplies for the prime-rl path.
+
+    Any exception during lookup (network error, non-JSON body, attribute
+    miss on a mock client in tests) is treated as "unknown cap": cached
+    ``None`` so we don't retry on every call.
+    """
+    key = (str(getattr(client, "base_url", "")), model)
+    if key in _max_prompt_len_cache:
+        return _max_prompt_len_cache[key]
+    async with _max_prompt_len_lock:
+        if key in _max_prompt_len_cache:
+            return _max_prompt_len_cache[key]
+        try:
+            payload = await client.get("/models", cast_to=cast(Any, dict[str, Any]))
+        except Exception as exc:
+            _request_logger.debug("max_prompt_len lookup failed: %s", exc)
+            _max_prompt_len_cache[key] = None
+            return None
+        value: int | None = None
+        for card in payload.get("data") or []:
+            if not isinstance(card, Mapping):
+                continue
+            if card.get("id") != model:
+                continue
+            raw = card.get("max_model_len")
+            if isinstance(raw, int) and raw > 0:
+                value = raw
+            break
+        _max_prompt_len_cache[key] = value
+        return value
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):
@@ -58,6 +132,7 @@ async def generate(
     cache_salt: str | None = None,
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
+    max_prompt_len: int | None = None,
 ) -> dict[str, Any]:
     """Tokenize messages, call vLLM /inference/v1/generate, parse the response.
 
@@ -73,6 +148,16 @@ async def generate(
     sidecar, then serializes it to vLLM's ``features`` schema (mm_hashes,
     mm_placeholders, kwargs_data) before POSTing. The serializer imports
     ``vllm.*`` lazily so text-only consumers never pay for the import.
+
+    ``max_prompt_len`` controls the pre-flight overflow check. When the
+    rendered prompt is strictly longer than the cap, the request is never
+    sent and ``OverlongPromptError`` is raised. If ``max_prompt_len`` is
+    ``None`` (the default), the cap is auto-discovered once per
+    ``(base_url, model)`` via ``GET /v1/models`` (vLLM's
+    ``ModelCard.max_model_len`` extension); engines that don't expose it
+    cache a ``None`` cap and the pre-flight silently disables. Engine 4xx
+    that still slip through propagate raw — converting them into a domain
+    error is the calling client's job (its error shape is engine-specific).
 
     Returns a dict with: request_id, prompt_ids, completion_ids,
     completion_logprobs, content, reasoning_content, tool_calls,
@@ -95,6 +180,13 @@ async def generate(
         )
 
     prompt_ids, stop_token_ids, mm_data = await _maybe_offload(renderer, _prepare)
+
+    if max_prompt_len is None:
+        max_prompt_len = await _resolve_max_prompt_len(client, model)
+    if max_prompt_len is not None and len(prompt_ids) > max_prompt_len:
+        raise OverlongPromptError(
+            prompt_len=len(prompt_ids), max_prompt_len=max_prompt_len
+        )
 
     sp: dict[str, Any] = dict(sampling_params or {})
     sp["stop_token_ids"] = stop_token_ids
@@ -135,16 +227,7 @@ async def generate(
     }
     if extra_headers:
         post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-    try:
-        data = await client.post(endpoint, **post_kwargs)
-    except BadRequestError as exc:
-        _log_overlong_prompt_diagnostic(
-            prompt_ids=prompt_ids,
-            messages=messages,
-            max_tokens=sp.get("max_tokens"),
-            exc=exc,
-        )
-        raise
+    data = await client.post(endpoint, **post_kwargs)
 
     choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
@@ -224,8 +307,8 @@ def _build_mm_features(
     (``MultiModalData``) is already framework-agnostic and does not need
     to change. Don't pre-build the abstraction with one engine in tree.
     """
-    from renderers.qwen35 import Qwen35Renderer
     from renderers.qwen3_vl import Qwen3VLRenderer
+    from renderers.qwen35 import Qwen35Renderer
 
     # Type dispatch only needs the renderer class. Pools expose
     # ``renderer_cls`` as a snapshot attribute, so we don't have to check
@@ -309,44 +392,3 @@ def _build_qwen_vl_features(
         out["kwargs_data"] = None
 
     return out
-
-
-def _log_overlong_prompt_diagnostic(
-    *,
-    prompt_ids: list[int],
-    messages: list[Message],
-    max_tokens: int | None,
-    exc: BadRequestError,
-) -> None:
-    """Log a structured snapshot when vLLM rejects with 4xx — usually overlong.
-
-    Captures total prompt length, per-message role + character count, and
-    the first chunk of the response body.
-    """
-    body_text = ""
-    response = getattr(exc, "response", None)
-    if response is not None:
-        body_text = (response.text or "")[:500].replace("\n", " ")
-    msg_summary = []
-    for i, m in enumerate(messages):
-        role = m.get("role", "?")
-        content = m.get("content")
-        if isinstance(content, str):
-            content_len = len(content)
-        elif isinstance(content, list):
-            content_len = sum(
-                len(p.get("text", "")) if isinstance(p, dict) else 0 for p in content
-            )
-        else:
-            content_len = 0
-        tool_calls = m.get("tool_calls")
-        tc_count = len(tool_calls) if tool_calls else 0
-        msg_summary.append(f"[{i}]{role}(c={content_len},tc={tc_count})")
-    _request_logger.warning(
-        "vllm 4xx prompt_len=%d messages=%d max_tokens=%s per_msg=%s response_body=%s",
-        len(prompt_ids),
-        len(messages),
-        max_tokens,
-        " ".join(msg_summary),
-        body_text,
-    )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,6 @@ import base64
 
 import numpy as np
 import pytest
-
 from renderers.base import (
     ParsedResponse,
     ParsedToolCall,
@@ -236,7 +235,6 @@ def test_generate_serializes_multimodal_features_for_qwen_vl_family(
     pytest.importorskip("vllm", reason="vllm needed for features serialization")
 
     import torch as _torch
-
     from renderers.base import (
         MultiModalData,
         PlaceholderRange,
@@ -305,3 +303,136 @@ def test_generate_serializes_multimodal_features_for_qwen_vl_family(
     # Items are base64 strings (encode_mm_kwargs_item output).
     for item in features["kwargs_data"]["image"]:
         assert isinstance(item, str) and len(item) > 0
+
+
+# ---------------------------------------------------------------------------
+# Prompt overflow handling.
+# ---------------------------------------------------------------------------
+
+
+class _LongRenderer(_FakeRenderer):
+    """Renders a 10-token prompt regardless of input — enough to overflow a
+    small ``max_prompt_len``."""
+
+    def render(self, messages, *, tools=None, add_generation_prompt=False):
+        from renderers.base import RenderedTokens
+
+        return RenderedTokens(token_ids=list(range(10)))
+
+
+def test_generate_raises_overlong_prompt_when_explicit_cap_exceeded():
+    """Pre-flight overflow check: when an explicit ``max_prompt_len`` is set
+    and the rendered prompt is longer, ``generate`` raises
+    ``OverlongPromptError`` without dispatching the request to the engine."""
+    from renderers.client import OverlongPromptError
+
+    client = _FakeClient()
+    renderer = _LongRenderer()
+
+    with pytest.raises(OverlongPromptError) as excinfo:
+        asyncio.run(
+            generate(
+                client=client,
+                renderer=renderer,
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+                max_prompt_len=4,
+            )
+        )
+
+    assert excinfo.value.prompt_len == 10
+    assert excinfo.value.max_prompt_len == 4
+    assert client.calls == [], "request must not be dispatched on pre-flight fail"
+
+
+def test_generate_allows_prompt_at_max_prompt_len():
+    """A prompt exactly equal to ``max_prompt_len`` is allowed (the check is
+    strict ``>``); only longer prompts trip the pre-flight."""
+    client = _FakeClient()
+    renderer = _LongRenderer()
+
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=renderer,
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            max_prompt_len=10,
+        )
+    )
+
+    assert len(client.calls) == 1
+    assert result["prompt_ids"] == list(range(10))
+
+
+def test_generate_auto_discovers_max_prompt_len_from_models_endpoint():
+    """When ``max_prompt_len`` is ``None`` (default), ``generate`` discovers
+    the cap via ``GET /v1/models`` and reads ``ModelCard.max_model_len``.
+    The result is cached per ``(base_url, model)`` so subsequent calls
+    don't re-query."""
+    from renderers.client import OverlongPromptError, _max_prompt_len_cache
+
+    class _ClientWithModels(_FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.base_url = "http://disco-host:8000/v1"
+            self.models_calls = 0
+
+        async def get(self, path, *, cast_to):
+            self.models_calls += 1
+            assert path == "/models"
+            return {
+                "object": "list",
+                "data": [
+                    {"id": "test-model", "max_model_len": 4},
+                    {"id": "other", "max_model_len": 999},
+                ],
+            }
+
+    # Clear cache so this test isn't affected by earlier ones.
+    _max_prompt_len_cache.clear()
+
+    client = _ClientWithModels()
+    renderer = _LongRenderer()
+
+    with pytest.raises(OverlongPromptError) as excinfo:
+        asyncio.run(
+            generate(
+                client=client,
+                renderer=renderer,
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+            )
+        )
+
+    assert excinfo.value.max_prompt_len == 4
+    assert excinfo.value.prompt_len == 10
+    assert client.models_calls == 1, "lookup must hit /models once"
+    assert client.calls == [], "pre-flight must short-circuit the request"
+
+
+def test_generate_caches_max_prompt_len_lookup_failure():
+    """When ``GET /v1/models`` fails (e.g. mock client without ``.get``),
+    the lookup result is cached as ``None`` and the pre-flight quietly
+    disables — the request still goes through, callers fall back to
+    whatever reactive overflow handling they have."""
+    from renderers.client import _max_prompt_len_cache
+
+    # _FakeClient has no .get method → AttributeError → cached None.
+    _max_prompt_len_cache.clear()
+    client = _FakeClient()
+    client.base_url = "http://no-models:8000/v1"
+
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=_LongRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+        )
+    )
+
+    # Request was dispatched (no pre-flight rejection) and round-tripped.
+    assert len(client.calls) == 1
+    assert result["prompt_ids"] == list(range(10))
+    assert _max_prompt_len_cache[("http://no-models:8000/v1", "test-model")] is None


### PR DESCRIPTION
## Summary

Adds a typed `OverlongPromptError` plus engine context-length discovery to `renderers.client.generate(...)`. Callers get pre-flight overflow rejection without threading anything through: pass nothing, and `generate()` looks up the cap once per `(base_url, model)` via `GET /v1/models` (vLLM's `ModelCard.max_model_len` extension), caches it, and raises a structured exception before dispatching an oversized prompt to the engine.

Driven by [prime-rl#2535](https://github.com/PrimeIntellect-ai/prime-rl/issues/2535): in a multi-turn rollout, a 70k-token tool message overflowed the model context window. The orchestrator saw a noisy `vllm 4xx prompt_len=...` WARNING from this module and a raw `BadRequestError` propagating through. This PR eliminates both — the renderer short-circuits client-side, and there's no log noise.

## Why `OverlongPromptError` and not `PromptTooLongError`?

Earlier revisions called it `PromptTooLongError`. The downstream verifiers client has `verifiers.errors.OverlongPromptError` (a `vf.Error` subclass) — different package hierarchy, same concept. Matching the name keeps the verifier-side translation a one-line rebadge:

```python
except RendererOverlongPromptError as exc:
    raise OverlongPromptError(str(exc)) from exc
```

## Why auto-discovery in renderers and not just an explicit kwarg?

Callers don't have to know about discovery to get pre-flight. `RendererClient` in [verifiers#1408](https://github.com/PrimeIntellect-ai/verifiers/pull/1408) no longer carries any cap-resolution code — its only job is the name rebadge above.

Engines whose `/v1/models` doesn't expose `max_model_len` (SGLang as of this writing, third-party gateways) cache `None` and the pre-flight quietly disables. Callers fall back to whatever reactive overflow handling they have for engine 4xx (in the prime-rl path, verifiers' `@handle_openai_overlong_prompt` decorator). Discovery is mildly vLLM-coupled (`max_model_len` is a vLLM extension); after the `RendererBackend` split tracked in [#49](https://github.com/PrimeIntellect-ai/renderers/issues/49), `_resolve_max_prompt_len` will move to the vLLM backend.

## Test plan

- Four unit tests in `tests/test_client.py`:
  - explicit `max_prompt_len` set → `OverlongPromptError`, no engine call
  - boundary: `len(prompt_ids) == max_prompt_len` is allowed (strict `>`)
  - auto-discovery: `generate()` with no kwarg hits `/v1/models`, parses `max_model_len`, raises `OverlongPromptError`, doesn't dispatch
  - lookup failure caches `None`, pre-flight quietly disables, the request goes through
- Live integration against `Qwen/Qwen3-0.6B` with `--max-model-len 2048`:
  - explicit cap ✓
  - auto-discovery from `/v1/models` ✓
  - `RendererClient` rebadges to `vf.OverlongPromptError` ✓
  - `cap=None` fallback path (decorator catches engine 4xx) ✓
  - happy path with short prompt ✓