### PR TITLE
ci: auto-publish dev release to PyPI on every commit to main

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,0 +1,104 @@
+name: Publish Dev
+
+# Tag every commit on main as ``renderers-v<next>.dev<N>`` and publish the
+# wheel to PyPI as a pre-release. ``<next>`` is the latest release tag with
+# its patch bumped; ``<N>`` is the number of commits since that release so
+# each main commit maps to a unique PEP 440 dev version.
+#
+# Building from the freshly-created tag means hatch-vcs resolves the version
+# cleanly (no ``+gHASH`` local segment), which PyPI requires.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: publish-dev-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.compute.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute next dev tag
+        id: compute
+        run: |
+          set -euo pipefail
+          LATEST_RELEASE=$(git tag --list 'renderers-v*' --sort=-v:refname \
+            | grep -Ev '(dev|rc|a[0-9]|b[0-9])' \
+            | head -1)
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "No release tag matching 'renderers-v<MAJOR.MINOR.PATCH>' found" >&2
+            exit 1
+          fi
+          BASE=${LATEST_RELEASE#renderers-v}
+          MAJOR=$(echo "$BASE" | cut -d. -f1)
+          MINOR=$(echo "$BASE" | cut -d. -f2)
+          PATCH=$(echo "$BASE" | cut -d. -f3)
+          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
+          N=$(git rev-list --count "${LATEST_RELEASE}..HEAD")
+          TAG="renderers-v${NEXT}.dev${N}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Computed tag: ${TAG} (base=${LATEST_RELEASE}, commits=${N})"
+
+      - name: Create and push tag
+        env:
+          TAG: ${{ steps.compute.outputs.tag }}
+        run: |
+          set -euo pipefail
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin — nothing to do" >&2
+            exit 0
+          fi
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git tag -a "$TAG" -m "Automated dev release ${TAG}"
+          git push origin "$TAG"
+
+  build:
+    needs: tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: refs/tags/${{ needs.tag.outputs.tag }}
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Build renderers
+        run: uv build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-dev
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi-prod
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist-dev
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/publish-dev.yml` runs on every push to `main`.
- It tags the commit as `renderers-v<next-patch>.dev<N>` (where `N` = commits since the latest non-prerelease tag) and publishes the wheel to PyPI as a pre-release.
- Builds run from the freshly-created tag so hatch-vcs resolves a clean PEP 440 version (no `+gHASH` local segment that PyPI rejects).
- Mirrors the build → publish split from `publish.yml` so OIDC stays scoped to the publish job only.

## Notes
- Reuses the existing `pypi-prod` environment / trusted publisher. Confirm the PyPI Trusted Publisher allows `publish-dev.yml` as a workflow name — if it's pinned to `publish.yml`, the entry needs to be added.
- The tag job pushes with `GITHUB_TOKEN`, which deliberately does **not** re-trigger `publish.yml` (avoids double-publish).
- Counter is derived from `git rev-list --count <release>..HEAD`, so each main commit maps to a unique dev version even across reruns.

## Test plan
- [ ] Merge to main and confirm a `renderers-v0.1.8.devN` tag appears and a matching pre-release version lands on PyPI.
- [ ] Verify the next commit increments `N` and publishes cleanly.
- [ ] Confirm `publish.yml` does not also fire from the auto-pushed tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates tagging and publishing to the production PyPI project on every `main` push; mis-tagging, trusted publisher config, or workflow bugs could create unintended public prereleases.
> 
> **Overview**
> Adds a new GitHub Actions workflow, `publish-dev.yml`, that runs on every push to `main` and automatically **creates a `renderers-v<next-patch>.dev<N>` tag** based on the latest non-prerelease release tag and commit count.
> 
> The workflow then builds the wheel from that tag (to ensure a clean PEP 440 version) and publishes the resulting artifacts to PyPI using the existing `pypi-prod` OIDC/trusted publisher setup, keeping the build→publish job split so only the publish job has `id-token: write`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73aa68cab92a3a83dcca287a38acdbaecbfca235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-publish dev releases to PyPI on every commit to main
> Adds a [publish-dev.yml](.github/workflows/publish-dev.yml) GitHub Actions workflow that runs on every push to main.
>
> - Computes the next dev tag (`renderers-v<NEXT>.dev<N>`) from the latest non-prerelease tag, bumping patch and using commit count since last release as `N`.
> - Creates and pushes the tag if it does not exist, then builds the package from that tag using `uv build`.
> - Publishes the resulting wheel to PyPI as a pre-release via OIDC (`pypa/gh-action-pypi-publish`).
> - Concurrency is scoped per ref with `cancel-in-progress: false` to avoid dropped publishes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73aa68c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->