### PR TITLE
fix(nemotron3): forward tools to parse_qwen35 for schema-aware coercion

### DIFF
--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -430,7 +430,7 @@ class Nemotron3Renderer:
         self,
         token_ids: list[int],
         *,
-        tools: list[ToolSpec] | None = None,  # noqa: ARG002 — args land in a JSON object, schema not needed
+        tools: list[ToolSpec] | None = None,
     ) -> ParsedResponse:
         stop_ids = {self._im_end}
         if self._endoftext is not None:
@@ -443,6 +443,7 @@ class Nemotron3Renderer:
             think_end_id=self._think_end,
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
+            tools=tools,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/tests/test_tool_arg_type_preservation.py
+++ b/tests/test_tool_arg_type_preservation.py
@@ -26,7 +26,7 @@ import pytest
 
 
 # (HuggingFace model name, renderer name). Two JSON-shaped controls
-# (string types already preserved by the wire format) + four XML-style
+# (string types already preserved by the wire format) + five XML-style
 # parsers that rely on the schema to preserve them.
 _MODELS = [
     ("Qwen/Qwen3-8B", "auto"),  # hermes JSON  — control
@@ -35,6 +35,7 @@ _MODELS = [
     ("zai-org/GLM-5", "auto"),  # XML
     ("MiniMaxAI/MiniMax-M2.5", "auto"),  # XML
     ("poolside/Laguna-XS.2", "auto"),  # XML
+    ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "auto"),  # XML
 ]
 
 


### PR DESCRIPTION
## Summary

`Nemotron3Renderer.parse_response` accepted `tools` but didn't forward it to `parse_qwen35`, with a `# noqa: ARG002 — args land in a JSON object, schema not needed` comment. The comment is wrong for Nemotron3's actual wire format, which is identical XML to Qwen3.5 (`<tool_call><function=name><parameter=k>v</parameter>...`).

## Why it wasn't surfacing

Pre-fix, the no-schema branch of `_coerce_arg_value` did an opportunistic `json.loads` with a raw-text fallback, so numeric/boolean args were recovered by accident from raw `<parameter=>` strings. With #52's vLLM-parity refactor in flight (no schema → verbatim string, matching vLLM's `extract_types_from_schema(None) → ["string"]`), every Nemotron3 tool-call arg would silently become a string. Cursor Bugbot flagged this on #52.

## The fix

One line: drop the `# noqa`, add `tools=tools` to the `parse_qwen35` call. That routes Nemotron3 through the same schema-aware coercion the other five XML renderers (Qwen3.5/3.6, GLM-4.5/5, MiniMax-M2, Laguna-XS.2) already use — which is what vLLM does for the same wire format via its shared `qwen3_coder` parser (vLLM has no Nemotron-specific tool parser).

## Test plan

- [x] Extends `tests/test_tool_arg_type_preservation.py` to include Nemotron-3-Nano alongside the four existing XML renderers — same string-vs-coerced-type matrix.
- [x] `pytest tests/test_tool_arg_type_preservation.py tests/test_roundtrip.py` — 141 passed, 2 skipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line wiring change in response parsing plus an extended parametrized test; no auth, data, or API surface changes.
> 
> **Overview**
> **Nemotron 3** tool-call parsing now passes the caller’s **`tools`** schema into **`parse_qwen35`**, matching the other XML renderers on the same wire format instead of leaving **`tools`** unused.
> 
> That enables **schema-aware argument coercion** for `<parameter>` values (e.g. keeping declared **`string`** args verbatim when they look like JSON booleans/numbers). Coverage adds **NVIDIA Nemotron-3-Nano** to the shared **`test_tool_arg_type_preservation`** matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092c2049c504c02a5f9ae16b62106be316e6d365. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `Nemotron3Renderer.parse_response` to forward tools to `parse_qwen35` for schema-aware coercion
> - Passes the `tools` argument through to `parse_qwen35` in [nemotron3.py](https://github.com/PrimeIntellect-ai/renderers/pull/65/files#diff-e8a543eb88bcdf53b7ca269b37e492e22a0297a1f30f6db73b6b376cb9ce5a84), enabling schema-aware type coercion of tool call arguments.
> - Adds `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16` to the tool argument type preservation test suite in [test_tool_arg_type_preservation.py](https://github.com/PrimeIntellect-ai/renderers/pull/65/files#diff-a8b4d31bea96c447698c46d3f9af5f11307f136309be083862e18031affbd47a).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 092c204.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->