### PR TITLE
fix(tokenizer): apply config-build fallback to offset tokenizer too

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1587,7 +1587,6 @@ def _get_offset_tokenizer(tokenizer):
         cached = _offset_tokenizers.get(name_or_path)
         if cached is not None:
             return cached
-        from transformers import AutoTokenizer
 
         kwargs: dict[str, Any] = {}
         revision = TRUSTED_REVISIONS.get(name_or_path)
@@ -1597,10 +1596,12 @@ def _get_offset_tokenizer(tokenizer):
             kwargs = {"trust_remote_code": False}
         # Explicitly vanilla — we want HF's Rust tokenizer with offset
         # tracking, not the fastokens shim. ``load_tokenizer`` would
-        # patch fastokens in by default; calling
-        # ``AutoTokenizer.from_pretrained`` directly here keeps the
-        # fastokens patch out of this code path entirely.
-        offset_tok = AutoTokenizer.from_pretrained(name_or_path, **kwargs)
+        # patch fastokens in by default; routing through
+        # ``_load_tokenizer_via_auto`` keeps the fastokens patch out
+        # of this code path while still applying the config-build
+        # fallback (RoPE-validation failures on nested
+        # ``rope_parameters``, etc.).
+        offset_tok = _load_tokenizer_via_auto(name_or_path, **kwargs)
         if not getattr(offset_tok, "is_fast", False):
             raise RuntimeError(
                 f"Vanilla tokenizer for {name_or_path!r} is not a fast "


### PR DESCRIPTION
## Problem

#72 wired `_load_fast_tokenizer_directly` into `_load_tokenizer_via_auto` so `load_tokenizer` survives model-config build failures (e.g. HF RoPE validation rejecting nested `rope_parameters` for `poolside/Laguna-XS.2`).

But `_get_offset_tokenizer` was calling `AutoTokenizer.from_pretrained` directly to keep the fastokens patch out of this path — bypassing the fallback entirely.

That meant every hand-coded renderer (`LagunaXS2`, `Qwen35`, ...) still crashed on the first rollout for Laguna-family models, with the same `KeyError` #72 was meant to fix:

```
LagunaXS2Renderer.render
 → emit_text_segments
 → attribute_text_segments
 → _get_offset_tokenizer
 → AutoTokenizer.from_pretrained
 → HF RoPE validator
 → KeyError("Missing required keys in `rope_parameters` for 'rope_type'='default': {'rope_theta'}")
```

This bypass is also why disabling renderers made the symptom go away on hosted-rl: the offset-tokenizer path is only hit when a hand-coded renderer is in use.

## Fix

Route the offset-tokenizer load through `_load_tokenizer_via_auto`. Same vanilla path (no fastokens patching, since that helper doesn't apply it), but now the `_load_fast_tokenizer_directly` fallback runs when the model config build fails.

## Verification

Reproduced end-to-end against `poolside/Laguna-XS.2` with prime-rl + `reverse-text`:

- **Without this patch** — every rollout aborts with `ModelError() -> KeyError("Missing required keys in 'rope_parameters' for 'rope_type'='default': {'rope_theta'}")`.
- **With this patch** — rollouts succeed; first two RL steps complete cleanly:
  - Step 0: reward 0.3553, 97.9 tok/sample
  - Step 1: reward 0.3116, 110.8 tok/sample

(The run then OOMs on the trainer side at step 2, which is an unrelated single-GPU FSDP capacity issue with the 256-expert Laguna model.)

## Follow-up worth a separate issue

For hand-coded renderers, the bulk of message-body tokenization goes through `attribute_text_segments` → vanilla offset tokenizer, not through the fastokens-patched main tokenizer. fastokens only helps decode + the few `_encode` calls that don't need offsets. Worth considering whether to skip fastokens entirely for hand-coded renderers (`load_tokenizer(..., use_fastokens=False)`) and avoid keeping two tokenizer copies in memory. Not in scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Apply config-build fallback to `_get_offset_tokenizer` in renderer base
> Routes tokenizer instantiation in `_get_offset_tokenizer` through `_load_tokenizer_via_auto` instead of calling `AutoTokenizer.from_pretrained` directly, bringing it in line with the main tokenizer loading path. This ensures the config-build fallback is available when loading offset tokenizers, while still requiring the result to be a fast tokenizer with `offset_mapping` support.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0435d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single call-site change in tokenizer loading for offset attribution; aligns with an existing tested fallback path and does not alter fastokens or main `load_tokenizer` behavior.
> 
> **Overview**
> **`_get_offset_tokenizer`** no longer calls **`AutoTokenizer.from_pretrained`** directly. It now loads the vanilla, offset-capable tokenizer through **`_load_tokenizer_via_auto`**, same trust/revision kwargs as before.
> 
> That keeps this path **without fastokens** (still not **`load_tokenizer`**) but applies the **config-build fallback** used elsewhere: when HF fails building the model config (e.g. Laguna **`rope_parameters`** / missing **`rope_theta`**), loading can succeed via **`tokenizer.json`** instead. Hand-coded renderers that depend on **`attribute_text_segments`** / offset mapping were still crashing on those models because the offset path skipped that fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0435d420324e90511841589a53143f51ba7a86f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->