### PR TITLE
fix(kimi_k25): emit JSON literals for bool/null in tool schema rendering

### DIFF
--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -213,7 +213,9 @@ class _EnumType(_BaseType):
         self.enum = schema["enum"]
 
     def to_typescript_style(self, indent: str = "") -> str:
-        return " | ".join(f'"{e}"' if isinstance(e, str) else str(e) for e in self.enum)
+        return " | ".join(
+            f'"{e}"' if isinstance(e, str) else json.dumps(e) for e in self.enum
+        )
 
 
 class _AnyOfType(_BaseType):
@@ -283,11 +285,7 @@ class _TypedParam:
     def to_typescript_style(self, indent: str = "") -> str:
         comments = self.type_.format_docstring(indent)
         if self.default is not None:
-            default_repr = (
-                json.dumps(self.default, ensure_ascii=False)
-                if not isinstance(self.default, (int, float, bool))
-                else repr(self.default)
-            )
+            default_repr = json.dumps(self.default, ensure_ascii=False)
             comments += f"{indent}// Default: {default_repr}\n"
         opt = "?" if self.optional else ""
         return (

--- a/tests/test_kimi_k25_tool_schema.py
+++ b/tests/test_kimi_k25_tool_schema.py
@@ -1,0 +1,53 @@
+"""Kimi K2.5 tool-schema TypeScript rendering: bool/null literal correctness.
+
+Regression for PR #55: ``_function_to_typescript`` used to leak Python
+literals (``True`` / ``False`` / ``None``) into output advertised as
+TypeScript. Both call sites — ``_EnumType.to_typescript_style`` (for
+non-string enum members) and ``_TypedParam.to_typescript_style`` (for
+bool defaults) — now route non-string values through ``json.dumps`` so
+booleans and ``None`` render as ``true`` / ``false`` / ``null``.
+"""
+
+from __future__ import annotations
+
+from renderers.kimi_k25 import _function_to_typescript
+
+
+def test_bool_default_renders_as_json_literal():
+    """Bool defaults must render as ``true`` / ``false``, not ``True`` / ``False``."""
+    out = _function_to_typescript(
+        {
+            "name": "set_logging",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "verbose": {"type": "boolean", "default": True},
+                    "quiet": {"type": "boolean", "default": False},
+                },
+            },
+        }
+    )
+    assert "// Default: true" in out
+    assert "// Default: false" in out
+    assert "Default: True" not in out
+    assert "Default: False" not in out
+
+
+def test_enum_non_string_members_render_as_json_literals():
+    """``null`` / bool / int enum members must render as JSON literals, not Python ``repr``."""
+    out = _function_to_typescript(
+        {
+            "name": "set_mode",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "mode": {"enum": ["auto", None, True, False, 0]},
+                },
+            },
+        }
+    )
+    assert '"auto" | null | true | false | 0' in out
+    # Python literals must not leak through.
+    assert "None" not in out
+    assert "True" not in out
+    assert "False" not in out


### PR DESCRIPTION
## Summary

Two cosmetic bugs in `renderers/kimi_k25.py` caused the TypeScript-style tool renderer to leak Python literals (`True` / `False` / `None`) into output that is advertised as TypeScript. Both share the same root cause: Python's `str()` / `repr()` produce capitalized literals where JSON / TS expect lower-case (`true` / `false` / `null`).

- `_EnumType.to_typescript_style` fell through to `str(e)` for non-string enum members, so `null` / `true` / `false` enum values rendered as `None` / `True` / `False`.
- `_TypedParam.to_typescript_style` routed numeric and boolean defaults through `repr()`, which is correct for ints/floats but wrong for bools (`repr(True) == "True"`).

## Fix

Route everything through `json.dumps`, which already produces correct JSON / TS-compatible syntax for ints, floats, bools, `None`, strings, lists, and dicts. The string branch in `_EnumType` is kept as-is to preserve the existing quoting style.

## Minimal Example for Repro

```python
from renderers.kimi_k25 import _function_to_typescript


# Bug 1: boolean default rendered as `True` instead of `true`
print(
    _function_to_typescript(
        {
            "name": "set_logging",
            "description": "Configure logging.",
            "parameters": {
                "type": "object",
                "properties": {
                    "verbose": {
                        "type": "boolean",
                        "description": "Print extra logs",
                        "default": True,
                    },
                    "quiet": {
                        "type": "boolean",
                        "description": "Suppress output",
                        "default": False,
                    },
                },
            },
        }
    )
)

print()

# Bug 2: null / bool enum members rendered as `None` / `True` / `False`
print(
    _function_to_typescript(
        {
            "name": "set_mode",
            "description": "Set a tri-state mode.",
            "parameters": {
                "type": "object",
                "properties": {
                    "mode": {
                        "description": "Mode discriminator",
                        "enum": ["auto", None, True, False, 0],
                    },
                },
            },
        }
    )
)
```



### Before

```
// Configure logging.
type set_logging = (_: {
  // Suppress output
  // Default: False     <--- False is Pythonic, should be false
  quiet?: boolean,
  // Print extra logs
  // Default: True      <--- True is Pythonic, should be true
  verbose?: boolean
}) => any;

// Set a tri-state mode.
type set_mode = (_: {
  // Mode discriminator
  mode?: "auto" | None | True | False | 0   <--- Similarly as above, with None -> null
}) => any;
```

### After

```
// Configure logging.
type set_logging = (_: {
  // Suppress output
  // Default: false
  quiet?: boolean,
  // Print extra logs
  // Default: true
  verbose?: boolean
}) => any;

// Set a tri-state mode.
type set_mode = (_: {
  // Mode discriminator
  mode?: "auto" | null | true | false | 0
}) => any;
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized serialization change in the TypeScript tool-schema renderer plus regression tests; main risk is minor output-format changes for consumers expecting the prior Python-literal formatting.
> 
> **Overview**
> Fixes Kimi K2.5 TypeScript tool-schema rendering to emit **JSON/TS literals** instead of leaking Python literals.
> 
> `_EnumType.to_typescript_style` now serializes non-string enum members via `json.dumps` (so `None`/`True`/`False` become `null`/`true`/`false`), and `_TypedParam.to_typescript_style` always uses `json.dumps` for default values. Adds regression tests covering boolean defaults and mixed-type enums.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f25a6f2455897379cd23febb3bdeba7aad2532. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix bool/null rendering in Kimi K2.5 tool schema to emit JSON literals instead of Python literals
> In [renderers/kimi_k25.py](https://github.com/PrimeIntellect-ai/renderers/pull/55/files#diff-d4782cf1b3846787eed0332fc8ee00c8ed8181a0eef318ba09ba616ff72cad94), `_EnumType.to_typescript_style` and `_TypedParam.to_typescript_style` were using Python `str()`/`repr()` to serialize non-string values, producing `True`, `False`, and `None` instead of the JSON-compatible `true`, `false`, and `null`. Both methods now use `json.dumps()` for non-string values. New tests in [tests/test_kimi_k25_tool_schema.py](https://github.com/PrimeIntellect-ai/renderers/pull/55/files#diff-dc889117e0d3ea412befaa683fae47e299ae7127a81da22bc89811fe4da16f94) verify that boolean defaults and non-string enum members render correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 36f25a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->