### PR TITLE
fix(tokenizer): fall back to direct fast-tokenizer load when model config build fails

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1089,7 +1089,6 @@ def _patched_load(model_name_or_path: str, **kwargs):
     path is still discoverable in logs.
     """
     import fastokens
-    from transformers import AutoTokenizer
 
     global _FASTOKENS_ANNOUNCED
 
@@ -1102,11 +1101,70 @@ def _patched_load(model_name_or_path: str, **kwargs):
             )
             _FASTOKENS_ANNOUNCED = True
     try:
-        return AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
+        return _load_tokenizer_via_auto(model_name_or_path, **kwargs)
     finally:
         with _FASTOKENS_PATCH_LOCK:
             with contextlib.redirect_stdout(io.StringIO()):
                 fastokens.unpatch_transformers()
+
+
+def _load_fast_tokenizer_directly(
+    model_name_or_path: str, revision: str | None
+) -> Any | None:
+    """Load a self-contained fast tokenizer without building the model config.
+
+    ``AutoTokenizer.from_pretrained`` eagerly constructs the *model* config to
+    resolve the tokenizer class — even for a plain ``PreTrainedTokenizerFast``.
+    That construction can raise on modeling-only concerns the tokenizer never
+    needs (e.g. RoPE parameter validation for configs that carry nested
+    ``rope_parameters``). When the repo ships a complete ``tokenizer.json`` and
+    declares no custom tokenizer, the tokenizer is fully self-describing, so we
+    load it directly and skip the config detour.
+
+    Returns ``None`` when there's nothing safe to load this way — a custom
+    ``auto_map`` tokenizer (which must run through ``AutoTokenizer`` with
+    ``trust_remote_code``) or no fast tokenizer at all — so the caller can
+    surface its original error instead.
+    """
+    from transformers import PreTrainedTokenizerFast
+    from transformers.models.auto.tokenization_auto import get_tokenizer_config
+
+    try:
+        if "auto_map" in get_tokenizer_config(model_name_or_path, revision=revision):
+            return None
+        return PreTrainedTokenizerFast.from_pretrained(
+            model_name_or_path, revision=revision
+        )
+    except Exception:
+        return None
+
+
+def _load_tokenizer_via_auto(model_name_or_path: str, **kwargs) -> Any:
+    """``AutoTokenizer.from_pretrained`` with a config-free fallback.
+
+    renderers needs the tokenizer, not the model. If ``AutoTokenizer`` fails
+    while building the model config it loads to resolve the tokenizer class,
+    retry by loading the repo's self-contained ``tokenizer.json`` directly. The
+    original error is re-raised if the repo has no such tokenizer.
+    """
+    from transformers import AutoTokenizer
+
+    try:
+        return AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
+    except Exception as exc:
+        tok = _load_fast_tokenizer_directly(
+            model_name_or_path, revision=kwargs.get("revision")
+        )
+        if tok is None:
+            raise
+        logger.debug(
+            "AutoTokenizer.from_pretrained(%r) failed building the model config "
+            "(%s: %s); loaded the tokenizer directly from tokenizer.json.",
+            model_name_or_path,
+            type(exc).__name__,
+            str(exc)[:160],
+        )
+        return tok
 
 
 def load_tokenizer(
@@ -1138,9 +1196,14 @@ def load_tokenizer(
     fastokens raises during the patched load (e.g. an unknown
     pre-tokenizer type), we automatically retry with the vanilla
     backend and emit an INFO log.
-    """
-    from transformers import AutoTokenizer
 
