### PR TITLE
feat(nemotron3): add Nemotron-3 Ultra chat-template variant

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1037,9 +1037,14 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     "moonshotai/Kimi-K2-Instruct": "kimi-k2",
     "moonshotai/Kimi-K2.5": "kimi-k2.5",
     "moonshotai/Kimi-K2.6": "kimi-k2.5",
-    # Nemotron 3.
+    # Nemotron 3. Nano / Super share one chat-template variant; the Ultra
+    # checkpoints use the Ultra variant — the renderer auto-selects it from
+    # the model name (see ``nemotron3._ULTRA_DEFAULTS``). BF16 and FP8 share the
+    # same tokenizer and template.
     "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "nemotron-3",
     "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": "nemotron-3",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": "nemotron-3",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8": "nemotron-3",
     # Poolside Laguna.
     "poolside/Laguna-XS.2": "laguna-xs.2",
     # GPT-OSS.

--- a/renderers/configs.py
+++ b/renderers/configs.py
@@ -337,12 +337,41 @@ class Nemotron3RendererConfig(BaseRendererConfig):
     """When ``True``, the generation prompt includes ``<think>``. Mirrors
     the chat template's ``enable_thinking`` kwarg."""
 
+    ultra: bool | None = None
+    """Select the Nemotron-3 **Ultra** chat-template variant.
+
+    ``None`` (default) auto-detects from the model name (see
+    ``renderers.nemotron3._ULTRA_DEFAULTS``): the Ultra checkpoints resolve
+    to ``True``; Nano / Super and unknown checkpoints to ``False``. Set
+    explicitly to force a variant — e.g. an Ultra fine-tune or a
+    locally-pathed checkpoint whose ``name_or_path`` isn't in the table.
+
+    Ultra's template differs from Nano/Super: the reasoning block is glued
+    as ``<think>\\n{reasoning}</think>{content}`` (no ``\\n`` around
+    ``</think>``), truncated historical turns collapse to
+    ``<think></think>{content}`` (no ``\\n``), and the thinking-truncation
+    boundary follows the template's ``loop.index0 < last_user_idx`` rule
+    (drop thinking on every assistant turn before the last user message).
+
+    Not a chat-template kwarg — it picks which template the renderer
+    mirrors, not a variable passed into one — so it's listed in
+    ``_internal_fields`` and excluded from ``template_field_names()``."""
+
     truncate_history_thinking: bool = True
     """When ``False``, keep ``<think>{reasoning}</think>`` on past-cycle
     assistant turns instead of dropping them. Mirrors the chat
     template's ``truncate_history_thinking`` toggle. OR-composes with
     ``preserve_all_thinking`` / ``preserve_thinking_between_tool_calls``
     — see :class:`BaseRendererConfig` for the contract."""
+
+    # ``ultra`` is a template-variant SELECTOR — it picks which template the
+    # renderer mirrors (Ultra vs Nano/Super), not a variable passed into one;
+    # there is no ``ultra`` Jinja variable. Marked internal so the parity
+    # matrix doesn't cross it as a template field. Same ``_internal_fields``
+    # mechanism DeepSeek-V3 uses for its no-op ``enable_thinking``, for a
+    # different underlying reason (theirs is an ignored kwarg, this is a
+    # variant switch).
+    _internal_fields = frozenset({"ultra"})
 
 
 class DeepSeekV3RendererConfig(BaseRendererConfig):

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -75,6 +75,35 @@ def _render_extra_keys(obj: dict[str, Any], handled_keys: set[str]) -> list[str]
     return lines
 
 
+# Per-model ``ultra`` default, applied when the renderer config leaves it
+# ``None``. The Nemotron-3 family ships two chat-template variants: Nano /
+# Super share one; Ultra differs in the reasoning-block glue (no ``\n`` around
+# ``</think>``) and the thinking-truncation boundary (drop thinking on every
+# assistant turn before the last user message). BF16 and FP8 share the same
+# tokenizer and template. Hard-coded keyed by
+# ``tokenizer.name_or_path`` rather than probed from the live template — the
+# same convention as Qwen3.5's ``_ENABLE_THINKING_DEFAULTS`` (avoids pulling
+# ``apply_chat_template`` onto the construction hot path and keeps
+# bring-your-own-tokenizer use working).
+_ULTRA_DEFAULTS: dict[str, bool] = {
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": False,
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": False,
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": True,
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8": True,
+}
+
+
+def _default_ultra(tokenizer) -> bool:
+    """Hard-coded ``ultra`` default for ``tokenizer``'s model.
+
+    Falls back to ``False`` (the Nano / Super template, and the majority of
+    the family) for unknown / fine-tuned checkpoints whose ``name_or_path``
+    isn't in ``_ULTRA_DEFAULTS`` — pass an explicit ``ultra=True`` for an
+    Ultra fine-tune or a locally-pathed Ultra checkpoint.
+    """
+    return _ULTRA_DEFAULTS.get(getattr(tokenizer, "name_or_path", ""), False)
+
+
 class Nemotron3Renderer:
     """Deterministic message → token renderer for Nemotron 3 models."""
 
