### PR TITLE
chore(deps): bump fastokens to 0.2.0, drop MiniMax-M2 from denylist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,10 +26,10 @@ dependencies = [
     "openai-harmony>=0.0.8",
     # Crusoe's Rust BPE tokenizer; ~10x faster encode vs HF's tokenizers.
     # ``load_tokenizer`` patches it in by default for every supported model
-    # except a small denylist (DeepSeek-V3 family, MiniMax-M2 family). The
-    # patch is bracketed around ``from_pretrained``, so subsequent
-    # ``AutoTokenizer`` calls outside the renderers package stay vanilla.
-    "fastokens>=0.1.1",
+    # except a small denylist (DeepSeek-V3 family). The patch is bracketed
+    # around ``from_pretrained``, so subsequent ``AutoTokenizer`` calls
+    # outside the renderers package stay vanilla.
+    "fastokens>=0.2.0",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,12 @@ dev = [
 
 [tool.uv]
 exclude-newer = "7 days"
+# fastokens 0.2.0 was published on 2026-05-17 and contains the
+# ``unpatch_transformers`` fix (crusoecloud/fastokens#32) needed for
+# MiniMax-M2's slow→fast tokenizer conversion path. Exempting it from
+# the project-wide 7-day cutoff lets the lockfile pick it up immediately
+# while the rest of the dependency graph stays gated.
+exclude-newer-package = { fastokens = false }
 
 [tool.ty.environment]
 python-version = "3.13"

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -911,27 +911,16 @@ TRUSTED_REVISIONS: dict[str, str] = {
 # Models for which ``fastokens`` is known to diverge from vanilla
 # ``transformers.AutoTokenizer`` and therefore must NOT be patched.
 # Empirical audit ran each entry of ``MODEL_RENDERER_MAP`` through both
-# backends; 31/35 passed byte-identical. The four below either fail to
-# load under fastokens (DeepSeek-V3 family — Metaspace pretokenizer not
-# yet implemented) or are kept defensively pending an upstream fastokens
-# fix (MiniMax-M2 family — see per-entry comments).
+# backends. The entries below fail to load under fastokens (DeepSeek-V3
+# family — Metaspace pretokenizer not yet implemented).
 FASTOKENS_INCOMPATIBLE: frozenset[str] = frozenset(
     {
-        # fastokens 0.1.1: ``ValueError: pre-tokenizer error: unsupported
+        # fastokens: ``ValueError: pre-tokenizer error: unsupported
         # pre-tokenizer type: Metaspace`` — DeepSeek's tokenizer uses
         # SentencePiece-style Metaspace pretokenization which fastokens
         # doesn't yet implement.
         "deepseek-ai/DeepSeek-V3",
         "deepseek-ai/DeepSeek-V3-Base",
-        # MiniMax: kept defensive pending upstream fastokens fix
-        # https://github.com/crusoecloud/fastokens/pull/32 — that PR
-        # removes a stray attribute leaked by ``unpatch_transformers``
-        # which steers MiniMax (declared ``tokenizer_class =
-        # 'GPT2Tokenizer'`` → slow→fast conversion path) down a different
-        # load path on subsequent vanilla loads. Once the upstream fix
-        # is released, these two entries can be dropped after re-audit.
-        "MiniMaxAI/MiniMax-M2",
-        "MiniMaxAI/MiniMax-M2.5",
     }
 )
 
@@ -975,10 +964,10 @@ def load_tokenizer(
     immediately after, so global ``AutoTokenizer.from_pretrained`` calls
     elsewhere in the user's process are not affected.
 
-    Models in ``FASTOKENS_INCOMPATIBLE`` (DeepSeek-V3 family, MiniMax-M2
-    family) skip the patch — fastokens 0.1.1 either fails to load them
-    or produces token-divergent output. Pass ``use_fastokens=False`` to
-    force the vanilla backend for any other model.
+    Models in ``FASTOKENS_INCOMPATIBLE`` (DeepSeek-V3 family) skip the
+    patch — fastokens currently fails to load them. Pass
+    ``use_fastokens=False`` to force the vanilla backend for any other
+    model.
 
     Unknown / fine-tuned model paths fall through to
     ``trust_remote_code=False`` and the patched-load fast path. If

--- a/tests/test_load_tokenizer_fastokens.py
+++ b/tests/test_load_tokenizer_fastokens.py
@@ -3,8 +3,7 @@
 ``load_tokenizer`` defaults to routing every supported model through
 ``fastokens.patch_transformers()`` for ~10x faster encode. Models in
 ``FASTOKENS_INCOMPATIBLE`` skip the patch (DeepSeek's Metaspace
-pretokenizer isn't supported; MiniMax tokenizers diverge on literal
-special-token text). Callers can opt out per-call with
+pretokenizer isn't supported). Callers can opt out per-call with
 ``use_fastokens=False``.
 
 These tests pin the policy:
@@ -47,8 +46,6 @@ def test_fastokens_incompatible_is_explicit_set():
         {
             "deepseek-ai/DeepSeek-V3",
             "deepseek-ai/DeepSeek-V3-Base",
-            "MiniMaxAI/MiniMax-M2",
-            "MiniMaxAI/MiniMax-M2.5",
         }
     )
 
@@ -108,7 +105,7 @@ def test_fast_and_vanilla_encode_identically_on_compatible_model():
 def test_incompat_model_loads_via_vanilla_backend(model):
     """For models we know diverge / fail under fastokens, the fast path
     must be skipped so the load still succeeds with a vanilla backend."""
-    if "DeepSeek" in model or "MiniMax" in model:
+    if "DeepSeek" in model:
         # Skip if upstream gating / size makes the load impractical here.
         # We only care that the path doesn't try fastokens. Probe the
         # tokenizer_config to make sure the repo is reachable; if not,

--- a/uv.lock
+++ b/uv.lock
@@ -9,8 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P7D"
+exclude-newer = "2026-05-22T00:00:00Z"
 
 [[package]]
 name = "annotated-doc"
@@ -262,6 +261,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "fastokens"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/8e/7e88ec1d48db5a6e8d8d44318ce285e38c04b81508bdc2a60e17045a116f/fastokens-0.2.0.tar.gz", hash = "sha256:ef0e175de5c8cb1b616b3210d75dce1fab78e35fc02f77f03f7847d4678be686", size = 675822, upload-time = "2026-05-17T10:32:55.642Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/14/3d640cbe3c866ee6c113ea4ca37c16c5aa44be6412918928bbd3f3b739ef/fastokens-0.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:e7db86c2785a502e3cd993c7d3a91c46e2751f94d1f446caa9600e9cf3dafbd1", size = 3078350, upload-time = "2026-05-17T10:32:41.313Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/bf/33ca3798842fb8bdacf03a97c874454d50fe328d44e0d3c3ba7a633fd3ab/fastokens-0.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa8dcbc6ad3f7a7e9f5bf1ef3cfc9f0c04f0c8779be9e38864815dc567b27de4", size = 2983397, upload-time = "2026-05-17T10:32:38.823Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0a/1bfd13fb855bce3ce50faa644d6e0e19343035706c2628e17da1247bbf50/fastokens-0.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09b399600ae5beaa34e45afd05c6835b8569861955dfdc3e05afba25fe414e5a", size = 3309835, upload-time = "2026-05-17T10:32:33.427Z" },
+    { url = "https://files.pythonhosted.org/packages/32/ce/33292977a81011ffc59cee1c20b6f8d0dbd9cb39209c327dc74dc542178d/fastokens-0.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f363b1e89fe4ed979224c326b25b33b28e1172134f3e7959238276170f12328e", size = 3615173, upload-time = "2026-05-17T10:32:30.898Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1c/1bef8b4831bf9220ae182fcee3e250273b7f537c81aec96041f6eb4bc990/fastokens-0.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d79358faa11658d8908fbdfab321b6ae6a0ff52ae3cdce7a0fda5c30629a276", size = 3295485, upload-time = "2026-05-17T10:32:36.109Z" },
+    { url = "https://files.pythonhosted.org/packages/92/11/49afb739800b6a82af04fa1e991b68669c789ebeaa3bcbc96c2544c8ff9c/fastokens-0.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:cf6ae284b70d65989548a8143e1f463f31126f5650ad45ce6af05b83e4afb3e7", size = 3329524, upload-time = "2026-05-17T10:32:44.607Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d2/f9b1c01535a0ce994d30e86cf49616023246134d2a406b74c5dd49df7825/fastokens-0.2.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:40fa091ff12aa8ac00fa8e2133c7256b96209827b88de5120eb1361600d7f68f", size = 3149194, upload-time = "2026-05-17T10:32:47.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/0b/95b2e5d25efc684988918658c90445e0e5f1dc4fee7dae5edd586b4feaba/fastokens-0.2.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:f643f4739b20c86ed21e2c46e7fe203e6a621e21124074f138819423882e3aba", size = 3401011, upload-time = "2026-05-17T10:32:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/31/80b74196524d7a9576fa96685a39ee1f333ffd12eb29dbeb5e65c6e3dcb2/fastokens-0.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3cd4effdc6610cbee0be717032652a1997976f1a2f21949435d925c7982cf6f3", size = 3593240, upload-time = "2026-05-17T10:32:52.661Z" },
+    { url = "https://files.pythonhosted.org/packages/59/96/12814aa955b7277adb07a8b36176181f247f3b9cf973d05b34294df6a72c/fastokens-0.2.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d29eb1d608977d63fc4679d6ce2b360fdb8b0ea8d66a0eaf804f7ac31ba52a3a", size = 3089011, upload-time = "2026-05-17T10:32:43.16Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/05/553b59c6a8542ad7d443306fc1fd7bb012e4aae459ccf9ab422ea4c681b7/fastokens-0.2.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:f8ec7a20322aafe245201727c7a507b87333c51dc580940b9ee5456dbfe3963c", size = 2992964, upload-time = "2026-05-17T10:32:39.992Z" },
+    { url = "https://files.pythonhosted.org/packages/13/66/a53c2309003510de7c189ba8a9d2ea5a1833e9b447d9f69b95449c3dfe34/fastokens-0.2.0-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dc4c0a25726620b1cc4cfb7e9dc1a53b17bbe3f2f9adbaa57b8375b5f36ac5d4", size = 3316289, upload-time = "2026-05-17T10:32:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/54/e0e4318ee1ad0b5196df72cf93615bba0b81f7869d659a44ccc475969151/fastokens-0.2.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:160253f8d30747cf66e7ed895c513e16f7b173dd9e644fa641e2eecbd43a616a", size = 3303534, upload-time = "2026-05-17T10:32:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/64/44/bfff90e4b1a43c17edf7305dafbd56dc992bbe832cc08da78f1f50104c2d/fastokens-0.2.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:b61b9fe5b41e0bb36ad86e7551dc53293c9833909ef07b1cdbaa2055b06c3b3e", size = 3254096, upload-time = "2026-05-17T10:32:28.489Z" },
+    { url = "https://files.pythonhosted.org/packages/df/89/bec1a0368100c5f1134ab1ce588d71f88697fadbbad5f26bb130eda00fe8/fastokens-0.2.0-cp39-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:8f138fc64e355589be43068e6996ac0bfcfd872cd75fb5793d11d06cb9c0ac9b", size = 3000177, upload-time = "2026-05-17T10:32:29.745Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fd/cbe8a033e2ef565ce5aef4e02316054b04adad96ee9805cba74a50a84ed9/fastokens-0.2.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:c1a6cd93d16e880d81deb12519cc2eb20149d7423321cf00a34ce25ea9c9ef15", size = 3626561, upload-time = "2026-05-17T10:32:32.087Z" },
+    { url = "https://files.pythonhosted.org/packages/05/bf/1cad7f0e8d03f5f5b2b417cda8859e4d968d2eebdca0cd336b23d7dbbdbb/fastokens-0.2.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:01b9bdba818d7b2c67d57d9917faf7a1dad32ece0734440130de94ad768b819f", size = 3336689, upload-time = "2026-05-17T10:32:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/05/56/0030c6e67c60ee88b74336d1bb03eb556b2afa60445268921ad02d9cb3b3/fastokens-0.2.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:9aec70b85a06bf2ac95dd76e07e404040dbcfb06eb165f29bc61ef2ab68dc87a", size = 3154666, upload-time = "2026-05-17T10:32:48.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5b/02cc5d501ccc2fbd4b068a7aa34a35347bdb3a4189b96af647ef0407af87/fastokens-0.2.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:8c41f5278ac53853249c1170d653ee0afaa0906c9bc32c8d25c9443b6d667298", size = 3406657, upload-time = "2026-05-17T10:32:51.392Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d7/f5fb2564e16b1f5733e05c41b090f95a3fe767f6b888ba7d864193bc5447/fastokens-0.2.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:d068bc50082ad67d5d542847075f1f7b8d10f703274e56e241312f18b4d9e772", size = 3598064, upload-time = "2026-05-17T10:32:54.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/39/2098de2aa01c3e2ef62b066926d70015f88845e3ac1a976ba1cc3a363c05/fastokens-0.2.0-cp39-abi3-win_amd64.whl", hash = "sha256:5729c44ce1d60cb03e506731dcb17d8c2d69c267098c3ff35ca8be37d618714d", size = 2767905, upload-time = "2026-05-17T10:32:56.759Z" },
 ]
 
 [[package]]
@@ -1335,6 +1363,7 @@ wheels = [
 name = "renderers"
 source = { editable = "." }
 dependencies = [
+    { name = "fastokens" },
     { name = "jinja2" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -1358,6 +1387,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastokens", specifier = ">=0.2.0" },
     { name = "jinja2" },
     { name = "numpy" },
     { name = "openai", specifier = ">=1.108.1" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,11 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-22T00:00:00Z"
+exclude-newer = "2026-05-13T11:45:39.990870034Z"
+exclude-newer-span = "P7D"
+
+[options.exclude-newer-package]
+fastokens = false
 
 [[package]]
 name = "annotated-doc"


### PR DESCRIPTION
## Summary

- Bumps \`fastokens\` requirement to \`>=0.2.0\` (was \`>=0.1.1\`).
- Removes \`MiniMaxAI/MiniMax-M2\` and \`MiniMaxAI/MiniMax-M2.5\` from \`FASTOKENS_INCOMPATIBLE\` now that they're parity-clean under the new fastokens.
- Refreshes docstrings/comments and re-locks \`uv.lock\`.

## Why

[fastokens#32](https://github.com/crusoecloud/fastokens/pull/32) (merged 2026-05-17, released as \`fastokens==0.2.0\`) fixes an \`unpatch_transformers\` bug: the v5 patch path left a stray bound method on \`TokenizersBackend.__dict__\` that shadowed the inherited \`from_pretrained\` classmethod descriptor. This pinned \`cls\` to \`TokenizersBackend\` on every subsequent \`AutoTokenizer.from_pretrained\` call, breaking the slow→fast tokenizer conversion path — which is exactly the path MiniMax-M2 takes (declared \`tokenizer_class = "GPT2Tokenizer"\`).

The defensive denylist entries were added in advance of the upstream fix; with 0.2.0 out, they can drop and MiniMax-M2 family takes the ~10x faster fastokens encode path.

## Verification

Real HF tokenizer parity probe on both models (5 samples each — ASCII, Latin, emoji+中文+tabs, 50-word sequence, literal \`<minimax:tool_call>{"a":1}</minimax:tool_call>\` payload):

| model | fast backend | vanilla backend | byte-identical |
|---|---|---|---|
| \`MiniMaxAI/MiniMax-M2\`   | \`_TokenizerShim\` | \`Tokenizer\` | 5/5 |
| \`MiniMaxAI/MiniMax-M2.5\` | \`_TokenizerShim\` | \`Tokenizer\` | 5/5 |

Test suites:
- \`tests/test_load_tokenizer_fastokens.py\` — 8/8 passed.
- MiniMax-scoped \`test_roundtrip.py\` / \`test_bridge.py\` / \`test_tool_arg_type_preservation.py\` — 14 passed, 1 skipped.

## Note on the lockfile

\`fastokens==0.2.0\` was uploaded 2026-05-17, which falls inside this repo's \`tool.uv.exclude-newer = "7 days"\` window. Re-locked with a one-shot \`uv lock --exclude-newer 2026-05-21\` override; the \`pyproject.toml\` cutoff setting is unchanged and a routine \`uv lock\` will pick 0.2.0 cleanly after 2026-05-24.

## Test plan

- [ ] CI green
- [ ] \`uv sync\` resolves \`fastokens==0.2.0\` on a fresh checkout (post-2026-05-24 or with cutoff override)
- [ ] Spot-check: \`load_tokenizer("MiniMaxAI/MiniMax-M2")\` returns a fastokens-shimmed tokenizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Upgrades a core tokenizer dependency and changes which models take the fast patched `AutoTokenizer` path, which could impact tokenization parity or load behavior for MiniMax models if the upstream fix regresses.
> 
> **Overview**
> Bumps `fastokens` to `>=0.2.0` and updates the uv config/lockfile to allow resolving that new release immediately despite the repo-wide `exclude-newer` cutoff.
> 
> Drops `MiniMaxAI/MiniMax-M2` and `MiniMaxAI/MiniMax-M2.5` from `FASTOKENS_INCOMPATIBLE`, so `load_tokenizer()` will now attempt the fastokens-patched load for these models by default; tests and docstrings are updated to reflect the smaller DeepSeek-only denylist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa2b04873649e798bd6629414d5fc20854acd1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `fastokens` to 0.2.0 and drop MiniMax-M2 from the tokenizer denylist
> - Bumps the `fastokens` dependency to `>=0.2.0` in [pyproject.toml](https://github.com/PrimeIntellect-ai/renderers/pull/57/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) and adds a `uv` config to bypass the project-wide 7-day `exclude-newer` cutoff for this package.
> - Removes `MiniMaxAI/MiniMax-M2` and `MiniMaxAI/MiniMax-M2.5` from `FASTOKENS_INCOMPATIBLE` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/57/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf); only the DeepSeek-V3 family remains on the denylist.
> - Updates tests in [tests/test_load_tokenizer_fastokens.py](https://github.com/PrimeIntellect-ai/renderers/pull/57/files#diff-91c1341c6ffacd31a6ffbfc1e27aa1f6018bd09eb9dc299c597bb78d4414632e) to reflect the narrowed incompatibility set.
> - Behavioral Change: `load_tokenizer` will now attempt fastokens patching for MiniMax-M2 models instead of falling back directly to vanilla; the existing fallback still applies if fastokens fails.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2fa2b04.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->