### PR TITLE
fix(base): suppress fastokens per-load print, log once instead

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import enum
+import io
 import logging
 import queue
 import threading
@@ -1049,6 +1051,10 @@ FASTOKENS_INCOMPATIBLE: frozenset[str] = frozenset(
 )
 
 
+_FASTOKENS_PATCH_LOCK = threading.Lock()
+_FASTOKENS_ANNOUNCED = False
+
+
 def _patched_load(model_name_or_path: str, **kwargs):
     """Run ``AutoTokenizer.from_pretrained`` with fastokens patched in
     process-locally — patch around the load, unpatch right after.
@@ -1058,15 +1064,39 @@ def _patched_load(model_name_or_path: str, **kwargs):
     fastokens for ``encode``/``decode`` while subsequent
     ``AutoTokenizer.from_pretrained`` calls (outside our control) go
     back to vanilla. This keeps the global side effect minimal.
+
+    fastokens itself prints ``[fastokens] patch_transformers: ...`` to
+    stdout on every patch/unpatch call. Building a pool of size N would
+    therefore emit ~N lines (more under thread contention, where some
+    threads see ``already patched``). We swallow those prints under a
+    lock — ``contextlib.redirect_stdout`` swaps ``sys.stdout``
+    process-wide, so the lock keeps unrelated stdout writes from other
+    threads from disappearing into our buffer. The patch/unpatch calls
+    are cheap; only the brief patch+unpatch is serialized, the actual
+    ``from_pretrained`` still runs concurrently across pool slots. A
+    single ``logger.info`` is emitted on the first patch so the fast
+    path is still discoverable in logs.
     """
     import fastokens
     from transformers import AutoTokenizer
 
-    fastokens.patch_transformers()
+    global _FASTOKENS_ANNOUNCED
+
+    with _FASTOKENS_PATCH_LOCK:
+        with contextlib.redirect_stdout(io.StringIO()):
+            fastokens.patch_transformers()
+        if not _FASTOKENS_ANNOUNCED:
+            logger.info(
+                "fastokens enabled — tokenizers load through the Rust BPE "
+                "fast path (~10x encode speedup)."
+            )
+            _FASTOKENS_ANNOUNCED = True
     try:
         return AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
     finally:
