### PR TITLE
fix(deps): lower openai-harmony floor to >=0.0.4 for SGLang compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,14 @@ dependencies = [
     # Used by GptOssRenderer to render and parse harmony tokens. Vendoring
     # OpenAI's reference implementation keeps us byte-identical with vLLM
     # (which also uses it) and saves us mirroring a 330-line Jinja template.
-    "openai-harmony>=0.0.8",
+    #
+    # Floor is ``>=0.0.4`` (not the latest 0.0.8) on purpose: every SGLang
+    # release through 0.5.12.post1 hard-pins ``openai-harmony==0.0.4``, so a
+    # higher floor makes ``renderers`` uninstallable alongside SGLang. The
+    # GptOssRenderer renders byte-identically on 0.0.4 (verified token-for-token
+    # against 0.0.8) and ``tests/test_gpt_oss_harmony_parity.py`` passes on it,
+    # so the older harmony is safe.
+    "openai-harmony>=0.0.4",
     # Crusoe's Rust BPE tokenizer; ~10x faster encode vs HF's tokenizers.
     # ``load_tokenizer`` patches it in by default for every supported model
     # except a small denylist (DeepSeek-V3 family). The patch is bracketed


### PR DESCRIPTION
## Why

Every SGLang release through the current **0.5.12.post1** hard-pins `openai-harmony==0.0.4` (unconditionally, as a direct dependency). renderers' previous `openai-harmony>=0.0.8` floor therefore made `renderers` and `sglang` **mutually uninstallable** in one environment:

```
Because sglang==0.5.10.post1 depends on openai-harmony==0.0.4 and you require
sglang==0.5.10.post1, we can conclude that you require openai-harmony==0.0.4.
And because renderers depends on openai-harmony>=0.0.8, your requirements are unsatisfiable.
```

This broke the SGLang examples (their inline deps were never satisfiable with `renderers>=0.1.6`) and blocks any downstream driving gpt-oss through SGLang.

## Why it's safe

The `>=0.0.8` floor was set in the initial commit with no stated rationale, and `GptOssRenderer` only uses long-standing harmony APIs. Verified the older harmony is equivalent for our use:

- **Byte-identical render** — a tool-using gpt-oss conversation renders to the exact same 149 token ids (and stop ids) on harmony 0.0.4 vs 0.0.8.
- **Parity suite passes** — `tests/test_gpt_oss_harmony_parity.py` is 7/7 green under 0.0.4.
- **Resolves + installs** — `uv pip install <renderers> sglang==0.5.10.post1 flash-attn-4` now resolves (177 packages) and installs `openai-harmony==0.0.4` alongside renderers.

harmony's published versions are `0.0.1–0.0.4, 0.0.6, 0.0.8`, so `>=0.0.4` still admits the newest.

## Change

One line in `pyproject.toml`: `openai-harmony>=0.0.8` → `openai-harmony>=0.0.4`, with a comment explaining the SGLang constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Packaging-only constraint change with documented parity coverage; no runtime logic changes in this diff.
> 
> **Overview**
> Lowers the **`openai-harmony`** dependency floor from **`>=0.0.8`** to **`>=0.0.4`** so **`renderers`** can install in the same environment as **SGLang** (which pins **`openai-harmony==0.0.4`**).
> 
> **`pyproject.toml`** adds a comment documenting that constraint and that **`GptOssRenderer`** / harmony parity tests are validated on **0.0.4** as well as newer releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b183b33bfcdb3c582f562385c992078f6d7a9ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lower `openai-harmony` minimum version to `>=0.0.4` for SGLang compatibility
> Relaxes the `openai-harmony` floor in [pyproject.toml](https://github.com/PrimeIntellect-ai/renderers/pull/69/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) from `>=0.0.8` to `>=0.0.4` so the dependency resolver can select versions compatible with SGLang. Comments are added to document the rationale and parity verification notes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1b183b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->