@@ -84,7 +113,14 @@ class Nemotron3Renderer:
         config: Nemotron3RendererConfig | None = None,
     ):
         self._tokenizer = tokenizer
-        self.config = config or Nemotron3RendererConfig()
+        cfg = config or Nemotron3RendererConfig()
+        # ``ultra=None`` defers to the model's known default (see
+        # ``_ULTRA_DEFAULTS``). Materialise here so downstream reads see a
+        # concrete bool; rebind the frozen config with the resolved value so
+        # introspection sees the same.
+        if cfg.ultra is None:
+            cfg = cfg.model_copy(update={"ultra": _default_ultra(tokenizer)})
+        self.config = cfg
 
         # Look up special token IDs from the tokenizer (not hardcoded).
         # <|endoftext|> is optional: Nemotron-3 Nano / Super tokenizers ship
@@ -335,6 +371,17 @@ class Nemotron3Renderer:
                 last_plain_assistant_idx = j
                 break
 
+        # Ultra truncates thinking on every assistant turn *before the last
+        # user message* (template rule ``loop.index0 < last_user_idx``),
+        # whereas Nano/Super preserve only the last plain assistant. Compute
+        # the last-user index over the normalized ``messages`` list (a leading
+        # system never holds a user, so the relative comparison is unaffected).
+        last_user_idx_norm = -1
+        for j in range(len(messages) - 1, -1, -1):
+            if messages[j].get("role") == "user":
+                last_user_idx_norm = j
+                break
+
         # ── 2. Iterate messages ─────────────────────────────────────
         for i, msg in enumerate(messages):
             role = msg["role"]
@@ -360,7 +407,10 @@ class Nemotron3Renderer:
                 emit_text("\n", msg_orig_idx, is_sampled=False, is_content=False)
 
             elif role == "assistant":
-                is_last_turn = i >= last_plain_assistant_idx
+                if self.config.ultra:
+                    is_last_turn = i >= last_user_idx_norm
+                else:
+                    is_last_turn = i >= last_plain_assistant_idx
                 preserve_thinking = msg_orig_idx >= 0 and should_preserve_past_thinking(
                     original_messages,
                     msg_orig_idx,
@@ -617,6 +667,7 @@ class Nemotron3Renderer:
             content = after_think_end.lstrip("\n")
 
         reasoning_content = reasoning_content.strip()
+        ultra = self.config.ultra
 
         # ``<|im_start|>assistant\n`` is template-injected scaffolding —
         # at inference the chat template emits these as the generation
@@ -645,28 +696,36 @@ class Nemotron3Renderer:
             or not self.config.truncate_history_thinking
         ):
             emit_special(self._think, msg_idx, is_sampled=True, is_content=True)
+            # Ultra: <think>\n{reasoning}</think>{content} (no \n around </think>).
+            # Nano/Super: <think>\n{reasoning}\n</think>\n{content}.
             emit_text(
-                "\n" + reasoning_content + "\n",
+                ("\n" + reasoning_content)
+                if ultra
+                else ("\n" + reasoning_content + "\n"),
                 msg_idx,
                 is_sampled=True,
                 is_content=True,
             )
             emit_special(self._think_end, msg_idx, is_sampled=True, is_content=True)
-            # Single \n separator (not \n\n like Qwen3.5)
+            # Single \n separator (not \n\n like Qwen3.5); Ultra glues directly.
             emit_text(
-                "\n" + content + content_suffix,
+                (content + content_suffix)
+                if ultra
+                else ("\n" + content + content_suffix),
                 msg_idx,
                 is_sampled=True,
                 is_content=True,
             )
         elif reasoning_content:
