### PR TITLE
Fix VCS versioning after dev tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,10 @@ tag-pattern = '^renderers-v(?P<version>.+)$'
 # only fires when the resolver has nothing to go on.
 fallback-version = "0.0.0"
 
+[tool.hatch.version.raw-options]
+# Dev release tags cannot be advanced by the default guess-next-dev scheme.
+version_scheme = "semver-pep440"
+
 [tool.hatch.build.hooks.vcs]
 # Write the resolved version to a Python file so it can be inspected
 # at runtime via ``renderers.__version__`` without re-parsing the


### PR DESCRIPTION
## Summary
- Make renderers installable from commits after the `renderers-v0.1.8.dev4` tag by using setuptools-scm `semver-pep440` versioning.
- This lets the routed-experts sidecar parser from PR #54 be consumed directly from a git/submodule commit instead of falling back to stale installed code.

## Verification
- `uv run --frozen python - <<PY ...` imported `renderers.client` from the workspace and resolved version `0.1.9.dev1+g3177399b7.d20260521`.
- Mocked compact `/inference/v1/generate` JSON and verified `renderers.client.generate()` returns `routed_experts.data` as `memoryview`.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix VCS versioning by setting `version_scheme` to `semver-pep440` in Hatch config
> Sets `version_scheme = "semver-pep440"` under `[tool.hatch.version.raw-options]` in [pyproject.toml](https://github.com/PrimeIntellect-ai/renderers/pull/59/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) to correct version resolution after dev tags. The default scheme was producing incorrect versions in this scenario.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ae4d9b8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and packaging metadata only; no runtime application logic changes.
> 
> **Overview**
> Configures Hatch VCS versioning to use **`semver-pep440`** via `[tool.hatch.version.raw-options]`, passing through to setuptools-scm so versions resolve correctly **after dev release tags** (e.g. `renderers-v0.1.8.dev4`). The default **guess-next-dev** scheme was not advancing those tags, which blocked installing **`renderers`** from arbitrary git commits with sensible PEP 440 dev versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4d9b86ab7a30e17ea9f870988607271812f67e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->