### PR TITLE
feat(client): RENDERERS_MAX_PROMPT_LEN env override for pre-flight cap

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -66,6 +67,38 @@ _max_prompt_len_cache: dict[tuple[str, str], int | None] = {}
 _max_prompt_len_lock = asyncio.Lock()
 
 
+_MAX_PROMPT_LEN_ENV_VAR = "RENDERERS_MAX_PROMPT_LEN"
+
+
+def _max_prompt_len_from_env() -> int | None:
+    """Read the ``RENDERERS_MAX_PROMPT_LEN`` env-var override.
+
+    Returns the parsed positive int, or ``None`` if unset/invalid. When
+    set, ``_resolve_max_prompt_len`` returns this value without querying
+    the engine — useful when the engine's ``/v1/models`` endpoint is
+    broken (e.g., a misconfigured router) but the operator knows the
+    real ``max_model_len``.
+    """
+    raw = os.environ.get(_MAX_PROMPT_LEN_ENV_VAR)
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        _request_logger.warning(
+            "%s is set to %r, which is not a valid integer; ignoring.",
+            _MAX_PROMPT_LEN_ENV_VAR,
+            raw,
+        )
+        return None
+    if value <= 0:
+        _request_logger.warning(
+            "%s=%d is not positive; ignoring.", _MAX_PROMPT_LEN_ENV_VAR, value
+        )
+        return None
+    return value
+
+
 async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None:
     """Discover ``max_model_len`` from the engine via ``GET /v1/models``.
 
@@ -80,7 +113,16 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
     Any exception during lookup (network error, non-JSON body, attribute
     miss on a mock client in tests) is treated as "unknown cap": cached
     ``None`` so we don't retry on every call.
+
+    The ``RENDERERS_MAX_PROMPT_LEN`` env var overrides auto-discovery
+    entirely: when set to a positive integer, that value is returned and
+    no ``/v1/models`` request is issued. Use this when the engine's model
+    card is unreachable (e.g., a router whose ``/v1/models`` handler is
+    broken) but the operator knows the engine's real cap.
     """
+    override = _max_prompt_len_from_env()
+    if override is not None:
+        return override
     key = (str(getattr(client, "base_url", "")), model)
     if key in _max_prompt_len_cache:
         return _max_prompt_len_cache[key]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -502,3 +502,72 @@ def test_generate_caches_max_prompt_len_lookup_failure():
     assert len(client.calls) == 1
     assert result["prompt_ids"] == list(range(10))
     assert _max_prompt_len_cache[("http://no-models:8000/v1", "test-model")] is None
+
+
+def test_generate_uses_env_max_prompt_len_override(monkeypatch):
+    """``RENDERERS_MAX_PROMPT_LEN`` overrides auto-discovery entirely: the
+    pre-flight uses the env value and ``/v1/models`` is never queried,
+    even when the engine would have returned a different cap."""
+    from renderers.client import OverlongPromptError, _max_prompt_len_cache
+
+    class _ClientWithModels(_FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.base_url = "http://disco-host:8000/v1"
+            self.models_calls = 0
+
+        async def get(self, path, *, cast_to):
+            self.models_calls += 1
+            return {"object": "list", "data": [{"id": "test-model", "max_model_len": 999}]}
+
+    _max_prompt_len_cache.clear()
+    monkeypatch.setenv("RENDERERS_MAX_PROMPT_LEN", "4")
+
+    client = _ClientWithModels()
+    with pytest.raises(OverlongPromptError) as excinfo:
+        asyncio.run(
+            generate(
+                client=client,
+                renderer=_LongRenderer(),
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+            )
+        )
+
+    assert excinfo.value.max_prompt_len == 4, "env override beats engine card"
+    assert excinfo.value.prompt_len == 10
+    assert client.models_calls == 0, "env override must skip /v1/models query"
+    assert client.calls == [], "request must not be dispatched on pre-flight fail"
+
+
+def test_generate_env_override_invalid_falls_back_to_auto_discovery(monkeypatch):
+    """A non-integer or non-positive ``RENDERERS_MAX_PROMPT_LEN`` is ignored
+    (with a warning) and auto-discovery proceeds normally."""
+    from renderers.client import OverlongPromptError, _max_prompt_len_cache
+
+    class _ClientWithModels(_FakeClient):
+        def __init__(self):
+            super().__init__()
+            self.base_url = "http://disco-host-2:8000/v1"
+            self.models_calls = 0
+
+        async def get(self, path, *, cast_to):
+            self.models_calls += 1
+            return {"object": "list", "data": [{"id": "test-model", "max_model_len": 4}]}
+
+    _max_prompt_len_cache.clear()
+    monkeypatch.setenv("RENDERERS_MAX_PROMPT_LEN", "not-an-int")
+
+    client = _ClientWithModels()
+    with pytest.raises(OverlongPromptError) as excinfo:
+        asyncio.run(
+            generate(
+                client=client,
+                renderer=_LongRenderer(),
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+            )
+        )
+
+    assert excinfo.value.max_prompt_len == 4, "auto-discovered cap should win"
+    assert client.models_calls == 1, "invalid env override must not skip /v1/models"


### PR DESCRIPTION
Adds an env-var escape hatch for the pre-flight overflow check in `_resolve_max_prompt_len`. When `RENDERERS_MAX_PROMPT_LEN` is set to a positive integer, that value is returned directly and `/v1/models` is not queried.

Motivation: routers/gateways whose `/v1/models` handler is broken (observed with vllm-router v0.1.22 under `--intra-node-data-parallel-size`
> 1) silently disable the pre-flight via the cached-`None` path,
which lets overlong prompts reach the engine and crash the orchestrator with a raw `ValueError`. Operators who know the real cap can now set the env var to restore pre-flight without touching the broken endpoint.

Invalid values (non-integer, <= 0) are logged and ignored, falling back to the existing auto-discovery path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional env override on client-side pre-flight only; invalid values are ignored with fallback to existing discovery.
> 
> **Overview**
> Adds **`RENDERERS_MAX_PROMPT_LEN`** so operators can pin the client pre-flight context cap without calling **`GET /v1/models`**. When set to a positive integer, **`_resolve_max_prompt_len`** returns that value immediately and skips engine model-card discovery—useful when **`/v1/models`** is broken but the real **`max_model_len`** is known.
> 
> Invalid values (non-integer or ≤ 0) are logged and ignored; behavior falls back to the existing auto-discovery and cache path. Tests cover override winning over the model card, skipping **`/v1/models`**, and invalid env falling back to discovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f653df9acecebb4cb99e3d70aff60969f35d4b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `RENDERERS_MAX_PROMPT_LEN` env var override for pre-flight prompt length cap
> - Adds `_max_prompt_len_from_env` in [`renderers/client.py`](https://github.com/PrimeIntellect-ai/renderers/pull/62/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) that reads `RENDERERS_MAX_PROMPT_LEN` and parses it as a positive integer, logging a warning and returning `None` for invalid values.
> - Updates `_resolve_max_prompt_len` to return the env var value immediately when set, skipping the `/v1/models` HTTP request and the in-memory cache lookup.
> - When the env var is unset or invalid, behavior is unchanged: check the cache, then query `/v1/models`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5f653df.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->