### PR TITLE
refactor(qwen3.5): hard-code enable_thinking default per model

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -911,8 +911,8 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     # ``enable_thinking=true`` (open ``<think>\n`` at the gen prompt);
     # the smaller 0.8B / 2B variants flip the polarity (default
     # ``enable_thinking=false``, empty ``<think>\n\n</think>\n\n``).
-    # ``Qwen35Renderer`` auto-detects polarity from the tokenizer's
-    # chat_template at construction, so all seven sizes are
+    # ``Qwen35Renderer`` hard-codes this polarity per model
+    # (``_ENABLE_THINKING_DEFAULTS``), so all seven sizes are
     # token-for-token parity-tested against their own
     # ``apply_chat_template`` — including with
     # ``add_generation_prompt=True``.

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -66,39 +66,44 @@ _TOOLS_INSTRUCTIONS = (
 )
 
 
-def _detect_enable_thinking_default(tokenizer: PreTrainedTokenizer) -> bool:
-    """Probe the tokenizer's chat template to learn its ``enable_thinking``
-    default polarity at the generation-prompt boundary.
+# Per-model ``enable_thinking`` default, applied when the renderer config
+# leaves it ``None``. The Qwen3.5 family ships two chat-template variants
+# that differ only in the polarity of the gated thinking branch:
+#
+#   * Big sizes (4B / 9B / 35B-A3B / 122B-A10B / 397B-A17B) default
+#     ``enable_thinking=true`` — an open ``<think>\n`` at the gen prompt.
+#   * Small sizes (0.8B / 2B) flip it — default ``false``, emitting the
+#     empty ``<think>\n\n</think>\n\n`` block.
+#
+# These are hard-coded (keyed by ``tokenizer.name_or_path``) rather than
+# probed from the live ``chat_template``: probing meant calling
+# ``apply_chat_template`` at construction, which pulls ``transformers`` onto
+# the hot path and breaks bring-your-own-tokenizer use. The values are the
+# ground truth pinned by ``tests/test_qwen35_size_coverage.py`` — both the
+# polarity assertions and byte-parity against each size's own
+# ``apply_chat_template``.
+_ENABLE_THINKING_DEFAULTS: dict[str, bool] = {
+    "Qwen/Qwen3.5-0.8B": False,
+    "Qwen/Qwen3.5-2B": False,
+    "Qwen/Qwen3.5-4B": True,
+    "Qwen/Qwen3.5-9B": True,
+    "Qwen/Qwen3.5-35B-A3B": True,
+    "Qwen/Qwen3.5-122B-A10B": True,
+    "Qwen/Qwen3.5-397B-A17B": True,
+    # Qwen3.6 extends the Qwen3.5 template; same big-size polarity.
+    "Qwen/Qwen3.6-35B-A3B": True,
+}
 
-    The Qwen3.5 family ships two template variants that differ only in the
-    polarity of the gated branch:
 
-    * Big sizes (4B / 9B / 35B-A3B / 122B-A10B / 397B-A17B) emit an open
-      ``<think>\\n`` by default and the empty ``<think>\\n\\n</think>\\n\\n``
-      block when ``enable_thinking`` is explicitly false.
-    * Small sizes (0.8B / 2B) flip the polarity — they emit the empty
-      block by default and the open ``<think>\\n`` only when
-      ``enable_thinking`` is explicitly true.
+def _default_enable_thinking(tokenizer) -> bool:
+    """Hard-coded ``enable_thinking`` default for ``tokenizer``'s model.
 
