### PR TITLE
feat(map): add Qwen3-30B-A3B-{Instruct,Thinking}-2507, GLM-5-FP8

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -766,6 +766,8 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     "Qwen/Qwen3-14B": "qwen3",
     "Qwen/Qwen3-32B": "qwen3",
     "Qwen/Qwen3-30B-A3B": "qwen3",
+    "Qwen/Qwen3-30B-A3B-Instruct-2507": "qwen3",
+    "Qwen/Qwen3-30B-A3B-Thinking-2507": "qwen3",
     "Qwen/Qwen3-235B-A22B": "qwen3",
     # Qwen3.5. All seven sizes share the same renderer. The 4B / 9B /
     # 35B-A3B / 122B-A10B / 397B-A17B chat template defaults
@@ -792,6 +794,7 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     "Qwen/Qwen3-VL-30B-A3B-Instruct": "qwen3-vl",
     # GLM-5 family (GLM-4.7 reuses the GLM-5 template).
     "zai-org/GLM-5": "glm-5",
+    "zai-org/GLM-5-FP8": "glm-5",
     "zai-org/GLM-4.7-Flash": "glm-5",
     "zai-org/GLM-5.1": "glm-5.1",
     # GLM-4.5.


### PR DESCRIPTION
## Summary

Adds three entries to `MODEL_RENDERER_MAP`. Each has a `chat_template.jinja` that is byte-identical (md5-confirmed) to a model already in the map, so they can route to the same hand-coded renderer instead of falling back to `DefaultRenderer`:

| New entry | Routes to | Identical to |
|---|---|---|
| `Qwen/Qwen3-30B-A3B-Instruct-2507` | `qwen3` | `Qwen/Qwen3-4B-Instruct-2507` |
| `Qwen/Qwen3-30B-A3B-Thinking-2507` | `qwen3` | `Qwen/Qwen3-4B-Thinking-2507` |
| `zai-org/GLM-5-FP8` | `glm-5` | `zai-org/GLM-5` |

## Why

Unblocks four prime-rl example configs (`multinode`, `qwen30b_math`, `qwen30b_swe`, `glm5_pd_disag`) that were silently falling back to `DefaultRenderer` because their `model.name` wasn't an exact match in the map. With the new config-time validator in prime-rl (PrimeIntellect-ai/prime-rl#2540), these would otherwise need explicit `[orchestrator.renderer]` overrides — and adding to the map is the right answer because the templates are confirmed identical.

## Policy: no `PrimeIntellect/*` mirrors in the map

An earlier revision also added `PrimeIntellect/MiniMax-M2.5-bf16 → minimax-m2`. That entry has been removed.

`PrimeIntellect/*` re-uploads of upstream models mostly exist to carry chat-template patches. The renderers in this map **ignore** those patches — every hand-coded renderer applies its own hardcoded template, not the model's. So adding PI mirrors to the map gives them no benefit, and inviting them in makes the map a moving target as PI ships and retires patched mirrors.

Prime-rl configs should reference the **upstream** model id directly (e.g. `Qwen/Qwen3-0.6B`, not `PrimeIntellect/Qwen3-0.6B`) so auto-resolution picks the right hand-coded renderer. The rare exception — `PrimeIntellect/MiniMax-M2.5-bf16` is needed because we have to train in bf16 and upstream ships fp8 — keeps the PI id but sets `renderer.name = "minimax-m2"` explicitly in the prime-rl config.

## Verification

For each candidate, fetched `chat_template.jinja` (or extracted `chat_template` from `tokenizer_config.json`) from the HF repo and md5-hashed against the already-mapped sibling:

```
5795f12e815e  Qwen/Qwen3-4B-Instruct-2507/tokenizer_config.json chat_template (2630 B)
5795f12e815e  Qwen/Qwen3-30B-A3B-Instruct-2507/tokenizer_config.json chat_template (2630 B)

(4168 B)  Qwen/Qwen3-4B-Thinking-2507/tokenizer_config.json chat_template
(4168 B)  Qwen/Qwen3-30B-A3B-Thinking-2507/tokenizer_config.json chat_template

c39fa970531b98cb889b16714f8c5512  zai-org/GLM-5/chat_template.jinja
c39fa970531b98cb889b16714f8c5512  zai-org/GLM-5-FP8/chat_template.jinja
```

`test_modality_registry_models_route_to_renderer` passes locally.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Qwen3-30B-A3B-Instruct-2507, Qwen3-30B-A3B-Thinking-2507, and GLM-5-FP8 to renderer map
> Adds three new model ID entries to `MODEL_RENDERER_MAP` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/50/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf), routing `Qwen/Qwen3-30B-A3B-Instruct-2507` and `Qwen/Qwen3-30B-A3B-Thinking-2507` to the `qwen3` renderer and `zai-org/GLM-5-FP8` to the `glm-5` renderer instead of falling back to the default renderer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b3d3f2e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->