+    ``AutoTokenizer.from_pretrained`` eagerly builds the model config to
+    resolve the tokenizer class. If that construction raises on a
+    modeling-only concern the tokenizer doesn't need (e.g. RoPE
+    validation for configs with nested ``rope_parameters``), we fall
+    back to loading the repo's self-contained ``tokenizer.json``
+    directly — see ``_load_tokenizer_via_auto``.
+    """
     kwargs: dict[str, Any] = {}
     revision = TRUSTED_REVISIONS.get(model_name_or_path)
     if revision is not None:
@@ -1149,7 +1212,7 @@ def load_tokenizer(
         kwargs = {"trust_remote_code": False}
 
     if not use_fastokens or model_name_or_path in FASTOKENS_INCOMPATIBLE:
-        return AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
+        return _load_tokenizer_via_auto(model_name_or_path, **kwargs)
 
     try:
         return _patched_load(model_name_or_path, **kwargs)
@@ -1162,7 +1225,7 @@ def load_tokenizer(
             type(exc).__name__,
             str(exc)[:160],
         )
-        return AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
+        return _load_tokenizer_via_auto(model_name_or_path, **kwargs)
 
 
 def _populate_registry():


### PR DESCRIPTION
## Problem

Loading a tokenizer for **poolside/Laguna-XS.2** (and any model with nested per-layer `rope_parameters`) crashes renderers:

```
KeyError: "Missing required keys in `rope_parameters` for 'rope_type'='default': {'rope_theta'}"
```

The cause is entirely a **modeling-layer** concern leaking into tokenizer loading:

- `AutoTokenizer.from_pretrained` *always* constructs the **model config** first (to resolve the tokenizer class) — even for a plain `PreTrainedTokenizerFast`.
- Building Laguna's config runs HF's RoPE validator. Laguna's `rope_parameters` are nested (`full_attention` / `sliding_attention`) with no top-level `rope_theta`. vLLM's `patch_rope_parameters` injects `rope_theta` via `standardize_rope_params()` before validating, so vLLM loads fine — but plain transformers validates during `__init__` *without* that step and raises.
- `AutoTokenizer` only catches `ValueError`/`OSError`, so the `KeyError` escapes and kills the load.

renderers needs the **tokenizer**, not the model — it should never have been dragged through RoPE validation.

## Fix

When `AutoTokenizer.from_pretrained` fails while building the model config, fall back to loading the repo's self-contained `tokenizer.json` directly via `PreTrainedTokenizerFast`, which never touches the model config. The fallback:

- is **modeling-agnostic** — no Laguna/RoPE-specific knowledge, just "if the model config blew up but the tokenizer is self-describing, load it directly";
- runs **under the fastokens patch**, so Laguna keeps the Rust fast-path speedup (verified: backend is the fastokens shim, encode output byte-identical to vanilla);
- **excludes custom `auto_map` tokenizers** (e.g. Kimi-K2), which must keep going through `AutoTokenizer` + `trust_remote_code`;
- **re-raises the original error** if there's no usable fast tokenizer, so genuine failures still surface.

Laguna now loads via the fastokens fast path and routes to `LagunaXS2Renderer`, with a single clear INFO line and no misleading "fastokens could not load" warning.

## Verification

- `poolside/Laguna-XS.2`: `load_tokenizer` → fastokens-backed `TokenizersBackend`, `create_renderer` → `LagunaXS2Renderer`, encode matches vanilla.
- `Qwen/Qwen3-0.6B` and the existing `tests/test_load_tokenizer_fastokens.py` suite (9 tests): no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes central tokenizer loading for every model; behavior is gated on `auto_map` and re-raises when no fast tokenizer exists, but broad `except` on the fallback path could mask unrelated load failures in edge cases.
> 
> **Overview**
> Tokenizer loading no longer dies when **Hugging Face builds the model config** during `AutoTokenizer.from_pretrained` (e.g. RoPE validation on **poolside/Laguna-XS.2**). A shared **`_load_tokenizer_via_auto`** wrapper tries `AutoTokenizer` first; on failure it loads **`PreTrainedTokenizerFast`** from **`tokenizer.json`** via **`_load_fast_tokenizer_directly`**, skipping config construction when the repo has no custom **`auto_map`** tokenizer.
> 
> **`_patched_load`** and all **`load_tokenizer`** paths (vanilla, fastokens, fastokens fallback) now go through that wrapper so the fallback applies under the fastokens patch too. Custom remote tokenizers still require **`AutoTokenizer`**; if direct load isn’t safe, the **original exception** is re-raised.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30655d6e7b3aa1fe36baf8a4e49edea0650c2d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tokenizer loading to fall back to direct `tokenizer.json` load when `AutoTokenizer` fails
> - Adds `_load_fast_tokenizer_directly` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/72/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) to load a `PreTrainedTokenizerFast` straight from `tokenizer.json`, bypassing model config construction.
> - Adds `_load_tokenizer_via_auto` as a wrapper around `AutoTokenizer.from_pretrained` that catches failures and retries via the new direct loader, re-raising the original exception only if the fallback also fails.
> - Updates `load_tokenizer` and `_patched_load` to use `_load_tokenizer_via_auto` so the fallback applies in all tokenizer load paths.
> - The direct fallback is skipped if the tokenizer config declares an `auto_map` entry, since those require the full model config.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 30655d6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->