-    A one-shot ``apply_chat_template`` call with no flag and a minimal
-    user message reveals which variant is in use: the empty-block tail
-    ends with ``</think>``, the open-think tail does not. Failing the
-    probe (no chat_template, exotic config) falls back to the big-model
-    default of True, which matches every entry in
-    ``MODEL_RENDERER_MAP`` that routes to ``qwen3.5`` without explicit
-    polarity awareness.
+    Falls back to ``True`` (the big-model default, and the majority of the
+    family) for unknown / fine-tuned checkpoints whose ``name_or_path`` isn't
+    in ``_ENABLE_THINKING_DEFAULTS``; pass an explicit ``enable_thinking=`` to
+    a small-size fine-tune that needs ``False``.
     """
-    try:
-        out = tokenizer.apply_chat_template(
-            [{"role": "user", "content": "x"}],
-            tokenize=False,
-            add_generation_prompt=True,
-        )
-    except Exception:
-        return True
-    if not isinstance(out, str):
-        return True
-    return not out.rstrip().endswith("</think>")
+    return _ENABLE_THINKING_DEFAULTS.get(getattr(tokenizer, "name_or_path", ""), True)
 
 
 class Qwen35Renderer:
@@ -116,13 +121,13 @@ class Qwen35Renderer:
         self._tokenizer = tokenizer
         self._processor = processor
         cfg = config or type(self)._config_cls()
-        # ``enable_thinking=None`` defers to the tokenizer's chat-template
-        # default (Instruct → off, Thinking → on). Materialise here so
-        # downstream reads see a concrete bool; rebind the config with
-        # the resolved value so introspection sees the same.
+        # ``enable_thinking=None`` defers to the model's known default (see
+        # ``_ENABLE_THINKING_DEFAULTS``). Materialise here so downstream reads
+        # see a concrete bool; rebind the config with the resolved value so
+        # introspection sees the same.
         if cfg.enable_thinking is None:
             cfg = cfg.model_copy(
-                update={"enable_thinking": _detect_enable_thinking_default(tokenizer)}
+                update={"enable_thinking": _default_enable_thinking(tokenizer)}
             )
         self.config = cfg
 

--- a/tests/test_qwen35_size_coverage.py
+++ b/tests/test_qwen35_size_coverage.py
@@ -5,9 +5,8 @@ Seven Qwen3.5 sizes route to ``Qwen35Renderer``. The 4B / 9B / 35B-A3B /
 ``enable_thinking=true``); the smaller 0.8B / 2B sizes ship the polarity-
 flipped variant (default ``enable_thinking=false`` → empty
 ``<think>\\n\\n</think>\\n\\n`` at the gen-prompt boundary). The renderer
-detects polarity from the tokenizer's chat_template at construction, so
-both variants render byte-identical to their own
-``apply_chat_template``.
+hard-codes this polarity per model (``_ENABLE_THINKING_DEFAULTS``), so
+both variants render byte-identical to their own ``apply_chat_template``.
 
 These tests lock in (a) the exact set of Qwen3.5 sizes in the map and
 (b) byte parity for every one of them across representative
@@ -57,7 +56,7 @@ def test_no_other_qwen35_sizes_silently_added():
 
 
 # ---------------------------------------------------------------------------
-# Polarity auto-detection: 0.8B / 2B flip ``enable_thinking`` default.
+# Polarity defaults: 0.8B / 2B flip ``enable_thinking`` default.
 # ---------------------------------------------------------------------------
 
 
@@ -73,10 +72,10 @@ def test_no_other_qwen35_sizes_silently_added():
         ("Qwen/Qwen3.5-397B-A17B", True),
     ],
 )
-def test_qwen35_enable_thinking_polarity_autodetected(qwen35_model, expected_default):
-    """The renderer's ``_enable_thinking`` resolves to the chat template's
-    own default when no explicit flag is passed — so big / small sizes
-    each match their own template at the gen-prompt boundary."""
+def test_qwen35_enable_thinking_polarity_default(qwen35_model, expected_default):
+    """With no explicit flag, the renderer resolves ``enable_thinking`` from
+    the hard-coded per-model default — so big / small sizes each match their
+    own template at the gen-prompt boundary."""
     tok = load_tokenizer(qwen35_model)
     renderer = create_renderer(tok, Qwen35RendererConfig())
     assert isinstance(renderer, Qwen35Renderer)
@@ -84,6 +83,30 @@ def test_qwen35_enable_thinking_polarity_autodetected(qwen35_model, expected_def
         f"{qwen35_model}: expected enable_thinking default {expected_default}, "
         f"got {renderer.config.enable_thinking}"
     )
+
+
+def test_construction_does_not_call_apply_chat_template():
+    """The ``enable_thinking`` default is hard-coded per model, so building a
+    ``Qwen35Renderer`` must not probe ``apply_chat_template`` — a
+    bring-your-own tokenizer with no chat-template support still works."""
+
+    class _Stub:
+        name_or_path = "Qwen/Qwen3.5-0.8B"
+        unk_token_id = -1
+
+        def convert_tokens_to_ids(self, token):
+            # Any stable non-unk id per token; the renderer only needs the
+            # special tokens to resolve to distinct, in-vocab ids.
+            return abs(hash(token)) % 1_000_000 + 1
+
+        def apply_chat_template(self, *args, **kwargs):
+            raise AssertionError(
+                "apply_chat_template must not be called at construction"
+            )
+
+    renderer = Qwen35Renderer(_Stub())
+    # 0.8B is a small size → thinking defaults off, from the hard-coded table.
+    assert renderer.config.enable_thinking is False
 
 
 # ---------------------------------------------------------------------------
@@ -146,7 +169,7 @@ def test_qwen35_size_parity_with_apply_chat_template(
     """Each in-map Qwen3.5 size renders byte-identical to its own
     ``apply_chat_template`` output. Locks in the property that lets us
     share ``Qwen35Renderer`` across all seven sizes — the polarity
