### PR TITLE
Handle routed experts as response sidecar

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -12,12 +12,12 @@ achieve real parallelism.
 from __future__ import annotations
 
 import asyncio
-import base64
+import json
 import logging
 from collections.abc import Mapping
 from typing import Any, cast
 
-import numpy as np
+import httpx
 from openai import AsyncOpenAI
 
 from renderers.base import (
@@ -30,6 +30,7 @@ from renderers.base import (
 )
 
 _request_logger = logging.getLogger("renderers.client")
+ROUTED_EXPERTS_DATA_PREFIX = b'"routed_experts":{"data":"'
 
 
 class OverlongPromptError(Exception):
@@ -117,6 +118,26 @@ async def _maybe_offload(renderer: Renderer | RendererPool, fn):
     if isinstance(renderer, RendererPool):
         return await asyncio.to_thread(fn)
     return fn()
+
+
+def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
+    data_start = raw.find(ROUTED_EXPERTS_DATA_PREFIX)
+    if data_start < 0:
+        return raw, None
+
+    data_start += len(ROUTED_EXPERTS_DATA_PREFIX)
+    data_end = raw.index(b'"', data_start)
+    routed_data = memoryview(raw)[data_start:data_end]
+    stripped = raw[:data_start] + raw[data_end:]
+    return stripped, routed_data
+
+
+def parse_generate_response(raw: bytes) -> dict[str, Any]:
+    stripped, routed_data = strip_routed_experts_data(raw)
+    payload: dict[str, Any] = json.loads(stripped)
+    if routed_data is not None:
+        payload["choices"][0]["routed_experts"]["data"] = routed_data
+    return payload
 
 
 async def generate(
@@ -222,12 +243,13 @@ async def generate(
         sp.get("max_tokens"),
     )
     post_kwargs: dict[str, Any] = {
-        "cast_to": cast(Any, dict[str, Any]),
+        "cast_to": httpx.Response,
         "body": body,
     }
     if extra_headers:
         post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-    data = await client.post(endpoint, **post_kwargs)
+    raw_response = await client.post(endpoint, **post_kwargs)
+    data = parse_generate_response(raw_response.content)
 
     choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
@@ -241,14 +263,7 @@ async def generate(
     content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
     completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
 
-    routed_experts = None
-    raw_re = choice.get("routed_experts")
-    if isinstance(raw_re, dict) and "data" in raw_re and "shape" in raw_re:
-        routed_experts = (
-            np.frombuffer(base64.b85decode(raw_re["data"]), dtype=np.int32)
-            .reshape(raw_re["shape"])
-            .tolist()
-        )
+    routed_experts = choice.get("routed_experts")
 
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 import asyncio
 import base64
+import json
 
+import httpx
 import numpy as np
 import pytest
 from renderers.base import (
@@ -62,8 +64,8 @@ class _FakeClient:
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        routed_experts = np.array([[[1]], [[2]]], dtype=np.int32)
-        return {
+        routed_experts = np.array([[[1]], [[2]]], dtype=np.uint8)
+        payload = {
             "request_id": "gen-test",
             "choices": [
                 {
@@ -77,7 +79,7 @@ class _FakeClient:
                     },
                     "finish_reason": "stop",
                     "routed_experts": {
-                        "data": base64.b85encode(routed_experts.tobytes()).decode(
+                        "data": base64.b64encode(routed_experts.tobytes()).decode(
                             "ascii"
                         ),
                         "shape": list(routed_experts.shape),
@@ -85,6 +87,10 @@ class _FakeClient:
                 }
             ],
         }
+        return httpx.Response(
+            200,
+            content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+        )
 
 
 def test_generate_builds_request_body_and_parses_response():
@@ -113,6 +119,7 @@ def test_generate_builds_request_body_and_parses_response():
     # /inference/v1/generate is mounted at the server root, so we post to
     # an absolute URL stripped of the OpenAI SDK's automatic /v1 prefix.
     assert client.calls[0]["path"] == "http://fake-host:8000/inference/v1/generate"
+    assert client.calls[0]["cast_to"] is httpx.Response
     assert client.calls[0]["body"] == {
         "model": "test-model",
         "token_ids": [1, 2, 3],
@@ -134,7 +141,9 @@ def test_generate_builds_request_body_and_parses_response():
     assert result["prompt_ids"] == [1, 2, 3]
     assert result["completion_ids"] == [7, 8]
     assert result["completion_logprobs"] == [-0.1, -0.2]
-    assert result["routed_experts"] == [[[1]], [[2]]]
+    assert result["routed_experts"]["shape"] == [2, 1, 1]
+    assert isinstance(result["routed_experts"]["data"], memoryview)
+    assert result["routed_experts"]["data"].tobytes() == base64.b64encode(b"\x01\x02")
     assert result["multi_modal_data"] is None
     assert result["request_id"] == "gen-test"
     assert len(result["tool_calls"]) == 1


### PR DESCRIPTION
## Summary
- keep the branch limited to the client parser and affected client test; no dependency or lockfile changes
- parse /inference/v1/generate responses from raw bytes so routed_experts.data can be stripped before JSON parsing
- return routed_experts as the internal sidecar payload instead of decoding it to nested Python lists
- update the client test fake to return an httpx.Response matching production

## Verification
- SETUPTOOLS_SCM_PRETEND_VERSION=0.1.8.dev5 uv run pytest tests/test_client.py -q
- SETUPTOOLS_SCM_PRETEND_VERSION=0.1.8.dev5 uv run ruff check renderers/client.py tests/test_client.py
- SETUPTOOLS_SCM_PRETEND_VERSION=0.1.8.dev5 uv run ty check renderers/client.py

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Handle routed experts response data as a zero-copy memoryview sidecar
> - Changes `generate()` in [client.py](https://github.com/PrimeIntellect-ai/renderers/pull/54/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) to request a raw `httpx.Response` and parse it with a new `parse_generate_response` function instead of decoding the JSON dict directly.
> - Adds `strip_routed_experts_data` to extract the `routed_experts.data` JSON string value as a `memoryview` without decoding, avoiding a copy of potentially large binary data.
> - Removes the previous numpy/base85 decoding of `routed_experts`; the data is now surfaced as a `memoryview` of the raw base64 bytes.
> - Behavioral Change: callers of `generate()` now receive `routed_experts.data` as a `memoryview` instead of a decoded numeric array.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3177399.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->
