### PR TITLE
fix(parsing): accept bare-string args for union schemas with string

### DIFF
--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -65,30 +65,36 @@ def _coerce_arg_value(
     """Coerce a raw ``<arg_value>`` body to its declared type.
 
     Returns ``(value, used_json_fallback)``. The boolean is ``True`` only
-    when ``json.loads`` was attempted and raised, so the caller knows
-    whether to flag ``INVALID_JSON``. Returning a string verbatim
-    because the schema declared ``type: "string"`` is NOT a fallback.
+    when ``json.loads`` was attempted, raised, AND the schema doesn't
+    permit a string. Returning a string verbatim because the schema
+    permits strings is NOT a fallback.
 
     Rule (matches vLLM / SGLang reference parsers):
 
     - If the param's declared ``type`` is ``"string"`` (or single-element
       ``["string"]``), return ``text`` verbatim — never ``json.loads``.
-    - Anything else (no schema, non-string scalar, object, array, or
-      union types that include non-string): try ``json.loads`` and fall
-      back to raw ``text`` on parse failure.
+    - Otherwise try ``json.loads``. If that fails, return raw ``text``.
+      The ``used_json_fallback`` flag is ``True`` only when the schema
+      does NOT permit a string — i.e. the fallback is truly suspect.
 
-    Union types that include ``"string"`` alongside other types still
-    attempt ``json.loads`` first so an explicit integer / bool can
-    parse; the string branch only wins as the fallback.
+    Union types (``anyOf``/``oneOf``) that include ``"string"`` alongside
+    other types still attempt ``json.loads`` first so an explicit
+    integer / bool can parse; the string branch wins as fallback, and
+    landing there is expected — not a malformed-JSON signal.
     """
+    string_is_allowed = False
     if param_schema is not None:
         declared = param_schema.get("type")
         if declared == "string" or declared == ["string"]:
             return text, False
+        for branch in param_schema.get("anyOf") or param_schema.get("oneOf") or []:
+            if isinstance(branch, dict) and branch.get("type") == "string":
+                string_is_allowed = True
+                break
     try:
         return json.loads(text), False
     except (json.JSONDecodeError, ValueError):
-        return text, True
+        return text, not string_is_allowed
 
 
 def _find(ids: list[int], target: int, start: int = 0) -> int:

--- a/tests/test_tool_arg_type_preservation.py
+++ b/tests/test_tool_arg_type_preservation.py
@@ -137,3 +137,75 @@ def test_string_arg_preserves_type(model, renderer_name, renderer, args):
     assert got == args, (
         f"{model}: tool-arg type drift — sent {args!r}, parser returned {got!r}"
     )
+
+
+# Schemas where ``string`` is one branch of a union (``anyOf`` / ``oneOf``).
+# These are common in practice — e.g. ``form_input.value: str | bool`` in
+# Pydantic serialises to ``{"anyOf": [{"type": "string"}, {"type": "boolean"}]}``.
+# Without the union-aware check, the XML parser's ``json.loads`` falls back
+# to raw text for bare strings, but flags the call ``INVALID_JSON`` because
+# no top-level ``type`` key declared a string — silently dropping otherwise
+# valid tool calls in the renderer client.
+UNION_WITH_STRING_SCHEMAS = [
+    pytest.param(
+        {"anyOf": [{"type": "string"}, {"type": "boolean"}]},
+        id="anyOf-string-boolean",
+    ),
+    pytest.param(
+        {"anyOf": [{"type": "string"}, {"type": "null"}]},
+        id="anyOf-string-null",
+    ),
+    pytest.param(
+        {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+        id="oneOf-string-integer",
+    ),
+]
+
+
+@pytest.mark.parametrize("param_schema", UNION_WITH_STRING_SCHEMAS)
+def test_union_with_string_emits_ok_status(
+    model, renderer_name, renderer, param_schema
+):
+    """Union schemas containing ``string`` must yield ``status=OK`` when
+    the model emits a bare string. Pre-fix, ``_coerce_arg_value`` flagged
+    this as ``INVALID_JSON`` because the top-level ``type`` key was
+    absent (the string branch was under ``anyOf`` / ``oneOf``)."""
+    from renderers.base import ToolCallParseStatus
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "f",
+                "description": "Test tool with one union-typed parameter.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"x": param_schema},
+                    "required": ["x"],
+                },
+            },
+        }
+    ]
+    args = {"x": "abc"}
+    msg = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "functions.f:0",
+                "function": {"name": "f", "arguments": args},
+            }
+        ],
+    }
+    completion_ids = _extract_assistant_tokens(renderer, PROMPT, msg, tools=tools)
+    parsed = renderer.parse_response(completion_ids, tools=tools)
+
+    assert parsed.tool_calls, f"{model}: parser returned no tool_calls"
+    tc = parsed.tool_calls[0]
+    assert tc.status == ToolCallParseStatus.OK, (
+        f"{model}: union-with-string schema flagged {tc.status} on bare string"
+    )
+    got = _normalize_args(tc.arguments)
+    assert got == args, (
+        f"{model}: tool-arg drift — sent {args!r}, parser returned {got!r}"
+    )