-    flip on 0.8B / 2B is absorbed by the constructor's auto-detect."""
+    flip on 0.8B / 2B is absorbed by the per-model default."""
     tok = load_tokenizer(qwen35_model)
     renderer = create_renderer(tok, Qwen35RendererConfig())
     assert isinstance(renderer, Qwen35Renderer)


### PR DESCRIPTION
## Why

`Qwen35Renderer` resolved its `enable_thinking` default by **probing the tokenizer's chat template at construction**:

```python
if cfg.enable_thinking is None:
    cfg = cfg.model_copy(update={"enable_thinking": _detect_enable_thinking_default(tokenizer)})
# _detect_enable_thinking_default → tokenizer.apply_chat_template(...)
```

Since `Qwen35RendererConfig.enable_thinking` defaults to `None`, this fired on a normal `Qwen35Renderer(tok)` — calling `apply_chat_template` on the hot path. That pulls `transformers` into construction and breaks bring-your-own-tokenizer use (a raw `tokenizers.Tokenizer` has no `apply_chat_template`), which is exactly the dependency we're trying to shed (issue #31).

## What changed

Replaced the probe with a hard-coded table keyed by model name, enumerating every checkpoint routed to the `qwen3.5` / `qwen3.6` renderer:

```python
_ENABLE_THINKING_DEFAULTS = {
    "Qwen/Qwen3.5-0.8B": False,   # small sizes flip polarity → thinking off
    "Qwen/Qwen3.5-2B":   False,
    "Qwen/Qwen3.5-4B":   True,    # big sizes default thinking on
    "Qwen/Qwen3.5-9B":   True,
    "Qwen/Qwen3.5-35B-A3B":   True,
    "Qwen/Qwen3.5-122B-A10B": True,
    "Qwen/Qwen3.5-397B-A17B": True,
    "Qwen/Qwen3.6-35B-A3B":   True,
}
```

Unknown / fine-tuned checkpoints fall back to `True` (the big-model default, matching the old probe's failure fallback); pass an explicit `enable_thinking=` for a small-size fine-tune that needs `False`.

## Validation

- The values are exactly what the probe returned — already pinned by `tests/test_qwen35_size_coverage.py::test_qwen35_enable_thinking_polarity_default` and the **byte-parity** barrage against each size's own `apply_chat_template`. Full size-coverage suite: **37 passed** (all 7 sizes, with/without gen prompt).
- New guard test `test_construction_does_not_call_apply_chat_template`: builds a `Qwen35Renderer` with a stub tokenizer whose `apply_chat_template` raises, and asserts construction succeeds + resolves the right default.
- `ruff` + `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged for mapped models per existing parity tests; risk is limited to unknown fine-tunes that relied on probe vs table fallback (still defaults to True).
> 
> **Overview**
> **`Qwen35Renderer`** no longer calls **`apply_chat_template`** at construction to infer **`enable_thinking`**. When config leaves it **`None`**, defaults now come from **`_ENABLE_THINKING_DEFAULTS`** keyed by **`tokenizer.name_or_path`** (0.8B/2B → **`False`**, larger Qwen3.5 sizes and **`Qwen/Qwen3.6-35B-A3B`** → **`True`**, unknown checkpoints → **`True`**).
> 
> Docs and **`tests/test_qwen35_size_coverage.py`** were updated to describe hard-coded polarity instead of auto-detection, and **`test_construction_does_not_call_apply_chat_template`** asserts a stub tokenizer without chat-template support can still be constructed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45f02d6191c782c9e477b345f036e0c1f5ee782f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace dynamic tokenizer probing with a static lookup for `Qwen35Renderer` `enable_thinking` defaults
> - Removes `_detect_enable_thinking_default`, which called `tokenizer.apply_chat_template` to infer the `enable_thinking` default at construction time.
> - Adds `_ENABLE_THINKING_DEFAULTS`, a module-level dict in [qwen35.py](https://github.com/PrimeIntellect-ai/renderers/pull/71/files#diff-6ffae20154d6e887d44f7b667c5460ca3cf17b23fd5ed2768c0293580cd9f83a) mapping known Qwen3.5/3.6 model names to their correct `enable_thinking` polarity.
> - The new `_default_enable_thinking` helper looks up `tokenizer.name_or_path` in this table, falling back to `True` for unknown or fine-tuned checkpoints.
> - A new test verifies that `Qwen35Renderer` construction no longer calls `apply_chat_template` at all.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 45f02d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->