-        fastokens.unpatch_transformers()
+        with _FASTOKENS_PATCH_LOCK:
+            with contextlib.redirect_stdout(io.StringIO()):
+                fastokens.unpatch_transformers()
 
 
 def load_tokenizer(

--- a/tests/test_load_tokenizer_fastokens.py
+++ b/tests/test_load_tokenizer_fastokens.py
@@ -167,3 +167,45 @@ def test_fallback_on_fastokens_load_error(monkeypatch):
     assert "Shim" not in _backend_class_name(tok)
     # Still works.
     assert len(tok.encode("hi", add_special_tokens=False)) > 0
+
+
+# ---------------------------------------------------------------------------
+# Print suppression: fastokens itself prints "[fastokens]
+# patch_transformers: ..." on every patch/unpatch call. Building a
+# RendererPool of size N would emit ~N lines (the pool factory calls
+# load_tokenizer once per slot). load_tokenizer swallows that stdout
+# chatter and emits a single INFO log on the first patch instead.
+# ---------------------------------------------------------------------------
+
+
+def test_no_fastokens_stdout_chatter(capsys, caplog):
+    """``load_tokenizer`` must not leak ``[fastokens]`` prints onto
+    stdout, and must emit exactly one INFO log per process announcing
+    the fast path (not once per call)."""
+    import logging
+
+    import renderers.base as rb
+
+    # Reset the process-wide "announced" flag so this test sees the
+    # first-call log even if another test loaded a tokenizer earlier.
+    rb._FASTOKENS_ANNOUNCED = False
+
+    with caplog.at_level(logging.INFO, logger="renderers.base"):
+        load_tokenizer(_FAST_MODEL)
+        load_tokenizer(_FAST_MODEL)
+
+    captured = capsys.readouterr()
+    assert "[fastokens]" not in captured.out, (
+        f"fastokens print leaked to stdout: {captured.out!r}"
+    )
+    assert "[fastokens]" not in captured.err, (
+        f"fastokens print leaked to stderr: {captured.err!r}"
+    )
+
+    fastokens_info = [
+        r for r in caplog.records if "fastokens enabled" in r.getMessage()
+    ]
+    assert len(fastokens_info) == 1, (
+        f"expected exactly one fastokens INFO log across two loads, "
+        f"got {len(fastokens_info)}"
+    )


### PR DESCRIPTION
## Summary
- `fastokens.patch_transformers()` unconditionally `print()`s `[fastokens] patch_transformers: ...` on every call. `_patched_load` brackets every `AutoTokenizer.from_pretrained` with a patch/unpatch pair, so a `RendererPool(size=N)` emits ~N lines on startup (more under contention from the construction-time `ThreadPoolExecutor`, where some threads also see "already patched").
- Swallow the per-call stdout chatter under a lock and emit a single `logger.info` on the first patch so the fast path stays discoverable. The actual `from_pretrained` call still runs concurrently across pool slots — only the brief patch/unpatch is serialized (necessary because `contextlib.redirect_stdout` swaps `sys.stdout` process-wide).
- Adds a regression test in `tests/test_load_tokenizer_fastokens.py` pinning: zero `[fastokens]` lines on stdout/stderr, and exactly one INFO log across multiple `load_tokenizer` calls.

### Before (pool of size 10)
```
[fastokens] patch_transformers: already patched.
[fastokens] patch_transformers: already patched.
[fastokens] patch_transformers: already patched.
[fastokens] patch_transformers: successfully patched transformers v5.6.2
[fastokens] patch_transformers: already patched.
[fastokens] patch_transformers: successfully patched transformers v5.6.2
[fastokens] patch_transformers: successfully patched transformers v5.6.2
[fastokens] patch_transformers: successfully patched transformers v5.6.2
[fastokens] patch_transformers: successfully patched transformers v5.6.2
[fastokens] patch_transformers: successfully patched transformers v5.6.2
```

### After
```
INFO renderers.base: fastokens enabled — tokenizers load through the Rust BPE fast path (~10x encode speedup).
```
(One INFO log, no stdout chatter.)

## Test plan
- [x] `pytest tests/test_load_tokenizer.py tests/test_load_tokenizer_fastokens.py` — all 15 prior + 1 new test pass.
- [x] Manual repro: `create_renderer_pool('Qwen/Qwen3-0.6B', size=10)` followed by 10 `render_ids` calls — zero `[fastokens]` lines.
- [x] Confirmed fast-path tokenizer is still installed (existing `test_default_uses_fastokens_on_compatible_model` still passes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior change is limited to suppressing fastokens stdout prints during tokenizer load and adding a one-time INFO log, with a new regression test to pin output/logging behavior.
> 
> **Overview**
> `load_tokenizer`’s fastokens path now **suppresses fastokens’ per-call stdout chatter** by redirecting stdout during `patch_transformers`/`unpatch_transformers` under a global lock.
> 
> It also emits **a single one-time INFO log** announcing fastokens is enabled (instead of printing on every load), and adds a test ensuring no `[fastokens]` output leaks to stdout/stderr and that the INFO log appears exactly once across repeated loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41704572481f8cebb617e3ab5e694ef50ef170e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Suppress per-call `fastokens` stdout prints and log once per process instead
> - `_patched_load` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/61/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) now redirects stdout to an in-memory buffer during `fastokens.patch_transformers` and `fastokens.unpatch_transformers` calls, suppressing their built-in prints.
> - A process-wide `threading.Lock` serializes patch/unpatch calls across threads.
> - A module-level flag ensures a single `INFO` log (`fastokens enabled — ...`) is emitted on the first patch per process, replacing the previous per-call output.
> - A new test in [tests/test_load_tokenizer_fastokens.py](https://github.com/PrimeIntellect-ai/renderers/pull/61/files#diff-91c1341c6ffacd31a6ffbfc1e27aa1f6018bd09eb9dc299c597bb78d4414632e) verifies no `[fastokens]` strings appear on stdout/stderr and that exactly one INFO log is produced across multiple calls.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d417045.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->