-            # Historical assistant whose reasoning got stripped — template
-            # keeps a single \n between the collapsed <think></think> and
-            # the content as a marker that reasoning existed.
+            # Historical assistant whose reasoning got stripped. Nano/Super keep
+            # a single \n between the collapsed <think></think> and the content
+            # as a marker that reasoning existed; Ultra glues content directly.
             emit_special(self._think, msg_idx, is_sampled=True, is_content=True)
             emit_special(self._think_end, msg_idx, is_sampled=True, is_content=True)
             emit_text(
-                "\n" + content + content_suffix,
+                (content + content_suffix)
+                if ultra
+                else ("\n" + content + content_suffix),
                 msg_idx,
                 is_sampled=True,
                 is_content=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,8 @@ RENDERER_MODELS = [
     ("moonshotai/Kimi-K2.6", "auto"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "auto"),
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "auto"),
+    # Ultra resolves the Ultra template variant via name (auto → ultra=True).
+    ("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16", "auto"),
     ("poolside/Laguna-XS.2", "auto"),
     ("openai/gpt-oss-20b", "gpt-oss"),
     ("Qwen/Qwen2.5-0.5B-Instruct", "default"),

--- a/tests/test_nemotron3_ultra.py
+++ b/tests/test_nemotron3_ultra.py
@@ -1,0 +1,59 @@
+"""Offline wiring tests for the Nemotron-3 Ultra template variant.
+
+Assert the name-based ``ultra`` auto-selection, the model→renderer mapping,
+and the typed-config surface WITHOUT loading any tokenizer (no network). This
+pins the wiring the parity matrix can't reach — in particular the FP8 entry,
+which no test loads a tokenizer for — so it can't silently rot.
+"""
+
+from types import SimpleNamespace
+
+from renderers.base import MODEL_RENDERER_MAP
+from renderers.configs import Nemotron3RendererConfig
+from renderers.nemotron3 import _ULTRA_DEFAULTS, _default_ultra
+
+_ULTRA_REPOS = [
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",
+]
+_NON_ULTRA_REPOS = [
+    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
+    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16",
+]
+
+
+def _fake_tok(name):
+    return SimpleNamespace(name_or_path=name)
+
+
+def test_ultra_and_non_ultra_models_map_to_nemotron3():
+    for repo in _ULTRA_REPOS + _NON_ULTRA_REPOS:
+        assert MODEL_RENDERER_MAP.get(repo) == "nemotron-3", repo
+
+
+def test_default_ultra_resolves_by_name():
+    # Ultra checkpoints (incl. the gated FP8 repo) resolve True.
+    for repo in _ULTRA_REPOS:
+        assert _ULTRA_DEFAULTS[repo] is True
+        assert _default_ultra(_fake_tok(repo)) is True
+    # Nano / Super resolve False (the shared Nano/Super template).
+    for repo in _NON_ULTRA_REPOS:
+        assert _default_ultra(_fake_tok(repo)) is False
+    # Unknown / fine-tuned / local-path checkpoints fall back to False;
+    # those must pass an explicit ultra= if they need the Ultra template.
+    assert _default_ultra(_fake_tok("acme/my-nemotron-ultra-ft")) is False
+    assert _default_ultra(_fake_tok("/home/user/local-ckpt")) is False
+    assert _default_ultra(SimpleNamespace()) is False  # no name_or_path attr
+
+
+def test_ultra_is_not_a_template_kwarg():
+    fields = Nemotron3RendererConfig.template_field_names()
+    assert "ultra" not in fields
+    assert fields == frozenset({"enable_thinking", "truncate_history_thinking"})
+    assert "ultra" in Nemotron3RendererConfig._internal_fields
+
+
+def test_ultra_config_default_is_none_and_overridable():
+    assert Nemotron3RendererConfig().ultra is None  # None => auto-detect by name
+    assert Nemotron3RendererConfig(ultra=True).ultra is True
+    assert Nemotron3RendererConfig(ultra=False).ultra is False

--- a/tests/test_renderer_config_parity.py
+++ b/tests/test_renderer_config_parity.py
@@ -55,6 +55,9 @@ _RENDERER_MODELS = [
     ("moonshotai/Kimi-K2.6", "auto"),
     ("deepseek-ai/DeepSeek-V3", "auto"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "auto"),
+    # Ultra: auto-resolves to the Ultra template variant (ultra=True) via the
+    # model name; parity asserted against the Ultra apply_chat_template.
+    ("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16", "auto"),
     ("poolside/Laguna-XS.2", "auto"),
     ("openai/gpt-oss-20b", "gpt-oss"),
 ]

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -43,6 +43,9 @@ _ROUNDTRIP_MODELS = [
     ("moonshotai/Kimi-K2.6", "auto"),
     ("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16", "auto"),
     ("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16", "auto"),
+    # Ultra: parse must recover content after a </think> glued directly to it
+    # (no separating newline) — the Ultra-specific glue stresses the round-trip.
+    ("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16", "auto"),
     ("poolside/Laguna-XS.2", "auto"),
     ("openai/gpt-oss-20b", "gpt-oss"),
     ("Qwen/Qwen2.5-0.5B-Instruct", "default"),


### PR DESCRIPTION
## Summary

Adds the **Nemotron-3 Ultra** chat-template variant to the `nemotron-3` renderer. Ultra's template differs from Nano/Super in three ways:

- **Reasoning glue**: `<think>\n{reasoning}</think>{content}` — no `\n` around `</think>` (Nano/Super use `<think>\n{reasoning}\n</think>\n{content}`).
- **Historical truncation**: dropped-reasoning turns collapse to `<think></think>{content}` with no separating `\n`.
- **Truncation boundary**: thinking is dropped on every assistant turn *before the last user message* (the template's `loop.index0 < last_user_idx` rule), rather than preserving only the last plain assistant.

## Changes

- `Nemotron3RendererConfig.ultra: bool | None = None` — `None` auto-detects the variant from the model name. Marked `_internal_fields` (it selects a template *variant*, not a Jinja kwarg), so the parity matrix doesn't cross it as a template field.
- Variant auto-selected from `tokenizer.name_or_path` via `_ULTRA_DEFAULTS` + `_default_ultra`, materialized in `__init__` — mirrors Qwen3.5's `_ENABLE_THINKING_DEFAULTS`. Unknown / fine-tuned / local-path checkpoints fall back to the Nano/Super template; pass an explicit `ultra=` to override.
- Ultra BF16 + FP8 checkpoints mapped to the `nemotron-3` renderer in `MODEL_RENDERER_MAP`.
- Ultra added to the config-parity, shared-barrage (`conftest`), and roundtrip test matrices (BF16 as the representative), plus an offline test pinning the name-based selection and the model→renderer mapping.

## Validation

Token-parity verified against the canonical Ultra `apply_chat_template` across system / no-system, reasoning, multi-turn truncation, tool-call (including consecutive tool results and varied argument types), and generation-prompt shapes, with `enable_thinking` and `truncate_history_thinking` both toggled. Nano/Super behavior is unchanged — the Ultra branches are gated on the resolved flag, which is `False` for them.

CI uses BF16 as the Ultra representative; BF16 and FP8 share the same tokenizer and template.

> Pre-existing renderer content-normalization behaviors (e.g. inline `<think>…</think>` inside `content` rather than `reasoning_content`, and whitespace stripping of message content) are unchanged by this PR and apply identically to Nano/Super — out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tokenization and history-thinking rules for Ultra checkpoints; incorrect `ultra` resolution would break HF template parity and round-trips, though Nano/Super paths stay gated on `ultra=False`.
> 
> **Overview**
> Adds **Nemotron-3 Ultra** as a second chat-template variant on the existing `nemotron-3` renderer, selected by `Nemotron3RendererConfig.ultra` (auto from `tokenizer.name_or_path` via `_ULTRA_DEFAULTS`, overridable explicitly).
> 
> **Ultra vs Nano/Super behavior** when `ultra=True`: historical thinking is dropped on assistant turns before the **last user** message (not only before the last plain assistant); reasoning blocks glue as `{content}` **without** separating newlines around `` and on collapsed `` turns.
> 
> Registers **Ultra BF16 and FP8** in `MODEL_RENDERER_MAP`, excludes `ultra` from template parity fields (`_internal_fields`), and extends config-parity, conftest, roundtrip (BF16), plus offline tests for name-based selection and FP8 mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f63fa304e29467fa0b7a9eb8c2baac51fa3d04e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Nemotron-3 Ultra chat-template variant to `Nemotron3Renderer`
> - Adds an `ultra` boolean field to [`Nemotron3RendererConfig`](https://github.com/PrimeIntellect-ai/renderers/pull/77/files#diff-10791887ddad1a2d5da4c3ca89cda9ebb2a9fbb0fe806df97467baf11c546029); when `None` (default), it is auto-resolved at renderer init time by matching `tokenizer.name_or_path` against a new [`_ULTRA_DEFAULTS`](https://github.com/PrimeIntellect-ai/renderers/pull/77/files#diff-e8a543eb88bcdf53b7ca269b37e492e22a0297a1f30f6db73b6b376cb9ce5a84) lookup table.
> - Maps the `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16` and `nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8` checkpoints to the `nemotron-3` renderer in [`MODEL_RENDERER_MAP`](https://github.com/PrimeIntellect-ai/renderers/pull/77/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf).
> - Ultra rendering differs from Nano/Super in two ways: `</think>` is emitted directly adjacent to content (no surrounding newlines), and thinking is truncated on every assistant turn before the last user message rather than only at the final plain assistant turn.
> - `ultra` is marked as an internal field via `_internal_fields` so it is not exposed as a template kwarg.
> - Behavioral Change: existing callers using Nano/Super Nemotron-3 checkpoints are unaffected; Ultra checkpoints previously fell back to `DefaultRenderer` and now use the nemotron-3 renderer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f63fa30.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->