### PR DESCRIPTION
## Summary

Fix `_coerce_arg_value` to recognize `anyOf` / `oneOf` schemas with a string branch, so XML-style parsers (Qwen3.5, Qwen3.6, GLM, MiniMax, Laguna) don't wrongly flag bare-string args as `INVALID_JSON`.

## The bug

`form_input` and similar tools have parameters typed as `Union[str, bool]` (or `Optional[str]`), which Pydantic serialises to:

```json
{"anyOf": [{"type": "string"}, {"type": "boolean"}]}
```

The top-level `"type"` key is absent. So `_coerce_arg_value`:

1. Skipped the pure-string short-circuit (no top-level `"string"` type).
2. Tried `json.loads("LIS")` → `JSONDecodeError`.
3. Returned `(text, True)` — flagging the fallback as malformed-JSON.

`parse_qwen35` then OR's `used_fallback` across all params into `any_json_fallback`, and stamps the call `ToolCallParseStatus.INVALID_JSON`. Downstream, `verifiers/clients/renderer_client.py` silently dropped all non-OK tool calls (lines 604-609 on main), so any `form_input(value="LIS", ...)` was effectively erased before reaching the env. The env saw no `tool_calls` and terminated the rollout via the `no_tools_called` stop predicate.

Empirically (mini-browse-apps multi-turn eval, Qwen3.6-35B-A3B, n=20):
- Renderer-route reward pre-fix: **0.10**
- Renderer-route reward with this fix + the matching `verifiers` filter relaxation: **0.55**, basically at MITO parity (`/v1/chat/completions` got 0.60 on the same slice; 4 of MITO's failures were unrelated vLLM mm-cache crashes)

## The fix

Detect union (`anyOf` / `oneOf`) branches containing `"string"` and treat the `json.loads`-fails → text-fallback path as **expected** behavior under those schemas, not malformed. That matches the function's docstring intent ("the string branch wins as fallback") which the original code didn't actually enforce.

The pure-string short-circuit (`type: "string"` and `type: ["string"]`) is unchanged.

## Test plan

Extended `tests/test_tool_arg_type_preservation.py` with one new parametrized test `test_union_with_string_emits_ok_status` covering three schema shapes:
- `anyOf: [string, boolean]`
- `anyOf: [string, null]`
- `oneOf: [string, integer]`

Each case round-trips a bare-string arg through the existing XML-style parsers (Qwen3.5, GLM-5, MiniMax-M2.5, Laguna-XS.2) plus the two JSON-format controls (Qwen3, Kimi K2.5), and asserts both `status == OK` and value preservation. All 18 parametrized cases pass.

The matching `verifiers` change (stop silently dropping non-OK `ParsedToolCall` in `renderer_client.py`) is a separate PR — together they restore full multi-turn parity with the `/v1/chat/completions` route.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_coerce_arg_value` to accept bare strings for union schemas containing a string branch
> When a parameter schema uses `anyOf` or `oneOf` and includes a `string` type, bare string arguments failed JSON parsing and were incorrectly marked with `used_json_fallback=True`, causing them to be treated as malformed input.
>
> - [parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/63/files#diff-4eba1ee111275cd49ea938c89bfbb7dafa7894d18a97c858fb4a9df401e85c75) now detects union schemas with a `string` branch and returns the raw string with `used_json_fallback=False` on JSON parse failure.
> - Tests in [test_tool_arg_type_preservation.py](https://github.com/PrimeIntellect-ai/renderers/pull/63/files#diff-a8b4d31bea96c447698c46d3f9af5f11307f136309be083862e18031affbd47a) cover `anyOf` and `oneOf` unions with string plus boolean/null/integer branches, asserting `OK` status and unchanged argument values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9c30dc0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

---

## Note by @hallerite:

A few factual additions from a reviewer pass:

- **Nemotron3 also gets this fix.** It routes through `parse_qwen35` (see `renderers/nemotron3.py:33`), so the affected set is Qwen3.5, Qwen3.6, Nemotron3, GLM-4.5/5, Laguna-XS.2, MiniMax-M2.
- **JSON-format parsers don't need this fix** and are unaffected: `parse_qwen3` (Qwen3, Qwen3-VL), `parse_deepseek_v3`, `parse_kimi_k2` / `parse_kimi_k2_section`, `parse_gpt_oss` — they `json.loads` the entire args block, so unions work natively.
- **vLLM divergence (intentional).** vLLM's `qwen3xml_tool_parser._get_param_type` (`vllm/tool_parsers/qwen3xml_tool_parser.py:993-1009`) defaults missing `type` to `"string"` and never `json.loads` for that branch — never flags this case, but also can't recover `int`/`bool` from a `Union[str, int]`. This PR still tries `json.loads` first and only suppresses the fallback flag when a string branch exists.
- **Schema-shape coverage gaps** (likely theoretical, worth noting):
  - Detector only checks `anyOf`/`oneOf` one level deep — nested unions won't be detected. Pydantic v2 flattens these.
  - JSON Schema's array-type form `{"type": ["string", "boolean"]}` isn't handled; existing short-circuit only catches single-element `["string"]`. Pydantic doesn't emit this shape.
  - `param_schema.get("anyOf") or param_schema.get("oneOf") or []` short-circuits — a schema with both keys would ignore `oneOf`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared argument coercion used by multiple XML tool parsers; behavior is narrower (fewer false INVALID_JSON) but affects how non-OK tool calls are classified downstream.
> 
> **Overview**
> Fixes **`_coerce_arg_value`** in `renderers/parsing.py` so XML-style tool parsers no longer mark bare-string argument values as malformed JSON when the parameter schema is a **union that includes `string`** (`anyOf` / `oneOf`), not only when the top-level `type` is `"string"`.
> 
> After `json.loads` fails, the helper now scans union branches for a `string` type and sets **`used_json_fallback`** only when a string outcome is *not* allowed. That stops parsers (Qwen3.5-style XML, GLM, MiniMax, Laguna, etc.) from aggregating a false **`INVALID_JSON`** status on otherwise valid calls—e.g. Pydantic `str | bool` tools where values like `"LIS"` are emitted verbatim in `<arg_value>` tags.
> 
> **`tests/test_tool_arg_type_preservation.py`** adds **`test_union_with_string_emits_ok_status`** (three union shapes × existing renderer matrix) asserting **`ToolCallParseStatus.OK`** and preserved argument values for a bare string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c30dc0f37e3223f9e6bededf0ea104acd76c5e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->