### PR TITLE
Lazy-load concrete renderer classes via PEP 562 __getattr__

### DIFF
--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -59,6 +59,7 @@ from renderers.configs import (
     Qwen3VLRendererConfig,
     RendererConfig,
 )
+
 # Concrete renderer classes are lazy-loaded so that consumers needing
 # only the config layer (``RendererConfig`` discriminated union) — e.g.
 # the slim ``prime-rl-configs`` install path — don't pay the
@@ -103,6 +104,7 @@ def __getattr__(name: str):
 
 def __dir__() -> list[str]:
     return sorted(set(globals().keys()) | set(_LAZY_RENDERERS))
+
 
 __all__ = [
     "AutoRendererConfig",

--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -59,20 +59,50 @@ from renderers.configs import (
     Qwen3VLRendererConfig,
     RendererConfig,
 )
-from renderers.deepseek_v3 import DeepSeekV3Renderer
-from renderers.default import DefaultRenderer
-from renderers.glm5 import GLM5Renderer, GLM51Renderer
-from renderers.glm45 import GLM45Renderer
-from renderers.gpt_oss import GptOssRenderer
-from renderers.kimi_k2 import KimiK2Renderer
-from renderers.kimi_k25 import KimiK25Renderer
-from renderers.laguna_xs2 import LagunaXS2Renderer
-from renderers.minimax_m2 import MiniMaxM2Renderer
-from renderers.nemotron3 import Nemotron3Renderer
-from renderers.qwen3 import Qwen3Renderer
-from renderers.qwen3_vl import Qwen3VLRenderer
-from renderers.qwen35 import Qwen35Renderer
-from renderers.qwen36 import Qwen36Renderer
+# Concrete renderer classes are lazy-loaded so that consumers needing
+# only the config layer (``RendererConfig`` discriminated union) — e.g.
+# the slim ``prime-rl-configs`` install path — don't pay the
+# ``transformers`` import cost. Each renderer module does ``from
+# transformers.tokenization_utils import PreTrainedTokenizer`` at module
+# level, so eager imports here would drag ``transformers`` into every
+# downstream ``import renderers``. ``__getattr__`` (PEP 562) resolves
+# the names on first attribute access, so ``from renderers import
+# DefaultRenderer`` and ``renderers.DefaultRenderer`` both work
+# transparently. ``create_renderer`` doesn't depend on these eager
+# imports — ``renderers.base._populate_registry`` lazy-imports the
+# concrete classes itself when a renderer is instantiated.
+_LAZY_RENDERERS: dict[str, str] = {
+    "DeepSeekV3Renderer": "renderers.deepseek_v3",
+    "DefaultRenderer": "renderers.default",
+    "GLM45Renderer": "renderers.glm45",
+    "GLM51Renderer": "renderers.glm5",
+    "GLM5Renderer": "renderers.glm5",
+    "GptOssRenderer": "renderers.gpt_oss",
+    "KimiK25Renderer": "renderers.kimi_k25",
+    "KimiK2Renderer": "renderers.kimi_k2",
+    "LagunaXS2Renderer": "renderers.laguna_xs2",
+    "MiniMaxM2Renderer": "renderers.minimax_m2",
+    "Nemotron3Renderer": "renderers.nemotron3",
+    "Qwen35Renderer": "renderers.qwen35",
+    "Qwen36Renderer": "renderers.qwen36",
+    "Qwen3Renderer": "renderers.qwen3",
+    "Qwen3VLRenderer": "renderers.qwen3_vl",
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_RENDERERS:
+        import importlib
+
+        module = importlib.import_module(_LAZY_RENDERERS[name])
+        value = getattr(module, name)
+        globals()[name] = value  # cache for subsequent lookups
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    return sorted(set(globals().keys()) | set(_LAZY_RENDERERS))
 
 __all__ = [
     "AutoRendererConfig",

--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -61,14 +61,13 @@ from renderers.configs import (
 )
 
 # Concrete renderer classes are lazy-loaded so that consumers needing
-# only the config layer (``RendererConfig`` discriminated union) — e.g.
-# the slim ``prime-rl-configs`` install path — don't pay the
-# ``transformers`` import cost. Each renderer module does ``from
-# transformers.tokenization_utils import PreTrainedTokenizer`` at module
-# level, so eager imports here would drag ``transformers`` into every
-# downstream ``import renderers``. ``__getattr__`` (PEP 562) resolves
-# the names on first attribute access, so ``from renderers import
-# DefaultRenderer`` and ``renderers.DefaultRenderer`` both work
+# only the config layer (``RendererConfig`` discriminated union) don't
+# pay the ``transformers`` import cost. Each renderer module does
+# ``from transformers.tokenization_utils import PreTrainedTokenizer``
+# at module level, so eager imports here would drag ``transformers``
+# into every downstream ``import renderers``. ``__getattr__`` (PEP 562)
+# resolves the names on first attribute access, so ``from renderers
+# import DefaultRenderer`` and ``renderers.DefaultRenderer`` both work
 # transparently. ``create_renderer`` doesn't depend on these eager
 # imports — ``renderers.base._populate_registry`` lazy-imports the
 # concrete classes itself when a renderer is instantiated.


### PR DESCRIPTION
## Summary

- ``renderers/__init__.py`` previously imported every concrete renderer module (``renderers.default``, ``renderers.qwen3``, …) at load time. Each does ``from transformers.tokenization_utils import PreTrainedTokenizer`` at the top, so plain ``import renderers`` always pulled ``transformers`` into ``sys.modules``.
- That blocked light-import callers — most visibly ``prime-rl-configs``'s slim-install gate, which only needs the ``RendererConfig`` discriminated union from ``renderers.configs`` (no heavy deps).
- Defer the concrete-class imports to a module-level ``__getattr__`` (PEP 562). Configs and base symbols stay eager; ``from renderers import DefaultRenderer`` still works but only loads ``renderers.default`` (and hence ``transformers``) on first attribute access. ``create_renderer`` is unaffected — ``renderers.base._populate_registry`` already lazy-imports the concrete classes when a renderer is instantiated.

## Test plan

- [x] ``from renderers import RendererConfig`` no longer pulls ``transformers`` into ``sys.modules``
- [x] ``renderers.DefaultRenderer`` (and every other concrete class) still resolves; ``transformers`` loads on first access
- [x] Unknown attribute raises ``AttributeError`` with the standard message
- [x] Full test suite: 1544 passed, 53 skipped, 1 xfailed (no regressions)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-package import wiring with no logic changes to rendering or registry behavior; public API and `create_renderer` paths stay the same aside from deferred heavy imports.
> 
> **Overview**
> **`renderers/__init__.py` no longer eagerly imports every concrete renderer module**, so a plain `import renderers` (for configs, base types, `create_renderer`, etc.) does not transitively load `transformers` until something actually needs a renderer class.
> 
> Fifteen top-level renderer imports are replaced with a **`_LAZY_RENDERERS` name → submodule map** and **PEP 562 `__getattr__` / `__dir__`**: the first `from renderers import DefaultRenderer` (or `renderers.Qwen3Renderer`, etc.) runs `importlib.import_module`, caches the class on the package, and only then pulls in that submodule’s `transformers` dependency. **`__all__` and the public names stay the same**; unknown attributes still raise a normal `AttributeError`.
> 
> **`create_renderer` behavior is unchanged** — it still relies on `renderers.base._populate_registry()` to import concrete classes when a renderer is instantiated, not on the package `__init__` eager imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc43e11216df5a125e3c9d8c39c64eb401e3518f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lazy-load concrete renderer classes in `renderers/__init__.py` via PEP 562 `__getattr__`
> Replaces eager imports of concrete renderer classes with on-demand loading using a `_LAZY_RENDERERS` name-to-module mapping. A module-level `__getattr__` imports and caches the class on first access; `__dir__` advertises all lazy names upfront. This reduces import-time overhead for any code that imports from the `renderers` package without using every renderer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized dc43e11.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->