### PR TITLE
feat(client): add dynamo_chat transport + routed_experts to renderer generate

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -261,11 +261,13 @@ class _DynamoChatTransport(_Transport):
 
     Dynamo has no /inference/v1/generate route. ``nvext.token_data`` carries
     the pre-tokenized prompt (Dynamo skips tokenization when present) and
-    ``extra_fields=["engine_data"]`` opts into the completion-IDs/logprobs
-    channel (PR #8119). Mirrors
+    ``extra_fields=["engine_data", "routed_experts"]`` opts into the
+    completion-IDs/logprobs channel (PR #8119) and the MoE routed_experts
+    channel. Mirrors
     ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
-    so the wire payload is identical via either client. routed_experts is not
-    requested (its nvext shape differs from the downstream contract).
+    so the wire payload is identical via either client. routed_experts is read
+    from ``nvext.routed_experts`` (or ``nvext.engine_data.routed_experts``) and
+    surfaced as the prime-rl ``{data, shape, start, dtype}`` contract.
     """
 
     async def post(
@@ -322,9 +324,23 @@ class _DynamoChatTransport(_Transport):
         nvext: dict[str, Any] = dict(sp.get("nvext") or {})
         nvext["token_data"] = list(prompt_ids)
         extra_fields = list(nvext.get("extra_fields") or [])
-        if "engine_data" not in extra_fields:
-            extra_fields.append("engine_data")
+        for field in ("engine_data", "routed_experts"):
+            if field not in extra_fields:
+                extra_fields.append(field)
         nvext["extra_fields"] = extra_fields
+        # ``routed_experts_prompt_start`` is the multi-turn replay offset. Dynamo
+        # exposes no top-level field for it, so thread it through
+        # ``nvext.extra_args.sampling_options`` where the worker's
+        # ``build_sampling_params`` applies it to vLLM ``SamplingParams`` — vLLM
+        # then trims the leading prompt rows and the worker echoes the value back
+        # as ``routed_experts.start`` for completion alignment.
+        prompt_start = sp.get("routed_experts_prompt_start")
+        if prompt_start is not None:
+            extra_args = dict(nvext.get("extra_args") or {})
+            sampling_options = dict(extra_args.get("sampling_options") or {})
+            sampling_options["routed_experts_prompt_start"] = prompt_start
+            extra_args["sampling_options"] = sampling_options
+            nvext["extra_args"] = extra_args
         if cache_salt is not None:
             nvext["cache_salt"] = cache_salt
         if priority is not None:
@@ -402,10 +418,19 @@ class _DynamoChatTransport(_Transport):
                 f"completion token count ({len(completion_ids)})."
             )
 
+        # routed_experts: prefer the dedicated nvext.routed_experts field
+        # (extra_fields=["routed_experts"]); fall back to the engine_data
+        # passthrough (extra_fields=["engine_data"]) since the worker also nests
+        # it there. The Dynamo vLLM worker already emits the prime-rl contract
+        # shape {data(base64), shape, start, dtype}, so pass it through unchanged.
+        routed_experts = nvext.get("routed_experts")
+        if routed_experts is None:
+            routed_experts = engine.get("routed_experts")
+
         return _WireResult(
             completion_ids=completion_ids,
             completion_logprobs=logprobs,
-            routed_experts=None,
+            routed_experts=routed_experts,
             request_id=data.get("request_id") or data.get("id") or "",
             finish_reason=choice.get("finish_reason"),
         )

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -306,10 +306,19 @@ class _DynamoChatTransport(_Transport):
         cache_salt: str | None,
         priority: int | None,
     ) -> dict[str, Any]:
+        # cache_salt / priority may arrive as dedicated kwargs or inside
+        # sampling_params (the kwargs win). On Dynamo both belong in nvext, so
+        # they're routed there and never forwarded as top-level chat fields —
+        # keeping a shared sampling_params dict consistent with vllm_generate.
+        if cache_salt is None:
+            cache_salt = sp.get("cache_salt")
+        if priority is None:
+            priority = sp.get("priority")
+
         # Merge caller-supplied nvext rather than overwriting it, then layer on
         # the required fields: token_data (authoritative renderer tokens) and a
         # cumulative extra_fields union with "engine_data". The cache_salt /
-        # priority kwargs win over any caller nvext values.
+        # priority values win over any caller nvext values.
         nvext: dict[str, Any] = dict(sp.get("nvext") or {})
         nvext["token_data"] = list(prompt_ids)
         extra_fields = list(nvext.get("extra_fields") or [])
@@ -341,8 +350,8 @@ class _DynamoChatTransport(_Transport):
         for key, value in sp.items():
             if value is None or key in _DYNAMO_DROP_KEYS or key in body:
                 continue
-            if key in ("nvext", "max_tokens"):
-                continue  # handled above
+            if key in ("nvext", "max_tokens", "cache_salt"):
+                continue  # handled above (cache_salt -> nvext; priority denylisted)
             if key == "logprobs":
                 # vLLM takes logprobs=N (int); Dynamo's chat schema wants the
                 # OpenAI bool + top_logprobs split.

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -298,7 +298,16 @@ class _DynamoChatTransport(_Transport):
         if extra_headers:
             post_kwargs["options"] = cast(Any, {"headers": extra_headers})
         # Engine 4xx propagate raw (matches the vLLM path).
-        return await client.post("/chat/completions", **post_kwargs)
+        resp = await client.post("/chat/completions", **post_kwargs)
+        # Dynamo's NvExt request schema carries no field for
+        # routed_experts_prompt_start, so the worker cannot trim the prompt
+        # rows: it returns full-sequence routing with start=0. Stamp the
+        # intended trim offset (the prompt we sent) onto the payload here so the
+        # consumer aligns the completion. NOTE: this assumes the worker did NOT
+        # trim; if a forwarded prompt-start field is later added to NvExt (so the
+        # worker trims and reports the offset itself), drop this stamping.
+        _stamp_dynamo_routed_experts_start(resp, prompt_ids, sp)
+        return resp
 
     @staticmethod
     def _build_body(
@@ -331,19 +340,6 @@ class _DynamoChatTransport(_Transport):
         if "engine_data" not in extra_fields:
             extra_fields.append("engine_data")
         nvext["extra_fields"] = extra_fields
-        # ``routed_experts_prompt_start`` is the multi-turn replay offset. Dynamo
-        # exposes no top-level field for it, so thread it through
-        # ``nvext.extra_args.sampling_options`` where the worker's
-        # ``build_sampling_params`` applies it to vLLM ``SamplingParams`` — vLLM
-        # then trims the leading prompt rows and the worker echoes the value back
-        # as ``routed_experts.start`` for completion alignment.
-        prompt_start = sp.get("routed_experts_prompt_start")
-        if prompt_start is not None:
-            extra_args = dict(nvext.get("extra_args") or {})
-            sampling_options = dict(extra_args.get("sampling_options") or {})
-            sampling_options["routed_experts_prompt_start"] = prompt_start
-            extra_args["sampling_options"] = sampling_options
-            nvext["extra_args"] = extra_args
         if cache_salt is not None:
             nvext["cache_salt"] = cache_salt
         if priority is not None:
@@ -475,6 +471,34 @@ def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
         "start": int(payload.get("start", 0)),
         "dtype": payload.get("dtype", "uint8"),
     }
+
+
+def _stamp_dynamo_routed_experts_start(
+    resp: Any, prompt_ids: list[int], sp: dict[str, Any]
+) -> None:
+    """Set ``routed_experts.start`` on a dynamo_chat response in place.
+
+    The worker returns full-sequence routing with ``start=0`` (it can't trim —
+    NvExt carries no ``routed_experts_prompt_start``). Stamp the intended trim
+    offset so the consumer aligns the completion: the caller's
+    ``routed_experts_prompt_start`` if set, else ``len(prompt_ids) - 1`` (where
+    the completion's routing begins). No-op when routed_experts is absent.
+    """
+    if not isinstance(resp, Mapping):
+        return
+    nvext = resp.get("nvext")
+    if not isinstance(nvext, Mapping):
+        return
+    routed = nvext.get("routed_experts")
+    if not isinstance(routed, dict):
+        engine = nvext.get("engine_data")
+        routed = engine.get("routed_experts") if isinstance(engine, Mapping) else None
+    if not isinstance(routed, dict):
+        return
+    start = sp.get("routed_experts_prompt_start")
+    if start is None:
+        start = max(0, len(prompt_ids) - 1)
+    routed["start"] = int(start)
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -262,11 +262,6 @@ async def generate(
     sp.setdefault("skip_special_tokens", False)
 
     if transport == "dynamo_chat":
-        # Dynamo branch: POST /v1/chat/completions with nvext.token_data.
-        # Dynamo has no /inference/v1/generate route; the equivalent TITO
-        # surface lives on chat-completions via the ``nvext`` envelope
-        # (PR #8119: response token IDs come back under
-        # ``nvext.engine_data.completion_token_ids``).
         if mm_data is not None and not mm_data.is_empty():
             raise NotImplementedError(
                 "Multimodal renderers are not yet supported on the "
@@ -285,7 +280,6 @@ async def generate(
             messages=messages,
         )
     elif transport == "vllm_generate":
-        # vLLM-native branch: POST /inference/v1/generate (unchanged from upstream).
         features = (
             _build_mm_features(renderer, mm_data)
             if mm_data and not mm_data.is_empty()
@@ -327,9 +321,7 @@ async def generate(
 
     choice = (data.get("choices") or [{}])[0]
     is_dynamo = transport == "dynamo_chat"
-    # vLLM writes choices[0].token_ids; Dynamo returns engine fields under nvext
-    # (PR #8119). Only consult nvext on the dynamo path so the vLLM path stays
-    # byte-identical to upstream.
+    # Only consult nvext on the dynamo path, so the vLLM path is unchanged.
     nvext_resp = (data.get("nvext") or {}) if is_dynamo else {}
     engine_data = nvext_resp.get("engine_data") or {}
 
@@ -343,7 +335,7 @@ async def generate(
                 break
     completion_ids = list(completion_ids or [])
     if is_dynamo and not ids_present:
-        # Field absent (not merely an empty completion) — usually a missing
+        # Field absent (vs. an empty completion) — usually a missing
         # nvext.extra_fields=["engine_data"] opt-in.
         raise RuntimeError(
             "dynamo_chat response carried no completion token IDs "
@@ -355,26 +347,22 @@ async def generate(
     )
 
     # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}.
-    # engine_data.completion_logprobs is a dynamo-only fallback.
     raw_logprobs = choice.get("logprobs") or {}
     content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
     completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
     if not completion_logprobs and is_dynamo:
+        # Dynamo-only fallback when chat logprobs are absent.
         engine_lp = engine_data.get("completion_logprobs") or []
         if engine_lp:
             completion_logprobs = [float(x) for x in engine_lp]
 
-    # vLLM routed_experts sidecar ({shape, data}) passed through unchanged. Not
-    # surfaced on dynamo_chat: its nvext shape differs from the downstream
-    # RoutedExpertsPayload contract (base64 + ``start``).
+    # Not surfaced on dynamo_chat: its nvext shape differs from the
+    # downstream RoutedExpertsPayload contract (base64 + ``start``).
     routed_experts = choice.get("routed_experts")
 
-    # /inference/v1/generate returns finish_reason in {"stop","length",...} —
-    # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
-    # when we extracted tool calls client-side, so OpenAI-compatible agent
-    # loops continue past the tool turn instead of treating the response as
-    # final. Dynamo's chat-completions surface CAN return "tool_calls"
-    # directly, so this promotion is a no-op there.
+    # /inference/v1/generate never returns "tool_calls", so promote
+    # stop→tool_calls when we parsed tool calls client-side (keeps agent
+    # loops going). No-op on dynamo_chat, which can return it directly.
     finish_reason = choice.get("finish_reason")
     ok_tool_calls = [
         tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK
@@ -424,30 +412,14 @@ async def _post_dynamo_chat(
     """POST ``prompt_ids`` to Dynamo's ``/v1/chat/completions`` route.
 
     Mirrors ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
-    in shape, so the wire payload is identical whether the rollout goes
-    through the token client or the renderer client. Anything that lands
-    on Dynamo's chat-completions surface, lands here.
-
-    Wire shape:
-
-      - ``nvext.token_data``: pre-tokenized prompt; Dynamo's preprocessor
-        skips tokenization when present.
-      - ``nvext.extra_fields = ["engine_data"]``: opt-in to Dynamo's engine
-        metadata channel (completion token IDs + logprobs). routed_experts is
-        intentionally NOT requested — Dynamo's nvext shape differs from the
-        downstream RoutedExpertsPayload contract, so it is dropped on this path.
-      - ``messages``: placeholder (single user message). Dynamo ignores
-        when ``token_data`` is present, but the OpenAI schema requires
-        a non-empty messages array, so we send a 1-token stub.
-      - ``stop_token_ids`` / ``cache_salt`` / ``logprobs`` / backend sampling
-        hints ride as passthrough fields accepted by Dynamo's
-        ``PASSTHROUGH_EXTRA_FIELDS`` allowlist.
+    so the wire payload is identical via either client. ``nvext.token_data``
+    carries the pre-tokenized prompt (Dynamo skips tokenization when present)
+    and ``extra_fields=["engine_data"]`` opts into the completion-IDs/logprobs
+    channel. ``messages`` is a placeholder stub the OpenAI schema requires but
+    Dynamo ignores. routed_experts is not requested (incompatible nvext shape).
     """
-    # Standard OpenAI fields that map 1:1 onto Dynamo's chat-completions
-    # request schema (validate.rs accepts them natively).
     body: dict[str, Any] = {
         "model": model,
-        # Single placeholder user message; ignored when token_data is set.
         "messages": [{"role": "user", "content": ""}],
         "stream": False,
         "nvext": {
@@ -455,15 +427,14 @@ async def _post_dynamo_chat(
             "extra_fields": ["engine_data"],
         },
     }
-    # tools are NOT sent on the wire: the renderer already bakes them into
-    # token_data, and renderer ToolSpec isn't the OpenAI tool shape (would 400).
+    # tools are baked into token_data already; the renderer ToolSpec isn't the
+    # OpenAI tool shape, so forwarding it would 400.
     if cache_salt is not None:
         body["nvext"]["cache_salt"] = cache_salt
     if priority is not None:
         body["nvext"]["agent_hints"] = {"priority": priority}
 
-    # Surface standard sampling params at top level (Dynamo's schema
-    # recognizes them natively, so they flow into SamplingOptions cleanly).
+    # Sampling params Dynamo's schema recognizes natively at top level.
     promotable = (
         "max_tokens",
         "temperature",
@@ -484,17 +455,15 @@ async def _post_dynamo_chat(
         if key == "max_tokens":
             body["max_completion_tokens"] = value
         elif key == "logprobs":
-            # Standard OpenAI shape: logprobs=true + top_logprobs=N. The
-            # vLLM TITO surface accepts ``logprobs=N`` (int); Dynamo's
-            # chat-completions schema requires the bool+top_logprobs split.
+            # vLLM takes logprobs=N (int); Dynamo's chat schema wants the
+            # OpenAI bool + top_logprobs split.
             body["logprobs"] = True
             if isinstance(value, int) and value > 1:
                 body["top_logprobs"] = value
         else:
             body[key] = value
 
-    # Pass-through hints that Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist
-    # accepts (stop_token_ids, token constraints, backend sampling toggles).
+    # Pass-through hints on Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist.
     for key in (
         "stop_token_ids",
         "bad_words_token_ids",

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -415,17 +415,19 @@ class _DynamoChatTransport(_Transport):
         # positionally aligned with the ids. The choices[0] chat logprobs are a
         # detokenize/retokenize echo that can diverge from the sampled ids, which
         # would misalign while still passing the length check below. Fall back to
-        # the chat logprobs only when the engine channel is absent — a present
-        # but empty engine list is authoritative (logprobs off) and must NOT
-        # fall through to the chat echo (distinguish presence from truthiness).
+        # the chat logprobs only when the engine channel is absent. A present
+        # empty engine list is still authoritative for source selection and must
+        # NOT fall through to the chat echo, but it is only valid for a
+        # zero-token completion.
         engine_logprobs = engine.get("completion_logprobs")
         if engine_logprobs is not None:
             logprobs = [float(x) for x in engine_logprobs]
         else:
             logprobs = _flatten_chat_logprobs(choice)
         # Logprobs are indexed positionally against completion_ids downstream;
-        # a length mismatch would silently misalign tokens and logprobs.
-        if logprobs and len(logprobs) != len(completion_ids):
+        # a length mismatch would silently misalign tokens and logprobs or
+        # produce samples that prime-rl later rejects.
+        if len(logprobs) != len(completion_ids):
             raise RuntimeError(
                 f"dynamo_chat logprobs length ({len(logprobs)}) does not match "
                 f"completion token count ({len(completion_ids)})."

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -27,7 +27,9 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 import httpx
@@ -122,6 +124,272 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
 
 # Public type alias; matches verifiers.types.RendererTransport string set.
 RendererTransport = Literal["vllm_generate", "dynamo_chat"]
+
+# Sampling params Dynamo's chat schema recognizes natively at top level.
+_DYNAMO_PROMOTABLE_KEYS = (
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "min_p",
+    "seed",
+    "n",
+    "repetition_penalty",
+    "min_tokens",
+    "logprobs",
+    "skip_special_tokens",
+)
+# Pass-through hints on Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist.
+_DYNAMO_PASSTHROUGH_KEYS = (
+    "stop_token_ids",
+    "bad_words_token_ids",
+    "allowed_token_ids",
+    "detokenize",
+)
+
+# Absolute /inference/v1/generate URLs, cached per client base_url.
+_vllm_endpoint_cache: dict[str, str] = {}
+
+
+def _vllm_generate_endpoint(base_url: str) -> str:
+    """Absolute ``/inference/v1/generate`` URL for ``base_url`` (cached).
+
+    The route is mounted at the server root, not under /v1, so strip the
+    client's trailing /v1 and build an absolute URL — otherwise AsyncOpenAI
+    prepends its automatic /v1.
+    """
+    endpoint = _vllm_endpoint_cache.get(base_url)
+    if endpoint is None:
+        endpoint = f"{base_url.rstrip('/').removesuffix('/v1')}/inference/v1/generate"
+        _vllm_endpoint_cache[base_url] = endpoint
+    return endpoint
+
+
+def _flatten_chat_logprobs(choice: Mapping[str, Any]) -> list[float]:
+    """Flatten ChatCompletionLogProbs ``{"content": [{"logprob": ...}, ...]}``."""
+    raw = choice.get("logprobs") or {}
+    content = raw.get("content") if isinstance(raw, dict) else None
+    return [float(c.get("logprob") or 0.0) for c in content or []]
+
+
+@dataclass(frozen=True)
+class _WireResult:
+    """Normalized fields extracted from a backend's raw response."""
+
+    completion_ids: list[int]
+    completion_logprobs: list[float]
+    routed_experts: Any
+    request_id: str
+    finish_reason: str | None
+
+
+class _Transport(ABC):
+    """Per-backend request/response strategy for :func:`generate`."""
+
+    @abstractmethod
+    async def post(
+        self,
+        *,
+        client: AsyncOpenAI,
+        model: str,
+        prompt_ids: list[int],
+        sp: dict[str, Any],
+        renderer: Renderer | RendererPool,
+        mm_data: MultiModalData | None,
+        cache_salt: str | None,
+        priority: int | None,
+        extra_headers: dict[str, str] | None,
+    ) -> dict[str, Any]:
+        """Build the wire body, POST it, and return the decoded response dict."""
+
+    @abstractmethod
+    def parse(self, data: dict[str, Any]) -> _WireResult:
+        """Extract normalized completion fields from the backend response."""
+
+
+class _VllmGenerateTransport(_Transport):
+    """vLLM 0.20 TITO surface: ``POST /inference/v1/generate``."""
+
+    async def post(
+        self,
+        *,
+        client: AsyncOpenAI,
+        model: str,
+        prompt_ids: list[int],
+        sp: dict[str, Any],
+        renderer: Renderer | RendererPool,
+        mm_data: MultiModalData | None,
+        cache_salt: str | None,
+        priority: int | None,
+        extra_headers: dict[str, str] | None,
+    ) -> dict[str, Any]:
+        features = (
+            _build_mm_features(renderer, mm_data)
+            if mm_data and not mm_data.is_empty()
+            else None
+        )
+        body: dict[str, Any] = {
+            "model": model,
+            "token_ids": prompt_ids,
+            "sampling_params": sp,
+        }
+        if features is not None:
+            body["features"] = features
+        if cache_salt is not None:
+            body["cache_salt"] = cache_salt
+        if priority is not None:
+            body["priority"] = priority
+
+        endpoint = _vllm_generate_endpoint(str(client.base_url))
+        _request_logger.debug(
+            "POST %s prompt_len=%d max_tokens=%s",
+            endpoint,
+            len(prompt_ids),
+            sp.get("max_tokens"),
+        )
+        post_kwargs: dict[str, Any] = {"cast_to": httpx.Response, "body": body}
+        if extra_headers:
+            post_kwargs["options"] = cast(Any, {"headers": extra_headers})
+        raw_response = await client.post(endpoint, **post_kwargs)
+        return parse_generate_response(raw_response.content)
+
+    def parse(self, data: dict[str, Any]) -> _WireResult:
+        choice = (data.get("choices") or [{}])[0]
+        return _WireResult(
+            completion_ids=list(choice.get("token_ids") or []),
+            completion_logprobs=_flatten_chat_logprobs(choice),
+            routed_experts=choice.get("routed_experts"),
+            request_id=data.get("request_id") or "",
+            finish_reason=choice.get("finish_reason"),
+        )
+
+
+class _DynamoChatTransport(_Transport):
+    """NVIDIA Dynamo: ``POST /v1/chat/completions`` with the nvext envelope.
+
+    Dynamo has no /inference/v1/generate route. ``nvext.token_data`` carries
+    the pre-tokenized prompt (Dynamo skips tokenization when present) and
+    ``extra_fields=["engine_data"]`` opts into the completion-IDs/logprobs
+    channel (PR #8119). Mirrors
+    ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
+    so the wire payload is identical via either client. routed_experts is not
+    requested (its nvext shape differs from the downstream contract).
+    """
+
+    async def post(
+        self,
+        *,
+        client: AsyncOpenAI,
+        model: str,
+        prompt_ids: list[int],
+        sp: dict[str, Any],
+        renderer: Renderer | RendererPool,
+        mm_data: MultiModalData | None,
+        cache_salt: str | None,
+        priority: int | None,
+        extra_headers: dict[str, str] | None,
+    ) -> dict[str, Any]:
+        if mm_data is not None and not mm_data.is_empty():
+            raise NotImplementedError(
+                "Multimodal renderers are not yet supported on the dynamo_chat "
+                "transport. Use vllm_generate or stay on the token-client TITO "
+                "path for VLMs."
+            )
+        body = self._build_body(model, prompt_ids, sp, cache_salt, priority)
+        post_kwargs: dict[str, Any] = {
+            "cast_to": cast(Any, dict[str, Any]),
+            "body": body,
+        }
+        if extra_headers:
+            post_kwargs["options"] = cast(Any, {"headers": extra_headers})
+        # Engine 4xx propagate raw (matches the vLLM path).
+        return await client.post("/chat/completions", **post_kwargs)
+
+    @staticmethod
+    def _build_body(
+        model: str,
+        prompt_ids: list[int],
+        sp: dict[str, Any],
+        cache_salt: str | None,
+        priority: int | None,
+    ) -> dict[str, Any]:
+        # messages is a placeholder stub the OpenAI schema requires but Dynamo
+        # ignores. tools are baked into token_data; forwarding the renderer
+        # ToolSpec (not the OpenAI tool shape) would 400.
+        nvext: dict[str, Any] = {
+            "token_data": list(prompt_ids),
+            "extra_fields": ["engine_data"],
+        }
+        if cache_salt is not None:
+            nvext["cache_salt"] = cache_salt
+        if priority is not None:
+            nvext["agent_hints"] = {"priority": priority}
+        body: dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": ""}],
+            "stream": False,
+            "nvext": nvext,
+        }
+
+        for key in _DYNAMO_PROMOTABLE_KEYS:
+            value = sp.get(key)
+            if value is None:
+                continue
+            if key == "max_tokens":
+                body["max_completion_tokens"] = value
+            elif key == "logprobs":
+                # vLLM takes logprobs=N (int); Dynamo's chat schema wants the
+                # OpenAI bool + top_logprobs split.
+                body["logprobs"] = True
+                if isinstance(value, int) and value > 1:
+                    body["top_logprobs"] = value
+            else:
+                body[key] = value
+
+        for key in _DYNAMO_PASSTHROUGH_KEYS:
+            if sp.get(key) is not None:
+                body[key] = sp[key]
+        return body
+
+    def parse(self, data: dict[str, Any]) -> _WireResult:
+        choice = (data.get("choices") or [{}])[0]
+        nvext = data.get("nvext") or {}
+        engine = nvext.get("engine_data") or {}
+
+        completion_ids = choice.get("token_ids")
+        present = completion_ids is not None
+        if not present:
+            for src in (engine, nvext):
+                if src.get("completion_token_ids") is not None:
+                    completion_ids = src["completion_token_ids"]
+                    present = True
+                    break
+        if not present:
+            # Field absent (vs. an empty completion) — usually a missing
+            # nvext.extra_fields=["engine_data"] opt-in.
+            raise RuntimeError(
+                "dynamo_chat response carried no completion token IDs "
+                "(expected nvext.engine_data.completion_token_ids)."
+            )
+
+        logprobs = _flatten_chat_logprobs(choice)
+        if not logprobs:
+            # Dynamo-only fallback when chat logprobs are absent.
+            logprobs = [float(x) for x in engine.get("completion_logprobs") or []]
+
+        return _WireResult(
+            completion_ids=list(completion_ids or []),
+            completion_logprobs=logprobs,
+            routed_experts=None,
+            request_id=data.get("request_id") or data.get("id") or "",
+            finish_reason=choice.get("finish_reason"),
+        )
+
+
+_TRANSPORTS: dict[str, _Transport] = {
+    "vllm_generate": _VllmGenerateTransport(),
+    "dynamo_chat": _DynamoChatTransport(),
+}
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):
@@ -261,109 +529,30 @@ async def generate(
     sp["logprobs"] = 1
     sp.setdefault("skip_special_tokens", False)
 
-    if transport == "dynamo_chat":
-        if mm_data is not None and not mm_data.is_empty():
-            raise NotImplementedError(
-                "Multimodal renderers are not yet supported on the "
-                "dynamo_chat transport. Use vllm_generate or "
-                "stay on the token-client TITO path for VLMs."
-            )
-        data = await _post_dynamo_chat(
-            client=client,
-            model=model,
-            prompt_ids=prompt_ids,
-            sp=sp,
-            tools=tools,
-            cache_salt=cache_salt,
-            priority=priority,
-            extra_headers=extra_headers,
-            messages=messages,
-        )
-    elif transport == "vllm_generate":
-        features = (
-            _build_mm_features(renderer, mm_data)
-            if mm_data and not mm_data.is_empty()
-            else None
-        )
-        body: dict[str, Any] = {
-            "model": model,
-            "token_ids": prompt_ids,
-            "sampling_params": sp,
-        }
-        if features is not None:
-            body["features"] = features
-        if cache_salt is not None:
-            body["cache_salt"] = cache_salt
-        if priority is not None:
-            body["priority"] = priority
-
-        # /inference/v1/generate is mounted at the server root, not under /v1
-        # like the OpenAI-compatible endpoints. Build an absolute URL so the
-        # AsyncOpenAI client doesn't prepend its automatic /v1.
-        base = str(client.base_url).rstrip("/").removesuffix("/v1")
-        endpoint = f"{base}/inference/v1/generate"
-        _request_logger.debug(
-            "POST %s prompt_len=%d max_tokens=%s",
-            endpoint,
-            len(prompt_ids),
-            sp.get("max_tokens"),
-        )
-        post_kwargs: dict[str, Any] = {
-            "cast_to": httpx.Response,
-            "body": body,
-        }
-        if extra_headers:
-            post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-        raw_response = await client.post(endpoint, **post_kwargs)
-        data = parse_generate_response(raw_response.content)
-    else:
+    impl = _TRANSPORTS.get(transport)
+    if impl is None:
         raise ValueError(f"Unknown renderer transport: {transport!r}")
-
-    choice = (data.get("choices") or [{}])[0]
-    is_dynamo = transport == "dynamo_chat"
-    # Only consult nvext on the dynamo path, so the vLLM path is unchanged.
-    nvext_resp = (data.get("nvext") or {}) if is_dynamo else {}
-    engine_data = nvext_resp.get("engine_data") or {}
-
-    completion_ids = choice.get("token_ids")
-    ids_present = completion_ids is not None
-    if not ids_present and is_dynamo:
-        for src in (engine_data, nvext_resp):
-            if src.get("completion_token_ids") is not None:
-                completion_ids = src["completion_token_ids"]
-                ids_present = True
-                break
-    completion_ids = list(completion_ids or [])
-    if is_dynamo and not ids_present:
-        # Field absent (vs. an empty completion) — usually a missing
-        # nvext.extra_fields=["engine_data"] opt-in.
-        raise RuntimeError(
-            "dynamo_chat response carried no completion token IDs "
-            "(expected nvext.engine_data.completion_token_ids)."
-        )
+    data = await impl.post(
+        client=client,
+        model=model,
+        prompt_ids=prompt_ids,
+        sp=sp,
+        renderer=renderer,
+        mm_data=mm_data,
+        cache_salt=cache_salt,
+        priority=priority,
+        extra_headers=extra_headers,
+    )
+    wire = impl.parse(data)
 
     parsed = await _maybe_offload(
-        renderer, lambda: renderer.parse_response(completion_ids, tools=tools)
+        renderer, lambda: renderer.parse_response(wire.completion_ids, tools=tools)
     )
-
-    # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}.
-    raw_logprobs = choice.get("logprobs") or {}
-    content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
-    completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
-    if not completion_logprobs and is_dynamo:
-        # Dynamo-only fallback when chat logprobs are absent.
-        engine_lp = engine_data.get("completion_logprobs") or []
-        if engine_lp:
-            completion_logprobs = [float(x) for x in engine_lp]
-
-    # Not surfaced on dynamo_chat: its nvext shape differs from the
-    # downstream RoutedExpertsPayload contract (base64 + ``start``).
-    routed_experts = choice.get("routed_experts")
 
     # /inference/v1/generate never returns "tool_calls", so promote
     # stop→tool_calls when we parsed tool calls client-side (keeps agent
     # loops going). No-op on dynamo_chat, which can return it directly.
-    finish_reason = choice.get("finish_reason")
+    finish_reason = wire.finish_reason
     ok_tool_calls = [
         tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK
     ]
@@ -371,17 +560,15 @@ async def generate(
         finish_reason = "tool_calls"
 
     return {
-        "request_id": data.get("request_id")
-        or (data.get("id") if is_dynamo else None)
-        or "",
+        "request_id": wire.request_id,
         "prompt_ids": list(prompt_ids),
-        "completion_ids": list(completion_ids),
-        "completion_logprobs": completion_logprobs,
+        "completion_ids": list(wire.completion_ids),
+        "completion_logprobs": wire.completion_logprobs,
         "content": parsed.content,
         "reasoning_content": parsed.reasoning_content,
         "tool_calls": parsed.tool_calls,
         "finish_reason": finish_reason,
-        "routed_experts": routed_experts,
+        "routed_experts": wire.routed_experts,
         # The mm sidecar consumed on the request side, surfaced back so
         # callers can persist it on the trajectory step for downstream
         # multi-turn bridging and training-sample construction.
@@ -395,92 +582,6 @@ async def generate(
         # when the caller passed prompt_ids without attribution.
         "prompt_attribution": prompt_attr,
     }
-
-
-async def _post_dynamo_chat(
-    *,
-    client: AsyncOpenAI,
-    model: str,
-    prompt_ids: list[int],
-    sp: dict[str, Any],
-    tools: list[ToolSpec] | None,
-    cache_salt: str | None,
-    priority: int | None,
-    extra_headers: dict[str, str] | None,
-    messages: list[Message],
-) -> dict[str, Any]:
-    """POST ``prompt_ids`` to Dynamo's ``/v1/chat/completions`` route.
-
-    Mirrors ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
-    so the wire payload is identical via either client. ``nvext.token_data``
-    carries the pre-tokenized prompt (Dynamo skips tokenization when present)
-    and ``extra_fields=["engine_data"]`` opts into the completion-IDs/logprobs
-    channel. ``messages`` is a placeholder stub the OpenAI schema requires but
-    Dynamo ignores. routed_experts is not requested (incompatible nvext shape).
-    """
-    body: dict[str, Any] = {
-        "model": model,
-        "messages": [{"role": "user", "content": ""}],
-        "stream": False,
-        "nvext": {
-            "token_data": list(prompt_ids),
-            "extra_fields": ["engine_data"],
-        },
-    }
-    # tools are baked into token_data already; the renderer ToolSpec isn't the
-    # OpenAI tool shape, so forwarding it would 400.
-    if cache_salt is not None:
-        body["nvext"]["cache_salt"] = cache_salt
-    if priority is not None:
-        body["nvext"]["agent_hints"] = {"priority": priority}
-
-    # Sampling params Dynamo's schema recognizes natively at top level.
-    promotable = (
-        "max_tokens",
-        "temperature",
-        "top_p",
-        "top_k",
-        "min_p",
-        "seed",
-        "n",
-        "repetition_penalty",
-        "min_tokens",
-        "logprobs",
-        "skip_special_tokens",
-    )
-    for key in promotable:
-        value = sp.get(key)
-        if value is None:
-            continue
-        if key == "max_tokens":
-            body["max_completion_tokens"] = value
-        elif key == "logprobs":
-            # vLLM takes logprobs=N (int); Dynamo's chat schema wants the
-            # OpenAI bool + top_logprobs split.
-            body["logprobs"] = True
-            if isinstance(value, int) and value > 1:
-                body["top_logprobs"] = value
-        else:
-            body[key] = value
-
-    # Pass-through hints on Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist.
-    for key in (
-        "stop_token_ids",
-        "bad_words_token_ids",
-        "allowed_token_ids",
-        "detokenize",
-    ):
-        if sp.get(key) is not None:
-            body[key] = sp[key]
-
-    post_kwargs: dict[str, Any] = {
-        "cast_to": cast(Any, dict[str, Any]),
-        "body": body,
-    }
-    if extra_headers:
-        post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-    # Engine 4xx propagate raw (matches the vLLM path).
-    return await client.post("/chat/completions", **post_kwargs)
 
 
 def _build_mm_features(

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -2,12 +2,12 @@
 
 Two transports, selected per-call via ``transport=`` parameter:
 
-    "vllm_generate" (default)
+    "vllm" (default)
         messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
         → completion tokens → Renderer.parse_response() → structured message
         vLLM's TITO surface (server.py mounts the route in prime-rl).
 
-    "dynamo_chat"
+    "dynamo"
         messages → Renderer.render_ids() → token IDs → POST /v1/chat/completions
         with ``nvext.token_data`` + ``nvext.extra_fields=["engine_data"]``
         → completion tokens via ``nvext.engine_data.completion_token_ids``
@@ -124,7 +124,7 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
 
 
 # Public type alias; matches verifiers.types.RendererTransport string set.
-RendererTransport = Literal["vllm_generate", "dynamo_chat"]
+RendererTransport = Literal["vllm", "dynamo"]
 
 # Keys never forwarded to Dynamo at the top level: vLLM/prime-only fields its
 # strict validator rejects (mirrors the token client's drop set). ``priority``
@@ -145,7 +145,7 @@ _DYNAMO_DROP_KEYS = frozenset(
 _vllm_endpoint_cache: dict[str, str] = {}
 
 
-def _vllm_generate_endpoint(base_url: str) -> str:
+def _vllm_endpoint(base_url: str) -> str:
     """Absolute ``/inference/v1/generate`` URL for ``base_url`` (cached).
 
     The route is mounted at the server root, not under /v1, so strip the
@@ -234,7 +234,7 @@ class _VllmGenerateTransport(_Transport):
         if priority is not None:
             body["priority"] = priority
 
-        endpoint = _vllm_generate_endpoint(str(client.base_url))
+        endpoint = _vllm_endpoint(str(client.base_url))
         _request_logger.debug(
             "POST %s prompt_len=%d max_tokens=%s",
             endpoint,
@@ -265,7 +265,7 @@ class _DynamoChatTransport(_Transport):
     the pre-tokenized prompt (Dynamo skips tokenization when present) and
     ``extra_fields=["engine_data", "routed_experts"]`` opts into the
     completion-IDs/logprobs channel and the MoE routed_experts channel. Mirrors
-    ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
+    ``verifiers.clients.openai_chat_completions_token_client._post_dynamo``
     so the wire payload is identical via either client. routed_experts is read
     from ``nvext.routed_experts`` (or ``nvext.engine_data.routed_experts``) and
     surfaced as the prime-rl ``{data, shape, start, dtype}`` contract.
@@ -284,11 +284,11 @@ class _DynamoChatTransport(_Transport):
         priority: int | None,
         extra_headers: dict[str, str] | None,
     ) -> dict[str, Any]:
-        # TODO: Implement multimodal support for dynamo_chat transport.
+        # TODO: Implement multimodal support for dynamo transport.
         if mm_data is not None and not mm_data.is_empty():
             raise NotImplementedError(
-                "Multimodal renderers are not yet supported on the dynamo_chat "
-                "transport. Use vllm_generate or stay on the token-client TITO "
+                "Multimodal renderers are not yet supported on the dynamo "
+                "transport. Use vllm or stay on the token-client TITO "
                 "path for VLMs."
             )
         body = self._build_body(model, prompt_ids, sp, cache_salt, priority)
@@ -299,8 +299,8 @@ class _DynamoChatTransport(_Transport):
         raw_response = await client.post("/chat/completions", **post_kwargs)
         # Keep the (potentially large) routed_experts base64 blob as a zero-copy
         # memoryview instead of decoding it through json.loads — a synchronous
-        # full parse of the blob stalls the event loop. Mirrors vllm_generate.
-        resp = _parse_dynamo_chat_response(raw_response.content)
+        # full parse of the blob stalls the event loop. Mirrors vllm.
+        resp = _parse_dynamo_response(raw_response.content)
         # Back-compat trim: when the worker did NOT trim engine-side (start=0; it
         # trims when it honors nvext.routed_experts_prompt_start), drop the leading
         # prompt rows here so row 0 == start. No-op once the worker stamps start>0.
@@ -318,7 +318,7 @@ class _DynamoChatTransport(_Transport):
         # cache_salt / priority may arrive as dedicated kwargs or inside
         # sampling_params (the kwargs win). On Dynamo both belong in nvext, so
         # they're routed there and never forwarded as top-level chat fields —
-        # keeping a shared sampling_params dict consistent with vllm_generate.
+        # keeping a shared sampling_params dict consistent with vllm.
         if cache_salt is None:
             cache_salt = sp.get("cache_salt")
         if priority is None:
@@ -405,7 +405,7 @@ class _DynamoChatTransport(_Transport):
             # Field absent (vs. an empty completion) — usually a missing
             # nvext.extra_fields=["engine_data"] opt-in.
             raise RuntimeError(
-                "dynamo_chat response carried no completion token IDs "
+                "dynamo response carried no completion token IDs "
                 "(expected nvext.engine_data.completion_token_ids)."
             )
         completion_ids = list(completion_ids or [])
@@ -429,7 +429,7 @@ class _DynamoChatTransport(_Transport):
         # produce samples that prime-rl later rejects.
         if len(logprobs) != len(completion_ids):
             raise RuntimeError(
-                f"dynamo_chat logprobs length ({len(logprobs)}) does not match "
+                f"dynamo logprobs length ({len(logprobs)}) does not match "
                 f"completion token count ({len(completion_ids)})."
             )
 
@@ -453,13 +453,13 @@ class _DynamoChatTransport(_Transport):
 
 
 _TRANSPORTS: dict[str, _Transport] = {
-    "vllm_generate": _VllmGenerateTransport(),
-    "dynamo_chat": _DynamoChatTransport(),
+    "vllm": _VllmGenerateTransport(),
+    "dynamo": _DynamoChatTransport(),
 }
 
 
 def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
-    """Validate/normalize a dynamo_chat routed_experts payload to the
+    """Validate/normalize a dynamo routed_experts payload to the
     ``{data, shape, start, dtype}`` contract.
 
     Defaults ``start=0`` and ``dtype="uint8"`` for back-compat with payloads
@@ -472,13 +472,13 @@ def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
         return None
     if not isinstance(payload, Mapping) or "data" not in payload or "shape" not in payload:
         raise RuntimeError(
-            "dynamo_chat routed_experts must be a mapping with 'data' and "
+            "dynamo routed_experts must be a mapping with 'data' and "
             f"'shape'; got {type(payload).__name__}"
         )
     shape = payload["shape"]
     if not (isinstance(shape, (list, tuple)) and len(shape) == 3):
         raise RuntimeError(
-            "dynamo_chat routed_experts 'shape' must be 3-D [seq, layers, topk]; "
+            "dynamo routed_experts 'shape' must be 3-D [seq, layers, topk]; "
             f"got {shape!r}"
         )
     return {
@@ -493,7 +493,7 @@ _ROUTED_EXPERTS_ITEMSIZE = {"uint8": 1, "uint16": 2, "int16": 2, "int32": 4}
 
 
 def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
-    """Client-side trim of a dynamo_chat routed_experts payload, in place.
+    """Client-side trim of a dynamo routed_experts payload, in place.
 
     This is a **back-compat fallback**. The renderer now forwards
     ``routed_experts_prompt_start`` via ``nvext`` (see ``_build_body``), so a
@@ -578,8 +578,8 @@ def parse_generate_response(raw: bytes) -> dict[str, Any]:
     return payload
 
 
-def _parse_dynamo_chat_response(raw: bytes) -> dict[str, Any]:
-    """Parse a dynamo_chat response, keeping the routed_experts base64 blob as a
+def _parse_dynamo_response(raw: bytes) -> dict[str, Any]:
+    """Parse a dynamo response, keeping the routed_experts base64 blob as a
     zero-copy ``memoryview`` instead of decoding it through ``json.loads`` (a
     large blob would block the event loop). Mirrors ``parse_generate_response``,
     but re-attaches the blob at the nvext location (``nvext.routed_experts`` or
@@ -611,7 +611,7 @@ async def generate(
     prompt_attribution: RenderedTokens | None = None,
     tools: list[ToolSpec] | None = None,
     sampling_params: dict[str, Any] | None = None,
-    transport: RendererTransport = "vllm_generate",
+    transport: RendererTransport = "vllm",
     cache_salt: str | None = None,
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
@@ -725,7 +725,7 @@ async def generate(
 
     # /inference/v1/generate never returns "tool_calls", so promote
     # stop→tool_calls when we parsed tool calls client-side (keeps agent
-    # loops going). No-op on dynamo_chat, which can return it directly.
+    # loops going). No-op on dynamo, which can return it directly.
     finish_reason = wire.finish_reason
     ok_tool_calls = [
         tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -306,7 +306,7 @@ class _DynamoChatTransport(_Transport):
         # rows here and set start, so the payload matches the consumer contract
         # (row 0 == position start). NOTE: if a forwarded prompt-start field is
         # later added to NvExt (worker trims + reports start), drop this.
-        _trim_dynamo_routed_experts(resp, prompt_ids, sp)
+        _trim_dynamo_routed_experts(resp, sp)
         return resp
 
     @staticmethod
@@ -476,19 +476,18 @@ def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
 _ROUTED_EXPERTS_ITEMSIZE = {"uint8": 1, "uint16": 2, "int16": 2, "int32": 4}
 
 
-def _trim_dynamo_routed_experts(
-    resp: Any, prompt_ids: list[int], sp: dict[str, Any]
-) -> None:
+def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
     """Trim a dynamo_chat routed_experts payload to begin at ``start``, in place.
 
     The Dynamo worker returns FULL-sequence routing with ``start=0`` because
     NvExt carries no field to forward ``routed_experts_prompt_start`` for
     worker-side trimming. The consumer contract is that row 0 of the payload is
     the row at ``start`` (the vllm_generate path has vLLM trim internally), so
-    we drop the leading prompt rows here and set ``start`` to the offset:
-    the caller's ``routed_experts_prompt_start`` if set, else ``prefix_len - 1``
-    (the boundary row that produces the first completion token). No-op when
-    routed_experts is absent/empty or the offset is 0.
+    when the caller explicitly supplies ``routed_experts_prompt_start`` we drop
+    that many leading rows and set ``start`` to it. No-op when routed_experts is
+    absent/empty, the offset is 0, or no offset is supplied — a first-turn
+    request with no caller start keeps full-sequence routing with ``start=0``
+    rather than claiming a prefix the consumer has no state for.
 
     Worker-side trimming (avoiding full-prompt routing on the wire) is a future
     optimization gated on a forwarded NvExt prompt-start field.
@@ -513,7 +512,7 @@ def _trim_dynamo_routed_experts(
 
     offset = sp.get("routed_experts_prompt_start")
     if offset is None:
-        offset = len(prompt_ids) - 1
+        return
     offset = max(0, min(int(offset), int(shape[0])))
     if offset == 0:
         return

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -119,6 +119,7 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
         _max_prompt_len_cache[key] = value
         return value
 
+
 # Public type alias; matches verifiers.types.RendererTransport string set.
 RendererTransport = Literal["vllm_generate", "dynamo_chat"]
 

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -405,10 +405,15 @@ class _DynamoChatTransport(_Transport):
             )
         completion_ids = list(completion_ids or [])
 
-        logprobs = _flatten_chat_logprobs(choice)
+        # Prefer engine_data.completion_logprobs — the same authoritative source
+        # as the engine completion_token_ids used above — so logprobs stay
+        # positionally aligned with the ids. The choices[0] chat logprobs are a
+        # detokenize/retokenize echo that can diverge from the sampled ids, which
+        # would misalign while still passing the length check below. Fall back to
+        # the chat logprobs only when the engine channel carries none.
+        logprobs = [float(x) for x in engine.get("completion_logprobs") or []]
         if not logprobs:
-            # Dynamo-only fallback when chat logprobs are absent.
-            logprobs = [float(x) for x in engine.get("completion_logprobs") or []]
+            logprobs = _flatten_chat_logprobs(choice)
         # Logprobs are indexed positionally against completion_ids downstream;
         # a length mismatch would silently misalign tokens and logprobs.
         if logprobs and len(logprobs) != len(completion_ids):

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -25,6 +25,7 @@ achieve real parallelism.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 from abc import ABC, abstractmethod
@@ -300,13 +301,12 @@ class _DynamoChatTransport(_Transport):
         # Engine 4xx propagate raw (matches the vLLM path).
         resp = await client.post("/chat/completions", **post_kwargs)
         # Dynamo's NvExt request schema carries no field for
-        # routed_experts_prompt_start, so the worker cannot trim the prompt
-        # rows: it returns full-sequence routing with start=0. Stamp the
-        # intended trim offset (the prompt we sent) onto the payload here so the
-        # consumer aligns the completion. NOTE: this assumes the worker did NOT
-        # trim; if a forwarded prompt-start field is later added to NvExt (so the
-        # worker trims and reports the offset itself), drop this stamping.
-        _stamp_dynamo_routed_experts_start(resp, prompt_ids, sp)
+        # routed_experts_prompt_start, so the worker can't trim the prompt rows:
+        # it returns full-sequence routing with start=0. Trim the leading prompt
+        # rows here and set start, so the payload matches the consumer contract
+        # (row 0 == position start). NOTE: if a forwarded prompt-start field is
+        # later added to NvExt (worker trims + reports start), drop this.
+        _trim_dynamo_routed_experts(resp, prompt_ids, sp)
         return resp
 
     @staticmethod
@@ -473,16 +473,25 @@ def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
     }
 
 
-def _stamp_dynamo_routed_experts_start(
+_ROUTED_EXPERTS_ITEMSIZE = {"uint8": 1, "uint16": 2, "int16": 2, "int32": 4}
+
+
+def _trim_dynamo_routed_experts(
     resp: Any, prompt_ids: list[int], sp: dict[str, Any]
 ) -> None:
-    """Set ``routed_experts.start`` on a dynamo_chat response in place.
+    """Trim a dynamo_chat routed_experts payload to begin at ``start``, in place.
 
-    The worker returns full-sequence routing with ``start=0`` (it can't trim —
-    NvExt carries no ``routed_experts_prompt_start``). Stamp the intended trim
-    offset so the consumer aligns the completion: the caller's
-    ``routed_experts_prompt_start`` if set, else ``len(prompt_ids) - 1`` (where
-    the completion's routing begins). No-op when routed_experts is absent.
+    The Dynamo worker returns FULL-sequence routing with ``start=0`` because
+    NvExt carries no field to forward ``routed_experts_prompt_start`` for
+    worker-side trimming. The consumer contract is that row 0 of the payload is
+    the row at ``start`` (the vllm_generate path has vLLM trim internally), so
+    we drop the leading prompt rows here and set ``start`` to the offset:
+    the caller's ``routed_experts_prompt_start`` if set, else ``prefix_len - 1``
+    (the boundary row that produces the first completion token). No-op when
+    routed_experts is absent/empty or the offset is 0.
+
+    Worker-side trimming (avoiding full-prompt routing on the wire) is a future
+    optimization gated on a forwarded NvExt prompt-start field.
     """
     if not isinstance(resp, Mapping):
         return
@@ -495,10 +504,26 @@ def _stamp_dynamo_routed_experts_start(
         routed = engine.get("routed_experts") if isinstance(engine, Mapping) else None
     if not isinstance(routed, dict):
         return
-    start = sp.get("routed_experts_prompt_start")
-    if start is None:
-        start = max(0, len(prompt_ids) - 1)
-    routed["start"] = int(start)
+    data = routed.get("data")
+    shape = routed.get("shape")
+    if not isinstance(data, str) or not (
+        isinstance(shape, (list, tuple)) and len(shape) == 3
+    ):
+        return
+
+    offset = sp.get("routed_experts_prompt_start")
+    if offset is None:
+        offset = len(prompt_ids) - 1
+    offset = max(0, min(int(offset), int(shape[0])))
+    if offset == 0:
+        return
+
+    itemsize = _ROUTED_EXPERTS_ITEMSIZE.get(routed.get("dtype", "uint8"), 1)
+    row_size = int(shape[1]) * int(shape[2]) * itemsize
+    trimmed = base64.b64decode(data)[offset * row_size :]
+    routed["data"] = base64.b64encode(trimmed).decode("ascii")
+    routed["shape"] = [int(shape[0]) - offset, int(shape[1]), int(shape[2])]
+    routed["start"] = offset
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -437,15 +437,14 @@ async def _post_dynamo_chat_nvext(
 
       - ``nvext.token_data``: pre-tokenized prompt; Dynamo's preprocessor
         skips tokenization when present.
-      - ``nvext.extra_fields = ["engine_data"]``: opt-in to the PR #8119
-        channel — response carries ``nvext.engine_data.completion_token_ids``
-        and ``nvext.engine_data.completion_logprobs``.
+      - ``nvext.extra_fields = ["engine_data", "routed_experts"]``: opt-in
+        to Dynamo's engine metadata and router replay channels.
       - ``messages``: placeholder (single user message). Dynamo ignores
         when ``token_data`` is present, but the OpenAI schema requires
         a non-empty messages array, so we send a 1-token stub.
-      - ``stop_token_ids`` / ``cache_salt`` / ``logprobs`` ride as
-        ``extra_body`` passthrough (Dynamo's
-        ``PASSTHROUGH_EXTRA_FIELDS`` allowlist accepts them).
+      - ``stop_token_ids`` / ``cache_salt`` / ``logprobs`` / backend sampling
+        hints ride as passthrough fields accepted by Dynamo's
+        ``PASSTHROUGH_EXTRA_FIELDS`` allowlist.
     """
     # Standard OpenAI fields that map 1:1 onto Dynamo's chat-completions
     # request schema (validate.rs accepts them natively).
@@ -456,13 +455,15 @@ async def _post_dynamo_chat_nvext(
         "stream": False,
         "nvext": {
             "token_data": list(prompt_ids),
-            "extra_fields": ["engine_data"],
+            "extra_fields": ["engine_data", "routed_experts"],
         },
     }
     if tools:
         body["tools"] = tools
     if cache_salt is not None:
         body["nvext"]["cache_salt"] = cache_salt
+    if priority is not None:
+        body["nvext"]["agent_hints"] = {"priority": priority}
 
     # Surface standard sampling params at top level (Dynamo's schema
     # recognizes them natively, so they flow into SamplingOptions cleanly).
@@ -496,8 +497,13 @@ async def _post_dynamo_chat_nvext(
             body[key] = value
 
     # Pass-through hints that Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist
-    # accepts (stop_token_ids, bad_words_token_ids, ...).
-    for key in ("stop_token_ids", "bad_words_token_ids", "allowed_token_ids"):
+    # accepts (stop_token_ids, token constraints, backend sampling toggles).
+    for key in (
+        "stop_token_ids",
+        "bad_words_token_ids",
+        "allowed_token_ids",
+        "detokenize",
+    ):
         if sp.get(key) is not None:
             body[key] = sp[key]
 

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -431,8 +431,10 @@ async def _post_dynamo_chat(
 
       - ``nvext.token_data``: pre-tokenized prompt; Dynamo's preprocessor
         skips tokenization when present.
-      - ``nvext.extra_fields = ["engine_data", "routed_experts"]``: opt-in
-        to Dynamo's engine metadata and router replay channels.
+      - ``nvext.extra_fields = ["engine_data"]``: opt-in to Dynamo's engine
+        metadata channel (completion token IDs + logprobs). routed_experts is
+        intentionally NOT requested — Dynamo's nvext shape differs from the
+        downstream RoutedExpertsPayload contract, so it is dropped on this path.
       - ``messages``: placeholder (single user message). Dynamo ignores
         when ``token_data`` is present, but the OpenAI schema requires
         a non-empty messages array, so we send a 1-token stub.

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -1,7 +1,20 @@
-"""Renderer-based generate client for vLLM 0.20's /inference/v1/generate.
+"""Renderer-based generate client for vLLM 0.20 + Dynamo.
 
-    messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
-    → completion tokens → Renderer.parse_response() → structured message
+Two transports, selected per-call via ``transport=`` parameter:
+
+    "prime_vllm_generate" (default)
+        messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
+        → completion tokens → Renderer.parse_response() → structured message
+        vLLM's TITO surface (server.py mounts the route in prime-rl).
+
+    "dynamo_chat_nvext"
+        messages → Renderer.render_ids() → token IDs → POST /v1/chat/completions
+        with ``nvext.token_data`` + ``nvext.extra_fields=["engine_data"]``
+        → completion tokens via ``nvext.engine_data.completion_token_ids``
+        → Renderer.parse_response() → structured message
+        Dynamo has no ``/inference/v1/generate`` route; this branch posts to
+        the standard OpenAI chat-completions surface and reads the engine
+        token IDs back via the PR #8119 ``nvext.engine_data`` channel.
 
 When a RendererPool is passed instead of a single Renderer, the sync tokenization
 and parsing work is offloaded to threads for parallel execution across rollouts.
@@ -15,7 +28,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Mapping
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import httpx
 from openai import AsyncOpenAI
@@ -106,6 +119,9 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
         _max_prompt_len_cache[key] = value
         return value
 
+# Public type alias; matches verifiers.types.RendererTransport string set.
+RendererTransport = Literal["prime_vllm_generate", "dynamo_chat_nvext"]
+
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):
     """Run sync renderer work on a thread iff ``renderer`` is a pool.
@@ -152,6 +168,7 @@ async def generate(
     prompt_attribution: RenderedTokens | None = None,
     tools: list[ToolSpec] | None = None,
     sampling_params: dict[str, Any] | None = None,
+    transport: RendererTransport = "prime_vllm_generate",
     cache_salt: str | None = None,
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
@@ -243,65 +260,128 @@ async def generate(
     sp["logprobs"] = 1
     sp.setdefault("skip_special_tokens", False)
 
-    body: dict[str, Any] = {
-        "model": model,
-        "token_ids": prompt_ids,
-        "sampling_params": sp,
-    }
     features = (
         _build_mm_features(renderer, mm_data)
         if mm_data and not mm_data.is_empty()
         else None
     )
-    if features is not None:
-        body["features"] = features
-    if cache_salt is not None:
-        body["cache_salt"] = cache_salt
-    if priority is not None:
-        body["priority"] = priority
 
-    # /inference/v1/generate is mounted at the server root, not under /v1
-    # like the OpenAI-compatible endpoints. Build an absolute URL so the
-    # AsyncOpenAI client doesn't prepend its automatic /v1.
-    base = str(client.base_url).rstrip("/").removesuffix("/v1")
-    endpoint = f"{base}/inference/v1/generate"
-    _request_logger.debug(
-        "POST %s prompt_len=%d max_tokens=%s",
-        endpoint,
-        len(prompt_ids),
-        sp.get("max_tokens"),
-    )
-    post_kwargs: dict[str, Any] = {
-        "cast_to": httpx.Response,
-        "body": body,
-    }
-    if extra_headers:
-        post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-    raw_response = await client.post(endpoint, **post_kwargs)
-    data = parse_generate_response(raw_response.content)
+    if transport == "dynamo_chat_nvext":
+        # Dynamo branch: POST /v1/chat/completions with nvext.token_data.
+        # Dynamo has no /inference/v1/generate route; the equivalent TITO
+        # surface lives on chat-completions via the ``nvext`` envelope
+        # (PR #8119: response token IDs come back under
+        # ``nvext.engine_data.completion_token_ids``).
+        if features is not None:
+            raise NotImplementedError(
+                "Multimodal renderers are not yet supported on the "
+                "dynamo_chat_nvext transport. Use prime_vllm_generate or "
+                "stay on the token-client TITO path for VLMs."
+            )
+        data = await _post_dynamo_chat_nvext(
+            client=client,
+            model=model,
+            prompt_ids=prompt_ids,
+            sp=sp,
+            tools=tools,
+            cache_salt=cache_salt,
+            priority=priority,
+            extra_headers=extra_headers,
+            messages=messages,
+        )
+    else:
+        # vLLM-native branch: POST /inference/v1/generate (vLLM 0.20 TITO).
+        body: dict[str, Any] = {
+            "model": model,
+            "token_ids": prompt_ids,
+            "sampling_params": sp,
+        }
+        if features is not None:
+            body["features"] = features
+        if cache_salt is not None:
+            body["cache_salt"] = cache_salt
+        if priority is not None:
+            body["priority"] = priority
+
+        # /inference/v1/generate is mounted at the server root, not under /v1
+        # like the OpenAI-compatible endpoints. Build an absolute URL so the
+        # AsyncOpenAI client doesn't prepend its automatic /v1.
+        base = str(client.base_url).rstrip("/").removesuffix("/v1")
+        endpoint = f"{base}/inference/v1/generate"
+        _request_logger.debug(
+            "POST %s prompt_len=%d max_tokens=%s",
+            endpoint,
+            len(prompt_ids),
+            sp.get("max_tokens"),
+        )
+        post_kwargs: dict[str, Any] = {
+            "cast_to": cast(Any, dict[str, Any]),
+            "body": body,
+        }
+        if extra_headers:
+            post_kwargs["options"] = cast(Any, {"headers": extra_headers})
+        try:
+            data = await client.post(endpoint, **post_kwargs)
+        except BadRequestError as exc:
+            _log_overlong_prompt_diagnostic(
+                prompt_ids=prompt_ids,
+                messages=messages,
+                max_tokens=sp.get("max_tokens"),
+                exc=exc,
+            )
+            raise
 
     choice = (data.get("choices") or [{}])[0]
-    completion_ids = choice.get("token_ids") or []
+    # Dynamo emits engine token IDs under ``nvext.engine_data.completion_token_ids``
+    # (PR #8119 channel) rather than ``choice.token_ids``. Try both — vLLM's
+    # /inference/v1/generate writes the top-level shape; Dynamo's
+    # /v1/chat/completions writes the nested one. The first present wins.
+    completion_ids = choice.get("token_ids")
+    if not completion_ids:
+        nvext_resp = data.get("nvext") or {}
+        engine_data = nvext_resp.get("engine_data") or {}
+        completion_ids = (
+            engine_data.get("completion_token_ids")
+            or nvext_resp.get("completion_token_ids")
+            or []
+        )
+    completion_ids = list(completion_ids or [])
 
     parsed = await _maybe_offload(
         renderer, lambda: renderer.parse_response(completion_ids, tools=tools)
     )
 
-    # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}
+    # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}.
+    # Same shape on both transports (Dynamo aliases the standard OpenAI
+    # logprobs field). engine_data.completion_logprobs is a fallback when
+    # the OpenAI-style logprobs array is absent.
     raw_logprobs = choice.get("logprobs") or {}
     content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
     completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
+    if not completion_logprobs:
+        nvext_resp = data.get("nvext") or {}
+        engine_data = nvext_resp.get("engine_data") or {}
+        engine_lp = engine_data.get("completion_logprobs") or []
+        if engine_lp:
+            completion_logprobs = [float(x) for x in engine_lp]
 
-    routed_experts = choice.get("routed_experts")
+    routed_experts = None
+    raw_re = choice.get("routed_experts") or (data.get("nvext") or {}).get(
+        "routed_experts"
+    )
+    if isinstance(raw_re, dict) and "data" in raw_re and "shape" in raw_re:
+        routed_experts = (
+            np.frombuffer(base64.b85decode(raw_re["data"]), dtype=np.int32)
+            .reshape(raw_re["shape"])
+            .tolist()
+        )
 
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
-    # when we extracted at least one well-formed tool call client-side, so
-    # OpenAI-compatible agent loops continue past the tool turn instead of
-    # treating the response as final. Malformed attempts (INVALID_JSON,
-    # UNCLOSED_BLOCK, ...) don't qualify — those still surface on
-    # ``parsed.tool_calls`` so verifiers can inspect them, but they don't
-    # trigger the tool-loop continuation.
+    # when we extracted tool calls client-side, so OpenAI-compatible agent
+    # loops continue past the tool turn instead of treating the response as
+    # final. Dynamo's chat-completions surface CAN return "tool_calls"
+    # directly, so this promotion is a no-op there.
     finish_reason = choice.get("finish_reason")
     ok_tool_calls = [
         tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK
@@ -310,7 +390,7 @@ async def generate(
         finish_reason = "tool_calls"
 
     return {
-        "request_id": data.get("request_id") or "",
+        "request_id": data.get("request_id") or data.get("id") or "",
         "prompt_ids": list(prompt_ids),
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
@@ -332,6 +412,111 @@ async def generate(
         # when the caller passed prompt_ids without attribution.
         "prompt_attribution": prompt_attr,
     }
+
+
+async def _post_dynamo_chat_nvext(
+    *,
+    client: AsyncOpenAI,
+    model: str,
+    prompt_ids: list[int],
+    sp: dict[str, Any],
+    tools: list[ToolSpec] | None,
+    cache_salt: str | None,
+    priority: int | None,
+    extra_headers: dict[str, str] | None,
+    messages: list[Message],
+) -> dict[str, Any]:
+    """POST ``prompt_ids`` to Dynamo's ``/v1/chat/completions`` route.
+
+    Mirrors ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat_nvext``
+    in shape, so the wire payload is identical whether the rollout goes
+    through the token client or the renderer client. Anything that lands
+    on Dynamo's chat-completions surface, lands here.
+
+    Wire shape:
+
+      - ``nvext.token_data``: pre-tokenized prompt; Dynamo's preprocessor
+        skips tokenization when present.
+      - ``nvext.extra_fields = ["engine_data"]``: opt-in to the PR #8119
+        channel — response carries ``nvext.engine_data.completion_token_ids``
+        and ``nvext.engine_data.completion_logprobs``.
+      - ``messages``: placeholder (single user message). Dynamo ignores
+        when ``token_data`` is present, but the OpenAI schema requires
+        a non-empty messages array, so we send a 1-token stub.
+      - ``stop_token_ids`` / ``cache_salt`` / ``logprobs`` ride as
+        ``extra_body`` passthrough (Dynamo's
+        ``PASSTHROUGH_EXTRA_FIELDS`` allowlist accepts them).
+    """
+    # Standard OpenAI fields that map 1:1 onto Dynamo's chat-completions
+    # request schema (validate.rs accepts them natively).
+    body: dict[str, Any] = {
+        "model": model,
+        # Single placeholder user message; ignored when token_data is set.
+        "messages": [{"role": "user", "content": ""}],
+        "stream": False,
+        "nvext": {
+            "token_data": list(prompt_ids),
+            "extra_fields": ["engine_data"],
+        },
+    }
+    if tools:
+        body["tools"] = tools
+    if cache_salt is not None:
+        body["nvext"]["cache_salt"] = cache_salt
+
+    # Surface standard sampling params at top level (Dynamo's schema
+    # recognizes them natively, so they flow into SamplingOptions cleanly).
+    promotable = (
+        "max_tokens",
+        "temperature",
+        "top_p",
+        "top_k",
+        "min_p",
+        "seed",
+        "n",
+        "repetition_penalty",
+        "min_tokens",
+        "logprobs",
+        "skip_special_tokens",
+    )
+    for key in promotable:
+        value = sp.get(key)
+        if value is None:
+            continue
+        if key == "max_tokens":
+            body["max_completion_tokens"] = value
+        elif key == "logprobs":
+            # Standard OpenAI shape: logprobs=true + top_logprobs=N. The
+            # vLLM TITO surface accepts ``logprobs=N`` (int); Dynamo's
+            # chat-completions schema requires the bool+top_logprobs split.
+            body["logprobs"] = True
+            if isinstance(value, int) and value > 1:
+                body["top_logprobs"] = value
+        else:
+            body[key] = value
+
+    # Pass-through hints that Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist
+    # accepts (stop_token_ids, bad_words_token_ids, ...).
+    for key in ("stop_token_ids", "bad_words_token_ids", "allowed_token_ids"):
+        if sp.get(key) is not None:
+            body[key] = sp[key]
+
+    post_kwargs: dict[str, Any] = {
+        "cast_to": cast(Any, dict[str, Any]),
+        "body": body,
+    }
+    if extra_headers:
+        post_kwargs["options"] = cast(Any, {"headers": extra_headers})
+    try:
+        return await client.post("/chat/completions", **post_kwargs)
+    except BadRequestError as exc:
+        _log_overlong_prompt_diagnostic(
+            prompt_ids=prompt_ids,
+            messages=messages,
+            max_tokens=sp.get("max_tokens"),
+            exc=exc,
+        )
+        raise
 
 
 def _build_mm_features(

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -324,9 +324,12 @@ class _DynamoChatTransport(_Transport):
         nvext: dict[str, Any] = dict(sp.get("nvext") or {})
         nvext["token_data"] = list(prompt_ids)
         extra_fields = list(nvext.get("extra_fields") or [])
-        for field in ("engine_data", "routed_experts"):
-            if field not in extra_fields:
-                extra_fields.append(field)
+        # Only request "engine_data": the worker nests routed_experts inside it
+        # (engine_data.routed_experts), so also requesting the dedicated
+        # "routed_experts" field would duplicate the (large) base64 blob on the
+        # wire — once under engine_data and once promoted at the top level.
+        if "engine_data" not in extra_fields:
+            extra_fields.append("engine_data")
         nvext["extra_fields"] = extra_fields
         # ``routed_experts_prompt_start`` is the multi-turn replay offset. Dynamo
         # exposes no top-level field for it, so thread it through
@@ -418,14 +421,15 @@ class _DynamoChatTransport(_Transport):
                 f"completion token count ({len(completion_ids)})."
             )
 
-        # routed_experts: prefer the dedicated nvext.routed_experts field
-        # (extra_fields=["routed_experts"]); fall back to the engine_data
-        # passthrough (extra_fields=["engine_data"]) since the worker also nests
-        # it there. The Dynamo vLLM worker already emits the prime-rl contract
-        # shape {data(base64), shape, start, dtype}, so pass it through unchanged.
+        # routed_experts: read the dedicated nvext.routed_experts field if a
+        # caller opted into it, else the engine_data passthrough where the
+        # worker nests it (engine_data.routed_experts). Normalize to the
+        # {data, shape, start, dtype} contract so a malformed/legacy payload
+        # fails here with context instead of deep in trajectory processing.
         routed_experts = nvext.get("routed_experts")
         if routed_experts is None:
             routed_experts = engine.get("routed_experts")
+        routed_experts = _normalize_routed_experts(routed_experts)
 
         return _WireResult(
             completion_ids=completion_ids,
@@ -440,6 +444,37 @@ _TRANSPORTS: dict[str, _Transport] = {
     "vllm_generate": _VllmGenerateTransport(),
     "dynamo_chat": _DynamoChatTransport(),
 }
+
+
+def _normalize_routed_experts(payload: Any) -> dict[str, Any] | None:
+    """Validate/normalize a dynamo_chat routed_experts payload to the
+    ``{data, shape, start, dtype}`` contract.
+
+    Defaults ``start=0`` and ``dtype="uint8"`` for back-compat with payloads
+    serialized before those fields existed; raises a clear ``RuntimeError`` for
+    a non-contract payload (string/map, wrong rank) so the failure surfaces here
+    with context instead of as a ``TypeError``/``KeyError`` in trajectory
+    processing.
+    """
+    if payload is None:
+        return None
+    if not isinstance(payload, Mapping) or "data" not in payload or "shape" not in payload:
+        raise RuntimeError(
+            "dynamo_chat routed_experts must be a mapping with 'data' and "
+            f"'shape'; got {type(payload).__name__}"
+        )
+    shape = payload["shape"]
+    if not (isinstance(shape, (list, tuple)) and len(shape) == 3):
+        raise RuntimeError(
+            "dynamo_chat routed_experts 'shape' must be 3-D [seq, layers, topk]; "
+            f"got {shape!r}"
+        )
+    return {
+        "data": payload["data"],
+        "shape": [int(d) for d in shape],
+        "start": int(payload.get("start", 0)),
+        "dtype": payload.get("dtype", "uint8"),
+    }
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -261,14 +261,10 @@ class _VllmGenerateTransport(_Transport):
 class _DynamoChatTransport(_Transport):
     """NVIDIA Dynamo: ``POST /v1/chat/completions`` with the nvext envelope.
 
-    Dynamo has no /inference/v1/generate route. ``nvext.token_data`` carries
-    the pre-tokenized prompt (Dynamo skips tokenization when present) and
-    ``extra_fields=["engine_data", "routed_experts"]`` opts into the
-    completion-IDs/logprobs channel and the MoE routed_experts channel. Mirrors
-    ``verifiers.clients.openai_chat_completions_token_client._post_dynamo``
-    so the wire payload is identical via either client. routed_experts is read
-    from ``nvext.routed_experts`` (or ``nvext.engine_data.routed_experts``) and
-    surfaced as the prime-rl ``{data, shape, start, dtype}`` contract.
+    ``nvext.token_data`` carries the pre-tokenized prompt; ``extra_fields=
+    ["engine_data"]`` opts into the completion-IDs/logprobs/routed_experts
+    channel. routed_experts is normalized to the ``{data, shape, start,
+    dtype}`` contract.
     """
 
     async def post(
@@ -297,13 +293,9 @@ class _DynamoChatTransport(_Transport):
             post_kwargs["options"] = cast(Any, {"headers": extra_headers})
         # Engine 4xx propagate raw (matches the vLLM path).
         raw_response = await client.post("/chat/completions", **post_kwargs)
-        # Keep the (potentially large) routed_experts base64 blob as a zero-copy
-        # memoryview instead of decoding it through json.loads — a synchronous
-        # full parse of the blob stalls the event loop. Mirrors vllm.
+        # Keep routed_experts blob as zero-copy memoryview (avoids event-loop json.loads).
         resp = _parse_dynamo_response(raw_response.content)
-        # Back-compat trim: when the worker did NOT trim engine-side (start=0; it
-        # trims when it honors nvext.routed_experts_prompt_start), drop the leading
-        # prompt rows here so row 0 == start. No-op once the worker stamps start>0.
+        # Back-compat trim: no-op when worker already trimmed engine-side (start>0).
         _trim_dynamo_routed_experts(resp, sp)
         return resp
 
@@ -315,26 +307,18 @@ class _DynamoChatTransport(_Transport):
         cache_salt: str | None,
         priority: int | None,
     ) -> dict[str, Any]:
-        # cache_salt / priority may arrive as dedicated kwargs or inside
-        # sampling_params (the kwargs win). On Dynamo both belong in nvext, so
-        # they're routed there and never forwarded as top-level chat fields —
-        # keeping a shared sampling_params dict consistent with vllm.
+        # kwargs win over sampling_params; both route into nvext on Dynamo.
         if cache_salt is None:
             cache_salt = sp.get("cache_salt")
         if priority is None:
             priority = sp.get("priority")
 
-        # Merge caller-supplied nvext rather than overwriting it, then layer on
-        # the required fields: token_data (authoritative renderer tokens) and a
-        # cumulative extra_fields union with "engine_data". The cache_salt /
-        # priority values win over any caller nvext values.
+        # Merge caller nvext; layer required fields on top.
         nvext: dict[str, Any] = dict(sp.get("nvext") or {})
         nvext["token_data"] = list(prompt_ids)
         extra_fields = list(nvext.get("extra_fields") or [])
-        # Only request "engine_data": the worker nests routed_experts inside it
-        # (engine_data.routed_experts), so also requesting the dedicated
-        # "routed_experts" field would duplicate the (large) base64 blob on the
-        # wire — once under engine_data and once promoted at the top level.
+        # Only "engine_data": routed_experts nests inside it, so requesting
+        # the dedicated field separately would duplicate the blob on the wire.
         if "engine_data" not in extra_fields:
             extra_fields.append("engine_data")
         nvext["extra_fields"] = extra_fields
@@ -344,10 +328,7 @@ class _DynamoChatTransport(_Transport):
             agent_hints = dict(nvext.get("agent_hints") or {})
             agent_hints["priority"] = priority
             nvext["agent_hints"] = agent_hints
-        # routed_experts_prompt_start rides nvext (Dynamo rejects unknown
-        # top-level chat fields). The worker applies it to SamplingParams so vLLM
-        # trims the leading prompt rows engine-side and stamps the payload's
-        # `start` — the client-side trim then no-ops (see _trim_dynamo_routed_experts).
+        # Rides nvext; Dynamo rejects unknown top-level chat fields.
         reps = sp.get("routed_experts_prompt_start")
         if reps is not None:
             nvext["routed_experts_prompt_start"] = reps
@@ -433,11 +414,7 @@ class _DynamoChatTransport(_Transport):
                 f"completion token count ({len(completion_ids)})."
             )
 
-        # routed_experts: read the dedicated nvext.routed_experts field if a
-        # caller opted into it, else the engine_data passthrough where the
-        # worker nests it (engine_data.routed_experts). Normalize to the
-        # {data, shape, start, dtype} contract so a malformed/legacy payload
-        # fails here with context instead of deep in trajectory processing.
+        # Prefer nvext.routed_experts, fall back to engine_data.routed_experts.
         routed_experts = nvext.get("routed_experts")
         if not isinstance(routed_experts, Mapping):
             routed_experts = engine.get("routed_experts")
@@ -536,7 +513,13 @@ def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
     if offset == 0:
         return
 
-    itemsize = _ROUTED_EXPERTS_ITEMSIZE.get(routed.get("dtype", "uint8"), 1)
+    dtype = routed.get("dtype", "uint8")
+    itemsize = _ROUTED_EXPERTS_ITEMSIZE.get(dtype)
+    if itemsize is None:
+        raise RuntimeError(
+            f"unknown routed_experts dtype {dtype!r}; "
+            f"expected one of {sorted(_ROUTED_EXPERTS_ITEMSIZE)}"
+        )
     row_size = int(shape[1]) * int(shape[2]) * itemsize
     trimmed = base64.b64decode(data)[offset * row_size :]
     routed["data"] = base64.b64encode(trimmed).decode("ascii")

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -125,26 +125,18 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
 # Public type alias; matches verifiers.types.RendererTransport string set.
 RendererTransport = Literal["vllm_generate", "dynamo_chat"]
 
-# Sampling params Dynamo's chat schema recognizes natively at top level.
-_DYNAMO_PROMOTABLE_KEYS = (
-    "max_tokens",
-    "temperature",
-    "top_p",
-    "top_k",
-    "min_p",
-    "seed",
-    "n",
-    "repetition_penalty",
-    "min_tokens",
-    "logprobs",
-    "skip_special_tokens",
-)
-# Pass-through hints on Dynamo's PASSTHROUGH_EXTRA_FIELDS allowlist.
-_DYNAMO_PASSTHROUGH_KEYS = (
-    "stop_token_ids",
-    "bad_words_token_ids",
-    "allowed_token_ids",
-    "detokenize",
+# Keys never forwarded to Dynamo at the top level: vLLM/prime-only fields its
+# strict validator rejects (mirrors the token client's drop set), the
+# renderer-internal ``routed_experts_prompt_start`` parse hint (never a wire
+# field), and ``priority`` (routed into nvext.agent_hints instead). ``max_tokens``
+# and ``nvext`` are handled explicitly and skipped separately.
+_DYNAMO_DROP_KEYS = frozenset(
+    {
+        "return_token_ids",
+        "spaces_between_special_tokens",
+        "priority",
+        "routed_experts_prompt_start",
+    }
 )
 
 # Absolute /inference/v1/generate URLs, cached per client base_url.
@@ -289,6 +281,7 @@ class _DynamoChatTransport(_Transport):
         priority: int | None,
         extra_headers: dict[str, str] | None,
     ) -> dict[str, Any]:
+        # TODO: Implement multimodal support for dynamo_chat transport.
         if mm_data is not None and not mm_data.is_empty():
             raise NotImplementedError(
                 "Multimodal renderers are not yet supported on the dynamo_chat "
@@ -313,31 +306,44 @@ class _DynamoChatTransport(_Transport):
         cache_salt: str | None,
         priority: int | None,
     ) -> dict[str, Any]:
-        # messages is a placeholder stub the OpenAI schema requires but Dynamo
-        # ignores. tools are baked into token_data; forwarding the renderer
-        # ToolSpec (not the OpenAI tool shape) would 400.
-        nvext: dict[str, Any] = {
-            "token_data": list(prompt_ids),
-            "extra_fields": ["engine_data"],
-        }
+        # Merge caller-supplied nvext rather than overwriting it, then layer on
+        # the required fields: token_data (authoritative renderer tokens) and a
+        # cumulative extra_fields union with "engine_data". The cache_salt /
+        # priority kwargs win over any caller nvext values.
+        nvext: dict[str, Any] = dict(sp.get("nvext") or {})
+        nvext["token_data"] = list(prompt_ids)
+        extra_fields = list(nvext.get("extra_fields") or [])
+        if "engine_data" not in extra_fields:
+            extra_fields.append("engine_data")
+        nvext["extra_fields"] = extra_fields
         if cache_salt is not None:
             nvext["cache_salt"] = cache_salt
         if priority is not None:
-            nvext["agent_hints"] = {"priority": priority}
+            agent_hints = dict(nvext.get("agent_hints") or {})
+            agent_hints["priority"] = priority
+            nvext["agent_hints"] = agent_hints
+
+        # messages is a placeholder stub the OpenAI schema requires but Dynamo
+        # ignores. tools are baked into token_data; forwarding the renderer
+        # ToolSpec (not the OpenAI tool shape) would 400.
         body: dict[str, Any] = {
             "model": model,
             "messages": [{"role": "user", "content": ""}],
             "stream": False,
             "nvext": nvext,
         }
+        if sp.get("max_tokens") is not None:
+            body["max_completion_tokens"] = sp["max_tokens"]
 
-        for key in _DYNAMO_PROMOTABLE_KEYS:
-            value = sp.get(key)
-            if value is None:
+        # Forward every other non-None sampling field (denylist, not allowlist)
+        # so caller-requested params (presence_penalty, stop, guided_*, ...) are
+        # not silently dropped. Mirrors the token client's body construction.
+        for key, value in sp.items():
+            if value is None or key in _DYNAMO_DROP_KEYS or key in body:
                 continue
-            if key == "max_tokens":
-                body["max_completion_tokens"] = value
-            elif key == "logprobs":
+            if key in ("nvext", "max_tokens"):
+                continue  # handled above
+            if key == "logprobs":
                 # vLLM takes logprobs=N (int); Dynamo's chat schema wants the
                 # OpenAI bool + top_logprobs split.
                 body["logprobs"] = True
@@ -345,10 +351,6 @@ class _DynamoChatTransport(_Transport):
                     body["top_logprobs"] = value
             else:
                 body[key] = value
-
-        for key in _DYNAMO_PASSTHROUGH_KEYS:
-            if sp.get(key) is not None:
-                body[key] = sp[key]
         return body
 
     def parse(self, data: dict[str, Any]) -> _WireResult:
@@ -356,14 +358,20 @@ class _DynamoChatTransport(_Transport):
         nvext = data.get("nvext") or {}
         engine = nvext.get("engine_data") or {}
 
-        completion_ids = choice.get("token_ids")
-        present = completion_ids is not None
-        if not present:
-            for src in (engine, nvext):
-                if src.get("completion_token_ids") is not None:
-                    completion_ids = src["completion_token_ids"]
-                    present = True
-                    break
+        # Canonical Dynamo channel first (PR #8119: nvext.engine_data, then
+        # top-level nvext), then the OpenAI-extended choices[0].token_ids. The
+        # engine channel is authoritative — choices[0].token_ids may be a
+        # detokenize-then-retokenize echo that differs from what was sampled.
+        completion_ids = None
+        present = False
+        for src in (engine, nvext):
+            if src.get("completion_token_ids") is not None:
+                completion_ids = src["completion_token_ids"]
+                present = True
+                break
+        if not present and choice.get("token_ids") is not None:
+            completion_ids = choice["token_ids"]
+            present = True
         if not present:
             # Field absent (vs. an empty completion) — usually a missing
             # nvext.extra_fields=["engine_data"] opt-in.
@@ -371,14 +379,22 @@ class _DynamoChatTransport(_Transport):
                 "dynamo_chat response carried no completion token IDs "
                 "(expected nvext.engine_data.completion_token_ids)."
             )
+        completion_ids = list(completion_ids or [])
 
         logprobs = _flatten_chat_logprobs(choice)
         if not logprobs:
             # Dynamo-only fallback when chat logprobs are absent.
             logprobs = [float(x) for x in engine.get("completion_logprobs") or []]
+        # Logprobs are indexed positionally against completion_ids downstream;
+        # a length mismatch would silently misalign tokens and logprobs.
+        if logprobs and len(logprobs) != len(completion_ids):
+            raise RuntimeError(
+                f"dynamo_chat logprobs length ({len(logprobs)}) does not match "
+                f"completion token count ({len(completion_ids)})."
+            )
 
         return _WireResult(
-            completion_ids=list(completion_ids or []),
+            completion_ids=completion_ids,
             completion_logprobs=logprobs,
             routed_experts=None,
             request_id=data.get("request_id") or data.get("id") or "",

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -439,7 +439,7 @@ class _DynamoChatTransport(_Transport):
         # {data, shape, start, dtype} contract so a malformed/legacy payload
         # fails here with context instead of deep in trajectory processing.
         routed_experts = nvext.get("routed_experts")
-        if routed_experts is None:
+        if not isinstance(routed_experts, Mapping):
             routed_experts = engine.get("routed_experts")
         routed_experts = _normalize_routed_experts(routed_experts)
 

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -127,10 +127,11 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
 RendererTransport = Literal["vllm_generate", "dynamo_chat"]
 
 # Keys never forwarded to Dynamo at the top level: vLLM/prime-only fields its
-# strict validator rejects (mirrors the token client's drop set), the
-# renderer-internal ``routed_experts_prompt_start`` parse hint (never a wire
-# field), and ``priority`` (routed into nvext.agent_hints instead). ``max_tokens``
-# and ``nvext`` are handled explicitly and skipped separately.
+# strict validator rejects (mirrors the token client's drop set). ``priority``
+# is routed into nvext.agent_hints and ``routed_experts_prompt_start`` into
+# nvext.routed_experts_prompt_start instead (the worker applies the latter to
+# SamplingParams so vLLM trims routing engine-side). ``max_tokens`` and ``nvext``
+# are handled explicitly and skipped separately.
 _DYNAMO_DROP_KEYS = frozenset(
     {
         "return_token_ids",
@@ -346,6 +347,13 @@ class _DynamoChatTransport(_Transport):
             agent_hints = dict(nvext.get("agent_hints") or {})
             agent_hints["priority"] = priority
             nvext["agent_hints"] = agent_hints
+        # routed_experts_prompt_start rides nvext (Dynamo rejects unknown
+        # top-level chat fields). The worker applies it to SamplingParams so vLLM
+        # trims the leading prompt rows engine-side and stamps the payload's
+        # `start` — the client-side trim then no-ops (see _trim_dynamo_routed_experts).
+        reps = sp.get("routed_experts_prompt_start")
+        if reps is not None:
+            nvext["routed_experts_prompt_start"] = reps
 
         # messages is a placeholder stub the OpenAI schema requires but Dynamo
         # ignores. tools are baked into token_data; forwarding the renderer
@@ -486,20 +494,18 @@ _ROUTED_EXPERTS_ITEMSIZE = {"uint8": 1, "uint16": 2, "int16": 2, "int32": 4}
 
 
 def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
-    """Trim a dynamo_chat routed_experts payload to begin at ``start``, in place.
+    """Client-side trim of a dynamo_chat routed_experts payload, in place.
 
-    The Dynamo worker returns FULL-sequence routing with ``start=0`` because
-    NvExt carries no field to forward ``routed_experts_prompt_start`` for
-    worker-side trimming. The consumer contract is that row 0 of the payload is
-    the row at ``start`` (the vllm_generate path has vLLM trim internally), so
-    when the caller explicitly supplies ``routed_experts_prompt_start`` we drop
-    that many leading rows and set ``start`` to it. No-op when routed_experts is
-    absent/empty, the offset is 0, or no offset is supplied — a first-turn
-    request with no caller start keeps full-sequence routing with ``start=0``
-    rather than claiming a prefix the consumer has no state for.
-
-    Worker-side trimming (avoiding full-prompt routing on the wire) is a future
-    optimization gated on a forwarded NvExt prompt-start field.
+    This is a **back-compat fallback**. The renderer now forwards
+    ``routed_experts_prompt_start`` via ``nvext`` (see ``_build_body``), so a
+    current Dynamo worker trims the leading prompt rows engine-side (vLLM) and
+    stamps the payload's ``start`` > 0 — in which case this is a no-op. We only
+    trim here when the worker returned FULL-sequence routing with ``start == 0``
+    (an older worker that ignored the nvext field) and the caller supplied a
+    positive ``routed_experts_prompt_start``: drop that many leading rows and set
+    ``start``. No-op when routed_experts is absent/empty, the worker already
+    trimmed (``start`` > 0), or no positive offset is supplied (first-turn
+    requests keep full-sequence routing with ``start=0``).
     """
     if not isinstance(resp, Mapping):
         return
@@ -521,6 +527,9 @@ def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
 
     offset = sp.get("routed_experts_prompt_start")
     if offset is None:
+        return
+    # Worker already trimmed engine-side (stamped start > 0) — don't double-trim.
+    if int(routed.get("start") or 0) != 0:
         return
     offset = max(0, min(int(offset), int(shape[0])))
     if offset == 0:

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -1,4 +1,4 @@
-"""Renderer-based generate client for vLLM 0.20 + Dynamo.
+"""Renderer-based generate client for vLLM + Dynamo.
 
 Two transports, selected per-call via ``transport=`` parameter:
 
@@ -14,7 +14,7 @@ Two transports, selected per-call via ``transport=`` parameter:
         → Renderer.parse_response() → structured message
         Dynamo has no ``/inference/v1/generate`` route; this branch posts to
         the standard OpenAI chat-completions surface and reads the engine
-        token IDs back via the PR #8119 ``nvext.engine_data`` channel.
+        token IDs back via the ``nvext.engine_data`` channel.
 
 When a RendererPool is passed instead of a single Renderer, the sync tokenization
 and parsing work is offloaded to threads for parallel execution across rollouts.
@@ -202,7 +202,7 @@ class _Transport(ABC):
 
 
 class _VllmGenerateTransport(_Transport):
-    """vLLM 0.20 TITO surface: ``POST /inference/v1/generate``."""
+    """vLLM TITO surface: ``POST /inference/v1/generate``."""
 
     async def post(
         self,
@@ -264,8 +264,7 @@ class _DynamoChatTransport(_Transport):
     Dynamo has no /inference/v1/generate route. ``nvext.token_data`` carries
     the pre-tokenized prompt (Dynamo skips tokenization when present) and
     ``extra_fields=["engine_data", "routed_experts"]`` opts into the
-    completion-IDs/logprobs channel (PR #8119) and the MoE routed_experts
-    channel. Mirrors
+    completion-IDs/logprobs channel and the MoE routed_experts channel. Mirrors
     ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
     so the wire payload is identical via either client. routed_experts is read
     from ``nvext.routed_experts`` (or ``nvext.engine_data.routed_experts``) and
@@ -390,8 +389,8 @@ class _DynamoChatTransport(_Transport):
         nvext = data.get("nvext") or {}
         engine = nvext.get("engine_data") or {}
 
-        # Canonical Dynamo channel first (PR #8119: nvext.engine_data, then
-        # top-level nvext), then the OpenAI-extended choices[0].token_ids. The
+        # Canonical Dynamo channel first (nvext.engine_data, then top-level
+        # nvext), then the OpenAI-extended choices[0].token_ids. The
         # engine channel is authoritative — choices[0].token_ids may be a
         # detokenize-then-retokenize echo that differs from what was sampled.
         completion_ids = None
@@ -749,7 +748,7 @@ def _build_mm_features(
     model-family specific. For now we dispatch on the renderer class;
     extend the dispatch table as more multimodal renderers land.
 
-    NOTE — future engine pluggability: this encoder is vLLM 0.20-specific
+    NOTE — future engine pluggability: this encoder is vLLM-specific
     (uses ``vllm.multimodal.inputs.MultiModalKwargsItems``,
     ``vllm.entrypoints.serve.disagg.mm_serde.encode_mm_kwargs_item``, and
     ``_create_qwen2vl_field_factory``). When a second inference engine

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -325,23 +325,25 @@ async def generate(
         raise ValueError(f"Unknown renderer transport: {transport!r}")
 
     choice = (data.get("choices") or [{}])[0]
-    # Dynamo emits engine token IDs under ``nvext.engine_data.completion_token_ids``
-    # (PR #8119 channel) rather than ``choice.token_ids``. Try both — vLLM's
-    # /inference/v1/generate writes the top-level shape; Dynamo's
-    # /v1/chat/completions writes the nested one. The first present wins.
+    is_dynamo = transport == "dynamo_chat"
+    # vLLM writes choices[0].token_ids; Dynamo returns engine fields under nvext
+    # (PR #8119). Only consult nvext on the dynamo path so the vLLM path stays
+    # byte-identical to upstream.
+    nvext_resp = (data.get("nvext") or {}) if is_dynamo else {}
+    engine_data = nvext_resp.get("engine_data") or {}
+
     completion_ids = choice.get("token_ids")
-    if not completion_ids:
-        nvext_resp = data.get("nvext") or {}
-        engine_data = nvext_resp.get("engine_data") or {}
-        completion_ids = (
-            engine_data.get("completion_token_ids")
-            or nvext_resp.get("completion_token_ids")
-            or []
-        )
+    ids_present = completion_ids is not None
+    if not ids_present and is_dynamo:
+        for src in (engine_data, nvext_resp):
+            if src.get("completion_token_ids") is not None:
+                completion_ids = src["completion_token_ids"]
+                ids_present = True
+                break
     completion_ids = list(completion_ids or [])
-    if transport == "dynamo_chat" and not completion_ids:
-        # Fail loudly rather than parse an empty completion (usually a missing
-        # nvext.extra_fields=["engine_data"] opt-in).
+    if is_dynamo and not ids_present:
+        # Field absent (not merely an empty completion) — usually a missing
+        # nvext.extra_fields=["engine_data"] opt-in.
         raise RuntimeError(
             "dynamo_chat response carried no completion token IDs "
             "(expected nvext.engine_data.completion_token_ids)."
@@ -352,24 +354,19 @@ async def generate(
     )
 
     # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}.
-    # Same shape on both transports (Dynamo aliases the standard OpenAI
-    # logprobs field). engine_data.completion_logprobs is a fallback when
-    # the OpenAI-style logprobs array is absent.
+    # engine_data.completion_logprobs is a dynamo-only fallback.
     raw_logprobs = choice.get("logprobs") or {}
     content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
     completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
-    if not completion_logprobs:
-        nvext_resp = data.get("nvext") or {}
-        engine_data = nvext_resp.get("engine_data") or {}
+    if not completion_logprobs and is_dynamo:
         engine_lp = engine_data.get("completion_logprobs") or []
         if engine_lp:
             completion_logprobs = [float(x) for x in engine_lp]
 
-    # Pass the routed_experts sidecar through unchanged (binary {shape, data}
-    # for vLLM; same dict under nvext for Dynamo). Decoding is the consumer's job.
-    routed_experts = choice.get("routed_experts") or (data.get("nvext") or {}).get(
-        "routed_experts"
-    )
+    # vLLM routed_experts sidecar ({shape, data}) passed through unchanged. Not
+    # surfaced on dynamo_chat: its nvext shape differs from the downstream
+    # RoutedExpertsPayload contract (base64 + ``start``).
+    routed_experts = choice.get("routed_experts")
 
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
@@ -385,7 +382,9 @@ async def generate(
         finish_reason = "tool_calls"
 
     return {
-        "request_id": data.get("request_id") or data.get("id") or "",
+        "request_id": data.get("request_id")
+        or (data.get("id") if is_dynamo else None)
+        or "",
         "prompt_ids": list(prompt_ids),
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
@@ -450,7 +449,7 @@ async def _post_dynamo_chat(
         "stream": False,
         "nvext": {
             "token_data": list(prompt_ids),
-            "extra_fields": ["engine_data", "routed_experts"],
+            "extra_fields": ["engine_data"],
         },
     }
     # tools are NOT sent on the wire: the renderer already bakes them into

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -292,20 +292,18 @@ class _DynamoChatTransport(_Transport):
                 "path for VLMs."
             )
         body = self._build_body(model, prompt_ids, sp, cache_salt, priority)
-        post_kwargs: dict[str, Any] = {
-            "cast_to": cast(Any, dict[str, Any]),
-            "body": body,
-        }
+        post_kwargs: dict[str, Any] = {"cast_to": httpx.Response, "body": body}
         if extra_headers:
             post_kwargs["options"] = cast(Any, {"headers": extra_headers})
         # Engine 4xx propagate raw (matches the vLLM path).
-        resp = await client.post("/chat/completions", **post_kwargs)
-        # Dynamo's NvExt request schema carries no field for
-        # routed_experts_prompt_start, so the worker can't trim the prompt rows:
-        # it returns full-sequence routing with start=0. Trim the leading prompt
-        # rows here and set start, so the payload matches the consumer contract
-        # (row 0 == position start). NOTE: if a forwarded prompt-start field is
-        # later added to NvExt (worker trims + reports start), drop this.
+        raw_response = await client.post("/chat/completions", **post_kwargs)
+        # Keep the (potentially large) routed_experts base64 blob as a zero-copy
+        # memoryview instead of decoding it through json.loads — a synchronous
+        # full parse of the blob stalls the event loop. Mirrors vllm_generate.
+        resp = _parse_dynamo_chat_response(raw_response.content)
+        # Back-compat trim: when the worker did NOT trim engine-side (start=0; it
+        # trims when it honors nvext.routed_experts_prompt_start), drop the leading
+        # prompt rows here so row 0 == start. No-op once the worker stamps start>0.
         _trim_dynamo_routed_experts(resp, sp)
         return resp
 
@@ -519,7 +517,9 @@ def _trim_dynamo_routed_experts(resp: Any, sp: dict[str, Any]) -> None:
         return
     data = routed.get("data")
     shape = routed.get("shape")
-    if not isinstance(data, str) or not (
+    # data may be a zero-copy memoryview/bytes (engine_data blob kept un-parsed)
+    # or a str; base64.b64decode accepts all three.
+    if not isinstance(data, (str, bytes, memoryview)) or not (
         isinstance(shape, (list, tuple)) and len(shape) == 3
     ):
         return
@@ -573,6 +573,28 @@ def parse_generate_response(raw: bytes) -> dict[str, Any]:
     payload: dict[str, Any] = json.loads(stripped)
     if routed_data is not None:
         payload["choices"][0]["routed_experts"]["data"] = routed_data
+    return payload
+
+
+def _parse_dynamo_chat_response(raw: bytes) -> dict[str, Any]:
+    """Parse a dynamo_chat response, keeping the routed_experts base64 blob as a
+    zero-copy ``memoryview`` instead of decoding it through ``json.loads`` (a
+    large blob would block the event loop). Mirrors ``parse_generate_response``,
+    but re-attaches the blob at the nvext location (``nvext.routed_experts`` or
+    ``nvext.engine_data.routed_experts``) rather than ``choices[0]``."""
+    stripped, routed_data = strip_routed_experts_data(raw)
+    payload: dict[str, Any] = json.loads(stripped)
+    if routed_data is not None:
+        nvext = payload.get("nvext")
+        if isinstance(nvext, dict):
+            routed = nvext.get("routed_experts")
+            if not isinstance(routed, dict):
+                engine = nvext.get("engine_data")
+                routed = (
+                    engine.get("routed_experts") if isinstance(engine, dict) else None
+                )
+            if isinstance(routed, dict):
+                routed["data"] = routed_data
     return payload
 
 

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -410,9 +410,13 @@ class _DynamoChatTransport(_Transport):
         # positionally aligned with the ids. The choices[0] chat logprobs are a
         # detokenize/retokenize echo that can diverge from the sampled ids, which
         # would misalign while still passing the length check below. Fall back to
-        # the chat logprobs only when the engine channel carries none.
-        logprobs = [float(x) for x in engine.get("completion_logprobs") or []]
-        if not logprobs:
+        # the chat logprobs only when the engine channel is absent — a present
+        # but empty engine list is authoritative (logprobs off) and must NOT
+        # fall through to the chat echo (distinguish presence from truthiness).
+        engine_logprobs = engine.get("completion_logprobs")
+        if engine_logprobs is not None:
+            logprobs = [float(x) for x in engine_logprobs]
+        else:
             logprobs = _flatten_chat_logprobs(choice)
         # Logprobs are indexed positionally against completion_ids downstream;
         # a length mismatch would silently misalign tokens and logprobs.

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -2,12 +2,12 @@
 
 Two transports, selected per-call via ``transport=`` parameter:
 
-    "prime_vllm_generate" (default)
+    "vllm_generate" (default)
         messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
         → completion tokens → Renderer.parse_response() → structured message
         vLLM's TITO surface (server.py mounts the route in prime-rl).
 
-    "dynamo_chat_nvext"
+    "dynamo_chat"
         messages → Renderer.render_ids() → token IDs → POST /v1/chat/completions
         with ``nvext.token_data`` + ``nvext.extra_fields=["engine_data"]``
         → completion tokens via ``nvext.engine_data.completion_token_ids``
@@ -120,7 +120,7 @@ async def _resolve_max_prompt_len(client: AsyncOpenAI, model: str) -> int | None
         return value
 
 # Public type alias; matches verifiers.types.RendererTransport string set.
-RendererTransport = Literal["prime_vllm_generate", "dynamo_chat_nvext"]
+RendererTransport = Literal["vllm_generate", "dynamo_chat"]
 
 
 async def _maybe_offload(renderer: Renderer | RendererPool, fn):
@@ -168,7 +168,7 @@ async def generate(
     prompt_attribution: RenderedTokens | None = None,
     tools: list[ToolSpec] | None = None,
     sampling_params: dict[str, Any] | None = None,
-    transport: RendererTransport = "prime_vllm_generate",
+    transport: RendererTransport = "vllm_generate",
     cache_salt: str | None = None,
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
@@ -260,25 +260,19 @@ async def generate(
     sp["logprobs"] = 1
     sp.setdefault("skip_special_tokens", False)
 
-    features = (
-        _build_mm_features(renderer, mm_data)
-        if mm_data and not mm_data.is_empty()
-        else None
-    )
-
-    if transport == "dynamo_chat_nvext":
+    if transport == "dynamo_chat":
         # Dynamo branch: POST /v1/chat/completions with nvext.token_data.
         # Dynamo has no /inference/v1/generate route; the equivalent TITO
         # surface lives on chat-completions via the ``nvext`` envelope
         # (PR #8119: response token IDs come back under
         # ``nvext.engine_data.completion_token_ids``).
-        if features is not None:
+        if mm_data is not None and not mm_data.is_empty():
             raise NotImplementedError(
                 "Multimodal renderers are not yet supported on the "
-                "dynamo_chat_nvext transport. Use prime_vllm_generate or "
+                "dynamo_chat transport. Use vllm_generate or "
                 "stay on the token-client TITO path for VLMs."
             )
-        data = await _post_dynamo_chat_nvext(
+        data = await _post_dynamo_chat(
             client=client,
             model=model,
             prompt_ids=prompt_ids,
@@ -289,8 +283,13 @@ async def generate(
             extra_headers=extra_headers,
             messages=messages,
         )
-    else:
-        # vLLM-native branch: POST /inference/v1/generate (vLLM 0.20 TITO).
+    elif transport == "vllm_generate":
+        # vLLM-native branch: POST /inference/v1/generate (unchanged from upstream).
+        features = (
+            _build_mm_features(renderer, mm_data)
+            if mm_data and not mm_data.is_empty()
+            else None
+        )
         body: dict[str, Any] = {
             "model": model,
             "token_ids": prompt_ids,
@@ -315,21 +314,15 @@ async def generate(
             sp.get("max_tokens"),
         )
         post_kwargs: dict[str, Any] = {
-            "cast_to": cast(Any, dict[str, Any]),
+            "cast_to": httpx.Response,
             "body": body,
         }
         if extra_headers:
             post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-        try:
-            data = await client.post(endpoint, **post_kwargs)
-        except BadRequestError as exc:
-            _log_overlong_prompt_diagnostic(
-                prompt_ids=prompt_ids,
-                messages=messages,
-                max_tokens=sp.get("max_tokens"),
-                exc=exc,
-            )
-            raise
+        raw_response = await client.post(endpoint, **post_kwargs)
+        data = parse_generate_response(raw_response.content)
+    else:
+        raise ValueError(f"Unknown renderer transport: {transport!r}")
 
     choice = (data.get("choices") or [{}])[0]
     # Dynamo emits engine token IDs under ``nvext.engine_data.completion_token_ids``
@@ -346,6 +339,13 @@ async def generate(
             or []
         )
     completion_ids = list(completion_ids or [])
+    if transport == "dynamo_chat" and not completion_ids:
+        # Fail loudly rather than parse an empty completion (usually a missing
+        # nvext.extra_fields=["engine_data"] opt-in).
+        raise RuntimeError(
+            "dynamo_chat response carried no completion token IDs "
+            "(expected nvext.engine_data.completion_token_ids)."
+        )
 
     parsed = await _maybe_offload(
         renderer, lambda: renderer.parse_response(completion_ids, tools=tools)
@@ -365,16 +365,11 @@ async def generate(
         if engine_lp:
             completion_logprobs = [float(x) for x in engine_lp]
 
-    routed_experts = None
-    raw_re = choice.get("routed_experts") or (data.get("nvext") or {}).get(
+    # Pass the routed_experts sidecar through unchanged (binary {shape, data}
+    # for vLLM; same dict under nvext for Dynamo). Decoding is the consumer's job.
+    routed_experts = choice.get("routed_experts") or (data.get("nvext") or {}).get(
         "routed_experts"
     )
-    if isinstance(raw_re, dict) and "data" in raw_re and "shape" in raw_re:
-        routed_experts = (
-            np.frombuffer(base64.b85decode(raw_re["data"]), dtype=np.int32)
-            .reshape(raw_re["shape"])
-            .tolist()
-        )
 
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
@@ -414,7 +409,7 @@ async def generate(
     }
 
 
-async def _post_dynamo_chat_nvext(
+async def _post_dynamo_chat(
     *,
     client: AsyncOpenAI,
     model: str,
@@ -428,7 +423,7 @@ async def _post_dynamo_chat_nvext(
 ) -> dict[str, Any]:
     """POST ``prompt_ids`` to Dynamo's ``/v1/chat/completions`` route.
 
-    Mirrors ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat_nvext``
+    Mirrors ``verifiers.clients.openai_chat_completions_token_client._post_dynamo_chat``
     in shape, so the wire payload is identical whether the rollout goes
     through the token client or the renderer client. Anything that lands
     on Dynamo's chat-completions surface, lands here.
@@ -458,8 +453,8 @@ async def _post_dynamo_chat_nvext(
             "extra_fields": ["engine_data", "routed_experts"],
         },
     }
-    if tools:
-        body["tools"] = tools
+    # tools are NOT sent on the wire: the renderer already bakes them into
+    # token_data, and renderer ToolSpec isn't the OpenAI tool shape (would 400).
     if cache_salt is not None:
         body["nvext"]["cache_salt"] = cache_salt
     if priority is not None:
@@ -513,16 +508,8 @@ async def _post_dynamo_chat_nvext(
     }
     if extra_headers:
         post_kwargs["options"] = cast(Any, {"headers": extra_headers})
-    try:
-        return await client.post("/chat/completions", **post_kwargs)
-    except BadRequestError as exc:
-        _log_overlong_prompt_diagnostic(
-            prompt_ids=prompt_ids,
-            messages=messages,
-            max_tokens=sp.get("max_tokens"),
-            exc=exc,
-        )
-        raise
+    # Engine 4xx propagate raw (matches the vLLM path).
+    return await client.post("/chat/completions", **post_kwargs)
 
 
 def _build_mm_features(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -581,6 +581,14 @@ def test_trim_dynamo_routed_experts():
     _trim_dynamo_routed_experts(resp4, {"routed_experts_prompt_start": 3})
     assert resp4 == {"nvext": {"engine_data": {}}}
 
+    # unknown dtype -> RuntimeError (hard fail, not silent itemsize=1 fallback)
+    resp_bad = {"nvext": {"engine_data": {"routed_experts": {
+        "data": base64.b64encode(bytes([0, 1, 2, 3, 4])).decode(),
+        "shape": [5, 1, 1], "start": 0, "dtype": "float16",
+    }}}}
+    with pytest.raises(RuntimeError, match="unknown routed_experts dtype"):
+        _trim_dynamo_routed_experts(resp_bad, {"routed_experts_prompt_start": 3})
+
 
 def test_dynamo_parse_present_empty_engine_logprobs_raises_for_nonempty_completion():
     """A present-but-empty engine_data.completion_logprobs is authoritative for

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -509,6 +509,30 @@ def test_dynamo_transport_merges_caller_nvext():
     assert nvext["annotations"] == ["trace"]
 
 
+def test_dynamo_transport_routes_sampling_params_cache_salt_and_priority_to_nvext():
+    """cache_salt/priority supplied inside sampling_params (not the dedicated
+    kwargs) must still land in nvext, never as top-level chat fields."""
+    client = _DynamoFakeClient()
+    asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={"max_tokens": 7, "cache_salt": "ckpt-9", "priority": 5},
+            transport="dynamo_chat",
+            max_prompt_len=10_000,
+        )
+    )
+    body = client.calls[0]["body"]
+    assert body["nvext"]["cache_salt"] == "ckpt-9"
+    assert body["nvext"]["agent_hints"] == {"priority": 5}
+    # neither leaks to a top-level chat field
+    assert "cache_salt" not in body
+    assert "priority" not in body
+
+
 class _BothTokenIdsClient(_FakeClient):
     """Dynamo response carrying engine_data.completion_token_ids AND a divergent
     choices[0].token_ids — the canonical engine channel must win (F3)."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -280,7 +280,7 @@ def test_generate_threads_prompt_attribution_through_prebuilt_prompt_path():
 
 class _DynamoFakeClient(_FakeClient):
     """Dynamo-shaped response: engine fields + routed_experts under nvext (not
-    choices[0]), so the test proves routed_experts is dropped on dynamo_chat."""
+    choices[0]); used to prove routed_experts now surfaces on dynamo_chat."""
 
     async def post(self, path, *, cast_to=dict, body=None, options=None):
         self.calls.append(
@@ -297,7 +297,12 @@ class _DynamoFakeClient(_FakeClient):
             ],
             "nvext": {
                 "engine_data": {"completion_token_ids": [7, 8]},
-                "routed_experts": {"data": "AQI=", "shape": [2, 1, 1]},
+                "routed_experts": {
+                    "data": "AQI=",
+                    "shape": [2, 1, 1],
+                    "start": 0,
+                    "dtype": "uint8",
+                },
             },
         }
 
@@ -333,7 +338,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "stream": False,
         "nvext": {
             "token_data": [1, 2, 3],
-            "extra_fields": ["engine_data"],
+            "extra_fields": ["engine_data", "routed_experts"],
             "cache_salt": "ckpt-42",
             "agent_hints": {"priority": 17},
         },
@@ -348,8 +353,14 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "detokenize": False,
     }
     assert result["completion_ids"] == [7, 8]
-    # routed_experts is dropped on dynamo_chat (nvext shape != downstream contract).
-    assert result["routed_experts"] is None
+    # routed_experts now surfaces on dynamo_chat via nvext.routed_experts,
+    # passed through as the prime-rl {data, shape, start, dtype} contract.
+    assert result["routed_experts"] == {
+        "data": "AQI=",
+        "shape": [2, 1, 1],
+        "start": 0,
+        "dtype": "uint8",
+    }
 
 
 class _NoCompletionIdsClient(_FakeClient):
@@ -458,8 +469,10 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
                 "frequency_penalty": 0.25,
                 "stop": ["</s>"],
                 "guided_json": {"type": "object"},
-                # denylisted / renderer-internal — must NOT hit the wire
+                # denylisted — must NOT hit the wire
                 "return_token_ids": True,
+                # renderer-internal: forwarded via nvext.extra_args (below),
+                # never as a top-level chat field
                 "routed_experts_prompt_start": 3,
             },
             transport="dynamo_chat",
@@ -472,7 +485,14 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
     assert body["stop"] == ["</s>"]
     assert body["guided_json"] == {"type": "object"}
     assert "return_token_ids" not in body
+    # routed_experts_prompt_start is not a top-level field; it rides
+    # nvext.extra_args.sampling_options so the worker applies it to vLLM
+    # SamplingParams (trims the prompt rows) and echoes it back as start.
     assert "routed_experts_prompt_start" not in body
+    assert (
+        body["nvext"]["extra_args"]["sampling_options"]["routed_experts_prompt_start"]
+        == 3
+    )
 
 
 def test_dynamo_transport_merges_caller_nvext():
@@ -501,8 +521,8 @@ def test_dynamo_transport_merges_caller_nvext():
     )
     nvext = client.calls[0]["body"]["nvext"]
     assert nvext["token_data"] == [1, 2, 3]
-    # extra_fields union preserves caller "timing" + our "engine_data"
-    assert nvext["extra_fields"] == ["timing", "engine_data"]
+    # extra_fields union preserves caller "timing" + our "engine_data"/"routed_experts"
+    assert nvext["extra_fields"] == ["timing", "engine_data", "routed_experts"]
     # agent_hints merged: caller osl kept, priority overlaid
     assert nvext["agent_hints"] == {"osl": 4, "priority": 9}
     # unrelated caller nvext keys survive

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -309,7 +309,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "stream": False,
         "nvext": {
             "token_data": [1, 2, 3],
-            "extra_fields": ["engine_data", "routed_experts"],
+            "extra_fields": ["engine_data"],
             "cache_salt": "ckpt-42",
             "agent_hints": {"priority": 17},
         },
@@ -355,6 +355,44 @@ def test_dynamo_transport_raises_without_completion_ids():
                 max_prompt_len=10_000,
             )
         )
+
+
+class _EmptyCompletionClient(_FakeClient):
+    """Dynamo response with a present-but-empty completion_token_ids list."""
+
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
+        return {
+            "request_id": "x",
+            "choices": [{"index": 0, "finish_reason": "stop", "logprobs": {"content": []}}],
+            "nvext": {"engine_data": {"completion_token_ids": []}},
+        }
+
+
+class _EmptyParseRenderer(_FakeRenderer):
+    def parse_response(self, completion_ids, *, tools=None) -> ParsedResponse:
+        assert completion_ids == []
+        return ParsedResponse(content="", reasoning_content=None, tool_calls=[])
+
+
+def test_dynamo_transport_allows_present_but_empty_completion():
+    """A present-but-empty completion_token_ids is a valid zero-token completion
+    and must NOT raise (only an absent field raises)."""
+    result = asyncio.run(
+        generate(
+            client=_EmptyCompletionClient(),
+            renderer=_EmptyParseRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={"max_tokens": 7},
+            transport="dynamo_chat",
+            max_prompt_len=10_000,
+        )
+    )
+    assert result["completion_ids"] == []
 
 
 class _BoomClient(_FakeClient):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -275,6 +275,55 @@ def test_generate_threads_prompt_attribution_through_prebuilt_prompt_path():
     assert result["prompt_attribution"] is supplied
 
 
+def test_dynamo_transport_forwards_priority_and_detokenize():
+    client = _FakeClient()
+
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={
+                "temperature": 0.3,
+                "max_tokens": 7,
+                "detokenize": False,
+                "allowed_token_ids": [7, 8],
+                "bad_words_token_ids": [[1, 2]],
+            },
+            cache_salt="ckpt-42",
+            priority=17,
+            transport="dynamo_chat_nvext",
+        )
+    )
+
+    assert len(client.calls) == 1
+    assert client.calls[0]["path"] == "/chat/completions"
+    assert client.calls[0]["body"] == {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": ""}],
+        "stream": False,
+        "nvext": {
+            "token_data": [1, 2, 3],
+            "extra_fields": ["engine_data", "routed_experts"],
+            "cache_salt": "ckpt-42",
+            "agent_hints": {"priority": 17},
+        },
+        "tools": [{"type": "function", "function": {"name": "echo"}}],
+        "temperature": 0.3,
+        "max_completion_tokens": 7,
+        "logprobs": True,
+        "skip_special_tokens": False,
+        "stop_token_ids": [99],
+        "bad_words_token_ids": [[1, 2]],
+        "allowed_token_ids": [7, 8],
+        "detokenize": False,
+    }
+    assert result["completion_ids"] == [7, 8]
+    assert result["routed_experts"] == [[[1]], [[2]]]
+
+
 # ---------------------------------------------------------------------------
 # Multimodal features payload.
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -441,6 +441,149 @@ def test_generate_propagates_post_errors_raw(transport):
         )
 
 
+def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
+    """F1: sampling fields outside the old allowlist (presence_penalty, stop,
+    guided_json) must reach the wire; vLLM-only/internal keys are dropped."""
+    client = _DynamoFakeClient()
+    asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={
+                "max_tokens": 7,
+                "presence_penalty": 0.5,
+                "frequency_penalty": 0.25,
+                "stop": ["</s>"],
+                "guided_json": {"type": "object"},
+                # denylisted / renderer-internal — must NOT hit the wire
+                "return_token_ids": True,
+                "routed_experts_prompt_start": 3,
+            },
+            transport="dynamo_chat",
+            max_prompt_len=10_000,
+        )
+    )
+    body = client.calls[0]["body"]
+    assert body["presence_penalty"] == 0.5
+    assert body["frequency_penalty"] == 0.25
+    assert body["stop"] == ["</s>"]
+    assert body["guided_json"] == {"type": "object"}
+    assert "return_token_ids" not in body
+    assert "routed_experts_prompt_start" not in body
+
+
+def test_dynamo_transport_merges_caller_nvext():
+    """F2: caller-supplied nvext is merged — extra_fields union with engine_data,
+    agent_hints merged with priority, unrelated caller keys preserved."""
+    client = _DynamoFakeClient()
+    asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={
+                "max_tokens": 7,
+                "nvext": {
+                    "extra_fields": ["timing"],
+                    "agent_hints": {"osl": 4},
+                    "annotations": ["trace"],
+                },
+            },
+            priority=9,
+            transport="dynamo_chat",
+            max_prompt_len=10_000,
+        )
+    )
+    nvext = client.calls[0]["body"]["nvext"]
+    assert nvext["token_data"] == [1, 2, 3]
+    # extra_fields union preserves caller "timing" + our "engine_data"
+    assert nvext["extra_fields"] == ["timing", "engine_data"]
+    # agent_hints merged: caller osl kept, priority overlaid
+    assert nvext["agent_hints"] == {"osl": 4, "priority": 9}
+    # unrelated caller nvext keys survive
+    assert nvext["annotations"] == ["trace"]
+
+
+class _BothTokenIdsClient(_FakeClient):
+    """Dynamo response carrying engine_data.completion_token_ids AND a divergent
+    choices[0].token_ids — the canonical engine channel must win (F3)."""
+
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
+        return {
+            "id": "gen-dyn",
+            "choices": [
+                {
+                    "index": 0,
+                    "token_ids": [99, 99],  # divergent echo — must be ignored
+                    "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
+                    "finish_reason": "stop",
+                }
+            ],
+            "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},
+        }
+
+
+def test_dynamo_transport_prefers_engine_data_over_choices_token_ids():
+    client = _BothTokenIdsClient()
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=_FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+            sampling_params={"max_tokens": 7},
+            transport="dynamo_chat",
+            max_prompt_len=10_000,
+        )
+    )
+    assert result["completion_ids"] == [7, 8]
+
+
+class _MisalignedLogprobsClient(_FakeClient):
+    """Dynamo response whose logprobs length disagrees with completion_ids (F4)."""
+
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
+        return {
+            "id": "gen-dyn",
+            "choices": [
+                {
+                    "index": 0,
+                    "logprobs": {"content": [{"logprob": -0.1}]},  # only 1 logprob
+                    "finish_reason": "stop",
+                }
+            ],
+            "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},  # 2 tokens
+        }
+
+
+def test_dynamo_transport_raises_on_logprob_length_mismatch():
+    with pytest.raises(RuntimeError, match="logprobs length"):
+        asyncio.run(
+            generate(
+                client=_MisalignedLogprobsClient(),
+                renderer=_FakeRenderer(),
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+                tools=[{"type": "function", "function": {"name": "echo"}}],
+                sampling_params={"max_tokens": 7},
+                transport="dynamo_chat",
+                max_prompt_len=10_000,
+            )
+        )
+
+
 # ---------------------------------------------------------------------------
 # Multimodal features payload.
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -387,7 +387,9 @@ class _EmptyCompletionClient(_FakeClient):
         )
         return {
             "request_id": "x",
-            "choices": [{"index": 0, "finish_reason": "stop", "logprobs": {"content": []}}],
+            "choices": [
+                {"index": 0, "finish_reason": "stop", "logprobs": {"content": []}}
+            ],
             "nvext": {"engine_data": {"completion_token_ids": []}},
         }
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,17 @@ class _FakeClient:
         self.calls = []
         self.base_url = "http://fake-host:8000/v1"
 
+    @staticmethod
+    def _as_response(payload, cast_to):
+        """Both transports request cast_to=httpx.Response; deliver the payload as
+        JSON bytes off the wire so the client exercises the zero-copy
+        routed_experts strip. Falls back to the raw dict otherwise."""
+        if cast_to is httpx.Response:
+            return httpx.Response(
+                200, content=json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            )
+        return payload
+
     async def post(self, path, *, cast_to=dict, body=None, options=None):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
@@ -286,26 +297,31 @@ class _DynamoFakeClient(_FakeClient):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        return {
-            "id": "gen-dyn",
-            "choices": [
-                {
-                    "index": 0,
-                    "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
-                    "finish_reason": "stop",
-                }
-            ],
-            "nvext": {
-                "engine_data": {"completion_token_ids": [7, 8]},
-                "routed_experts": {
-                    # full-sequence routing (4 rows); worker can't trim
-                    "data": "AQIDBA==",
-                    "shape": [4, 1, 1],
-                    "start": 0,
-                    "dtype": "uint8",
+        return self._as_response(
+            {
+                "id": "gen-dyn",
+                "choices": [
+                    {
+                        "index": 0,
+                        "logprobs": {
+                            "content": [{"logprob": -0.1}, {"logprob": -0.2}]
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "nvext": {
+                    "engine_data": {"completion_token_ids": [7, 8]},
+                    "routed_experts": {
+                        # full-sequence routing (4 rows); worker can't trim
+                        "data": "AQIDBA==",
+                        "shape": [4, 1, 1],
+                        "start": 0,
+                        "dtype": "uint8",
+                    },
                 },
             },
-        }
+            cast_to,
+        )
 
 
 def test_dynamo_transport_forwards_priority_and_detokenize():
@@ -358,12 +374,11 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
     # contract. No routed_experts_prompt_start is set here (first-turn case), so
     # the renderer does NOT trim — full-sequence routing passes through with
     # start=0.
-    assert result["routed_experts"] == {
-        "data": "AQIDBA==",
-        "shape": [4, 1, 1],
-        "start": 0,
-        "dtype": "uint8",
-    }
+    re = result["routed_experts"]
+    assert re["shape"] == [4, 1, 1] and re["start"] == 0 and re["dtype"] == "uint8"
+    # data rides as a zero-copy memoryview (not json-parsed), like vllm_generate.
+    assert isinstance(re["data"], memoryview)
+    assert re["data"].tobytes() == b"AQIDBA=="
 
 
 class _NoCompletionIdsClient(_FakeClient):
@@ -373,7 +388,10 @@ class _NoCompletionIdsClient(_FakeClient):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        return {"request_id": "x", "choices": [{"index": 0, "finish_reason": "stop"}]}
+        return self._as_response(
+            {"request_id": "x", "choices": [{"index": 0, "finish_reason": "stop"}]},
+            cast_to,
+        )
 
 
 def test_dynamo_transport_raises_without_completion_ids():
@@ -399,13 +417,16 @@ class _EmptyCompletionClient(_FakeClient):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        return {
-            "request_id": "x",
-            "choices": [
-                {"index": 0, "finish_reason": "stop", "logprobs": {"content": []}}
-            ],
-            "nvext": {"engine_data": {"completion_token_ids": []}},
-        }
+        return self._as_response(
+            {
+                "request_id": "x",
+                "choices": [
+                    {"index": 0, "finish_reason": "stop", "logprobs": {"content": []}}
+                ],
+                "nvext": {"engine_data": {"completion_token_ids": []}},
+            },
+            cast_to,
+        )
 
 
 class _EmptyParseRenderer(_FakeRenderer):
@@ -525,6 +546,15 @@ def test_trim_dynamo_routed_experts():
     re2 = resp2["nvext"]["routed_experts"]
     assert re2["shape"] == [2, 1, 1] and re2["start"] == 3
 
+    # data as a zero-copy memoryview (the parse keeps the blob un-decoded) still
+    # trims on the back-compat path: b64decode accepts memoryview.
+    resp_mv = _payload("engine_data")
+    re_mv = resp_mv["nvext"]["engine_data"]["routed_experts"]
+    re_mv["data"] = memoryview(re_mv["data"].encode("ascii"))
+    _trim_dynamo_routed_experts(resp_mv, {"routed_experts_prompt_start": 3})
+    assert re_mv["shape"] == [2, 1, 1] and re_mv["start"] == 3
+    assert base64.b64decode(re_mv["data"]) == bytes([3, 4])
+
     # worker already trimmed engine-side (start>0) -> no-op (don't double-trim)
     resp_wt = {"nvext": {"engine_data": {"routed_experts": {
         "data": base64.b64encode(bytes([3, 4])).decode(),
@@ -643,18 +673,23 @@ class _BothTokenIdsClient(_FakeClient):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        return {
-            "id": "gen-dyn",
-            "choices": [
-                {
-                    "index": 0,
-                    "token_ids": [99, 99],  # divergent echo — must be ignored
-                    "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
-                    "finish_reason": "stop",
-                }
-            ],
-            "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},
-        }
+        return self._as_response(
+            {
+                "id": "gen-dyn",
+                "choices": [
+                    {
+                        "index": 0,
+                        "token_ids": [99, 99],  # divergent echo — must be ignored
+                        "logprobs": {
+                            "content": [{"logprob": -0.1}, {"logprob": -0.2}]
+                        },
+                        "finish_reason": "stop",
+                    }
+                ],
+                "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},
+            },
+            cast_to,
+        )
 
 
 def test_dynamo_transport_prefers_engine_data_over_choices_token_ids():
@@ -681,17 +716,20 @@ class _MisalignedLogprobsClient(_FakeClient):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        return {
-            "id": "gen-dyn",
-            "choices": [
-                {
-                    "index": 0,
-                    "logprobs": {"content": [{"logprob": -0.1}]},  # only 1 logprob
-                    "finish_reason": "stop",
-                }
-            ],
-            "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},  # 2 tokens
-        }
+        return self._as_response(
+            {
+                "id": "gen-dyn",
+                "choices": [
+                    {
+                        "index": 0,
+                        "logprobs": {"content": [{"logprob": -0.1}]},  # only 1 logprob
+                        "finish_reason": "stop",
+                    }
+                ],
+                "nvext": {"engine_data": {"completion_token_ids": [7, 8]}},  # 2 tokens
+            },
+            cast_to,
+        )
 
 
 def test_dynamo_transport_raises_on_logprob_length_mismatch():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -474,8 +474,9 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
                 "guided_json": {"type": "object"},
                 # denylisted — must NOT hit the wire
                 "return_token_ids": True,
-                # renderer-internal: never a wire field (stamped onto the
-                # response's routed_experts.start instead)
+                # not a top-level field (Dynamo rejects unknown ones); routed
+                # into nvext.routed_experts_prompt_start so the worker trims
+                # routing engine-side
                 "routed_experts_prompt_start": 3,
             },
             transport="dynamo_chat",
@@ -488,17 +489,19 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
     assert body["stop"] == ["</s>"]
     assert body["guided_json"] == {"type": "object"}
     assert "return_token_ids" not in body
-    # routed_experts_prompt_start is renderer-internal: Dynamo has no nvext
-    # field to forward it to the worker, so the renderer stamps it as
-    # routed_experts.start on the response instead. It must never hit the wire.
+    # routed_experts_prompt_start is dropped from the top level (Dynamo rejects
+    # unknown top-level fields) but routed into nvext so the worker applies it to
+    # SamplingParams and trims routing engine-side.
     assert "routed_experts_prompt_start" not in body
+    assert body["nvext"]["routed_experts_prompt_start"] == 3
     assert "extra_args" not in body.get("nvext", {})
 
 
 def test_trim_dynamo_routed_experts():
-    """The dynamo transport trims leading prompt rows ONLY when the caller
-    supplies routed_experts_prompt_start (worker returns full routing, start=0).
-    Absent start (first turn), offset 0, or absent routed_experts are no-ops."""
+    """Client-side trim is a back-compat fallback: it trims ONLY when the worker
+    returned full routing (start=0) AND the caller supplied a positive
+    routed_experts_prompt_start. No-op when the worker already trimmed (start>0),
+    no offset is supplied (first turn), offset is 0, or routed_experts is absent."""
     from renderers.client import _trim_dynamo_routed_experts
 
     def _payload(channel):
@@ -521,6 +524,16 @@ def test_trim_dynamo_routed_experts():
     _trim_dynamo_routed_experts(resp2, {"routed_experts_prompt_start": 3})
     re2 = resp2["nvext"]["routed_experts"]
     assert re2["shape"] == [2, 1, 1] and re2["start"] == 3
+
+    # worker already trimmed engine-side (start>0) -> no-op (don't double-trim)
+    resp_wt = {"nvext": {"engine_data": {"routed_experts": {
+        "data": base64.b64encode(bytes([3, 4])).decode(),
+        "shape": [2, 1, 1], "start": 3, "dtype": "uint8",
+    }}}}
+    _trim_dynamo_routed_experts(resp_wt, {"routed_experts_prompt_start": 3})
+    rewt = resp_wt["nvext"]["engine_data"]["routed_experts"]
+    assert rewt["shape"] == [2, 1, 1] and rewt["start"] == 3
+    assert base64.b64decode(rewt["data"]) == bytes([3, 4])
 
     # absent start (first turn) -> NO trim, full-sequence with start=0
     resp3 = _payload("engine_data")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -582,9 +582,9 @@ def test_trim_dynamo_routed_experts():
     assert resp4 == {"nvext": {"engine_data": {}}}
 
 
-def test_dynamo_parse_present_empty_engine_logprobs_does_not_fall_back_to_chat():
-    """A present-but-empty engine_data.completion_logprobs is authoritative
-    (logprobs off): parse must NOT fall through to the divergent chat echo."""
+def test_dynamo_parse_present_empty_engine_logprobs_raises_for_nonempty_completion():
+    """A present-but-empty engine_data.completion_logprobs is authoritative for
+    source selection, but nonempty completions still require aligned logprobs."""
     data = {
         "choices": [
             {
@@ -602,9 +602,8 @@ def test_dynamo_parse_present_empty_engine_logprobs_does_not_fall_back_to_chat()
     }
     from renderers.client import _TRANSPORTS
 
-    wire = _TRANSPORTS["dynamo_chat"].parse(data)
-    assert wire.completion_ids == [7, 8]
-    assert wire.completion_logprobs == []  # engine present-empty wins over chat echo
+    with pytest.raises(RuntimeError, match="logprobs length"):
+        _TRANSPORTS["dynamo_chat"].parse(data)
 
 
 def test_dynamo_transport_merges_caller_nvext():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -353,12 +353,13 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "detokenize": False,
     }
     assert result["completion_ids"] == [7, 8]
-    # routed_experts now surfaces on dynamo_chat via nvext.routed_experts,
-    # passed through as the prime-rl {data, shape, start, dtype} contract.
+    # routed_experts surfaces on dynamo_chat as the {data, shape, start, dtype}
+    # contract. start is stamped by the renderer from the prompt offset
+    # (no routed_experts_prompt_start set here -> prompt_len - 1 = 2).
     assert result["routed_experts"] == {
         "data": "AQI=",
         "shape": [2, 1, 1],
-        "start": 0,
+        "start": 2,
         "dtype": "uint8",
     }
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -471,8 +471,8 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
                 "guided_json": {"type": "object"},
                 # denylisted — must NOT hit the wire
                 "return_token_ids": True,
-                # renderer-internal: forwarded via nvext.extra_args (below),
-                # never as a top-level chat field
+                # renderer-internal: never a wire field (stamped onto the
+                # response's routed_experts.start instead)
                 "routed_experts_prompt_start": 3,
             },
             transport="dynamo_chat",
@@ -485,14 +485,33 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
     assert body["stop"] == ["</s>"]
     assert body["guided_json"] == {"type": "object"}
     assert "return_token_ids" not in body
-    # routed_experts_prompt_start is not a top-level field; it rides
-    # nvext.extra_args.sampling_options so the worker applies it to vLLM
-    # SamplingParams (trims the prompt rows) and echoes it back as start.
+    # routed_experts_prompt_start is renderer-internal: Dynamo has no nvext
+    # field to forward it to the worker, so the renderer stamps it as
+    # routed_experts.start on the response instead. It must never hit the wire.
     assert "routed_experts_prompt_start" not in body
-    assert (
-        body["nvext"]["extra_args"]["sampling_options"]["routed_experts_prompt_start"]
-        == 3
-    )
+    assert "extra_args" not in body.get("nvext", {})
+
+
+def test_stamp_dynamo_routed_experts_start():
+    """The dynamo transport stamps routed_experts.start (the worker returns
+    full routing with start=0): caller's routed_experts_prompt_start wins,
+    else prompt_len-1; absent routed_experts is a no-op."""
+    from renderers.client import _stamp_dynamo_routed_experts_start
+
+    # caller-provided prompt_start wins (engine_data channel)
+    resp = {"nvext": {"engine_data": {"routed_experts": {"data": "x", "shape": [5, 1, 1], "start": 0}}}}
+    _stamp_dynamo_routed_experts_start(resp, [1, 2, 3, 4], {"routed_experts_prompt_start": 3})
+    assert resp["nvext"]["engine_data"]["routed_experts"]["start"] == 3
+
+    # fallback to prompt_len - 1 (top-level routed_experts channel)
+    resp2 = {"nvext": {"routed_experts": {"data": "x", "shape": [5, 1, 1], "start": 0}}}
+    _stamp_dynamo_routed_experts_start(resp2, [1, 2, 3, 4], {})
+    assert resp2["nvext"]["routed_experts"]["start"] == 3
+
+    # no routed_experts -> no-op
+    resp3 = {"nvext": {"engine_data": {}}}
+    _stamp_dynamo_routed_experts_start(resp3, [1, 2], {})
+    assert resp3 == {"nvext": {"engine_data": {}}}
 
 
 def test_dynamo_transport_merges_caller_nvext():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -355,13 +355,13 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
     }
     assert result["completion_ids"] == [7, 8]
     # routed_experts surfaces on dynamo_chat as the {data, shape, start, dtype}
-    # contract. The renderer trims the leading prompt rows (offset = prompt_len
-    # - 1 = 2 here, no routed_experts_prompt_start set): 4 rows -> last 2, with
-    # start=2 so row 0 is the boundary the consumer expects.
+    # contract. No routed_experts_prompt_start is set here (first-turn case), so
+    # the renderer does NOT trim — full-sequence routing passes through with
+    # start=0.
     assert result["routed_experts"] == {
-        "data": "AwQ=",
-        "shape": [2, 1, 1],
-        "start": 2,
+        "data": "AQIDBA==",
+        "shape": [4, 1, 1],
+        "start": 0,
         "dtype": "uint8",
     }
 
@@ -496,42 +496,46 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
 
 
 def test_trim_dynamo_routed_experts():
-    """The dynamo transport trims leading prompt rows (worker returns full
-    routing, start=0) and sets start: caller's routed_experts_prompt_start
-    wins, else prompt_len-1; offset 0 / absent routed_experts is a no-op."""
+    """The dynamo transport trims leading prompt rows ONLY when the caller
+    supplies routed_experts_prompt_start (worker returns full routing, start=0).
+    Absent start (first turn), offset 0, or absent routed_experts are no-ops."""
     from renderers.client import _trim_dynamo_routed_experts
 
     def _payload(channel):
-        return {"nvext": {channel: {"routed_experts": {
+        re = {
             "data": base64.b64encode(bytes([0, 1, 2, 3, 4])).decode(),
             "shape": [5, 1, 1], "start": 0, "dtype": "uint8",
-        }}}} if channel == "engine_data" else {"nvext": {"routed_experts": {
-            "data": base64.b64encode(bytes([0, 1, 2, 3, 4])).decode(),
-            "shape": [5, 1, 1], "start": 0, "dtype": "uint8",
-        }}}
+        }
+        return {"nvext": {channel: {"routed_experts": re}} if channel == "engine_data"
+                else {"routed_experts": re}}
 
-    # caller-provided prompt_start=3 -> drop 3 rows, start=3 (engine_data channel)
+    # explicit prompt_start=3 -> drop 3 rows, start=3 (engine_data channel)
     resp = _payload("engine_data")
-    _trim_dynamo_routed_experts(resp, [1, 2, 3, 4], {"routed_experts_prompt_start": 3})
+    _trim_dynamo_routed_experts(resp, {"routed_experts_prompt_start": 3})
     re = resp["nvext"]["engine_data"]["routed_experts"]
     assert re["shape"] == [2, 1, 1] and re["start"] == 3
     assert base64.b64decode(re["data"]) == bytes([3, 4])
 
-    # fallback prompt_len-1 = 3 (top-level routed_experts channel)
+    # explicit prompt_start=3 (top-level routed_experts channel)
     resp2 = _payload("routed_experts")
-    _trim_dynamo_routed_experts(resp2, [1, 2, 3, 4], {})
+    _trim_dynamo_routed_experts(resp2, {"routed_experts_prompt_start": 3})
     re2 = resp2["nvext"]["routed_experts"]
     assert re2["shape"] == [2, 1, 1] and re2["start"] == 3
-    assert base64.b64decode(re2["data"]) == bytes([3, 4])
+
+    # absent start (first turn) -> NO trim, full-sequence with start=0
+    resp3 = _payload("engine_data")
+    _trim_dynamo_routed_experts(resp3, {})
+    re3 = resp3["nvext"]["engine_data"]["routed_experts"]
+    assert re3["shape"] == [5, 1, 1] and re3["start"] == 0
 
     # offset 0 -> no-op
-    resp3 = _payload("engine_data")
-    _trim_dynamo_routed_experts(resp3, [1], {"routed_experts_prompt_start": 0})
-    assert resp3["nvext"]["engine_data"]["routed_experts"]["shape"] == [5, 1, 1]
+    resp0 = _payload("engine_data")
+    _trim_dynamo_routed_experts(resp0, {"routed_experts_prompt_start": 0})
+    assert resp0["nvext"]["engine_data"]["routed_experts"]["shape"] == [5, 1, 1]
 
     # absent routed_experts -> no-op
     resp4 = {"nvext": {"engine_data": {}}}
-    _trim_dynamo_routed_experts(resp4, [1, 2], {})
+    _trim_dynamo_routed_experts(resp4, {"routed_experts_prompt_start": 3})
     assert resp4 == {"nvext": {"engine_data": {}}}
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -606,6 +606,37 @@ def test_dynamo_parse_present_empty_engine_logprobs_raises_for_nonempty_completi
         _TRANSPORTS["dynamo"].parse(data)
 
 
+def test_dynamo_parse_falls_back_to_engine_routed_experts_for_placeholder():
+    """A non-dict top-level routed_experts placeholder must not hide the valid
+    engine_data.routed_experts payload."""
+    data = {
+        "choices": [{"index": 0, "finish_reason": "stop"}],
+        "nvext": {
+            "routed_experts": "placeholder",
+            "engine_data": {
+                "completion_token_ids": [7, 8],
+                "completion_logprobs": [-0.1, -0.2],
+                "routed_experts": {
+                    "data": "AQI=",
+                    "shape": [2, 1, 1],
+                    "start": 3,
+                    "dtype": "uint8",
+                },
+            },
+        },
+    }
+    from renderers.client import _TRANSPORTS
+
+    result = _TRANSPORTS["dynamo"].parse(data)
+
+    assert result.routed_experts == {
+        "data": "AQI=",
+        "shape": [2, 1, 1],
+        "start": 3,
+        "dtype": "uint8",
+    }
+
+
 def test_dynamo_transport_merges_caller_nvext():
     """F2: caller-supplied nvext is merged — extra_fields union with engine_data,
     agent_hints merged with priority, unrelated caller keys preserved."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -298,8 +298,9 @@ class _DynamoFakeClient(_FakeClient):
             "nvext": {
                 "engine_data": {"completion_token_ids": [7, 8]},
                 "routed_experts": {
-                    "data": "AQI=",
-                    "shape": [2, 1, 1],
+                    # full-sequence routing (4 rows); worker can't trim
+                    "data": "AQIDBA==",
+                    "shape": [4, 1, 1],
                     "start": 0,
                     "dtype": "uint8",
                 },
@@ -354,10 +355,11 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
     }
     assert result["completion_ids"] == [7, 8]
     # routed_experts surfaces on dynamo_chat as the {data, shape, start, dtype}
-    # contract. start is stamped by the renderer from the prompt offset
-    # (no routed_experts_prompt_start set here -> prompt_len - 1 = 2).
+    # contract. The renderer trims the leading prompt rows (offset = prompt_len
+    # - 1 = 2 here, no routed_experts_prompt_start set): 4 rows -> last 2, with
+    # start=2 so row 0 is the boundary the consumer expects.
     assert result["routed_experts"] == {
-        "data": "AQI=",
+        "data": "AwQ=",
         "shape": [2, 1, 1],
         "start": 2,
         "dtype": "uint8",
@@ -493,26 +495,44 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
     assert "extra_args" not in body.get("nvext", {})
 
 
-def test_stamp_dynamo_routed_experts_start():
-    """The dynamo transport stamps routed_experts.start (the worker returns
-    full routing with start=0): caller's routed_experts_prompt_start wins,
-    else prompt_len-1; absent routed_experts is a no-op."""
-    from renderers.client import _stamp_dynamo_routed_experts_start
+def test_trim_dynamo_routed_experts():
+    """The dynamo transport trims leading prompt rows (worker returns full
+    routing, start=0) and sets start: caller's routed_experts_prompt_start
+    wins, else prompt_len-1; offset 0 / absent routed_experts is a no-op."""
+    from renderers.client import _trim_dynamo_routed_experts
 
-    # caller-provided prompt_start wins (engine_data channel)
-    resp = {"nvext": {"engine_data": {"routed_experts": {"data": "x", "shape": [5, 1, 1], "start": 0}}}}
-    _stamp_dynamo_routed_experts_start(resp, [1, 2, 3, 4], {"routed_experts_prompt_start": 3})
-    assert resp["nvext"]["engine_data"]["routed_experts"]["start"] == 3
+    def _payload(channel):
+        return {"nvext": {channel: {"routed_experts": {
+            "data": base64.b64encode(bytes([0, 1, 2, 3, 4])).decode(),
+            "shape": [5, 1, 1], "start": 0, "dtype": "uint8",
+        }}}} if channel == "engine_data" else {"nvext": {"routed_experts": {
+            "data": base64.b64encode(bytes([0, 1, 2, 3, 4])).decode(),
+            "shape": [5, 1, 1], "start": 0, "dtype": "uint8",
+        }}}
 
-    # fallback to prompt_len - 1 (top-level routed_experts channel)
-    resp2 = {"nvext": {"routed_experts": {"data": "x", "shape": [5, 1, 1], "start": 0}}}
-    _stamp_dynamo_routed_experts_start(resp2, [1, 2, 3, 4], {})
-    assert resp2["nvext"]["routed_experts"]["start"] == 3
+    # caller-provided prompt_start=3 -> drop 3 rows, start=3 (engine_data channel)
+    resp = _payload("engine_data")
+    _trim_dynamo_routed_experts(resp, [1, 2, 3, 4], {"routed_experts_prompt_start": 3})
+    re = resp["nvext"]["engine_data"]["routed_experts"]
+    assert re["shape"] == [2, 1, 1] and re["start"] == 3
+    assert base64.b64decode(re["data"]) == bytes([3, 4])
 
-    # no routed_experts -> no-op
-    resp3 = {"nvext": {"engine_data": {}}}
-    _stamp_dynamo_routed_experts_start(resp3, [1, 2], {})
-    assert resp3 == {"nvext": {"engine_data": {}}}
+    # fallback prompt_len-1 = 3 (top-level routed_experts channel)
+    resp2 = _payload("routed_experts")
+    _trim_dynamo_routed_experts(resp2, [1, 2, 3, 4], {})
+    re2 = resp2["nvext"]["routed_experts"]
+    assert re2["shape"] == [2, 1, 1] and re2["start"] == 3
+    assert base64.b64decode(re2["data"]) == bytes([3, 4])
+
+    # offset 0 -> no-op
+    resp3 = _payload("engine_data")
+    _trim_dynamo_routed_experts(resp3, [1], {"routed_experts_prompt_start": 0})
+    assert resp3["nvext"]["engine_data"]["routed_experts"]["shape"] == [5, 1, 1]
+
+    # absent routed_experts -> no-op
+    resp4 = {"nvext": {"engine_data": {}}}
+    _trim_dynamo_routed_experts(resp4, [1, 2], {})
+    assert resp4 == {"nvext": {"engine_data": {}}}
 
 
 def test_dynamo_transport_merges_caller_nvext():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -291,7 +291,7 @@ def test_generate_threads_prompt_attribution_through_prebuilt_prompt_path():
 
 class _DynamoFakeClient(_FakeClient):
     """Dynamo-shaped response: engine fields + routed_experts under nvext (not
-    choices[0]); used to prove routed_experts now surfaces on dynamo_chat."""
+    choices[0]); used to prove routed_experts now surfaces on dynamo."""
 
     async def post(self, path, *, cast_to=dict, body=None, options=None):
         self.calls.append(
@@ -343,7 +343,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
             },
             cache_salt="ckpt-42",
             priority=17,
-            transport="dynamo_chat",
+            transport="dynamo",
         )
     )
 
@@ -370,13 +370,13 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "detokenize": False,
     }
     assert result["completion_ids"] == [7, 8]
-    # routed_experts surfaces on dynamo_chat as the {data, shape, start, dtype}
+    # routed_experts surfaces on dynamo as the {data, shape, start, dtype}
     # contract. No routed_experts_prompt_start is set here (first-turn case), so
     # the renderer does NOT trim — full-sequence routing passes through with
     # start=0.
     re = result["routed_experts"]
     assert re["shape"] == [4, 1, 1] and re["start"] == 0 and re["dtype"] == "uint8"
-    # data rides as a zero-copy memoryview (not json-parsed), like vllm_generate.
+    # data rides as a zero-copy memoryview (not json-parsed), like vllm.
     assert isinstance(re["data"], memoryview)
     assert re["data"].tobytes() == b"AQIDBA=="
 
@@ -404,7 +404,7 @@ def test_dynamo_transport_raises_without_completion_ids():
                 model="test-model",
                 tools=[{"type": "function", "function": {"name": "echo"}}],
                 sampling_params={"max_tokens": 7},
-                transport="dynamo_chat",
+                transport="dynamo",
                 max_prompt_len=10_000,
             )
         )
@@ -446,7 +446,7 @@ def test_dynamo_transport_allows_present_but_empty_completion():
             model="test-model",
             tools=[{"type": "function", "function": {"name": "echo"}}],
             sampling_params={"max_tokens": 7},
-            transport="dynamo_chat",
+            transport="dynamo",
             max_prompt_len=10_000,
         )
     )
@@ -458,7 +458,7 @@ class _BoomClient(_FakeClient):
         raise ValueError("boom")
 
 
-@pytest.mark.parametrize("transport", ["vllm_generate", "dynamo_chat"])
+@pytest.mark.parametrize("transport", ["vllm", "dynamo"])
 def test_generate_propagates_post_errors_raw(transport):
     # POST errors must propagate unchanged (no NameError from a stale handler).
     with pytest.raises(ValueError, match="boom"):
@@ -500,7 +500,7 @@ def test_dynamo_transport_forwards_extra_sampling_fields_and_drops_denylist():
                 # routing engine-side
                 "routed_experts_prompt_start": 3,
             },
-            transport="dynamo_chat",
+            transport="dynamo",
             max_prompt_len=10_000,
         )
     )
@@ -603,7 +603,7 @@ def test_dynamo_parse_present_empty_engine_logprobs_raises_for_nonempty_completi
     from renderers.client import _TRANSPORTS
 
     with pytest.raises(RuntimeError, match="logprobs length"):
-        _TRANSPORTS["dynamo_chat"].parse(data)
+        _TRANSPORTS["dynamo"].parse(data)
 
 
 def test_dynamo_transport_merges_caller_nvext():
@@ -626,7 +626,7 @@ def test_dynamo_transport_merges_caller_nvext():
                 },
             },
             priority=9,
-            transport="dynamo_chat",
+            transport="dynamo",
             max_prompt_len=10_000,
         )
     )
@@ -652,7 +652,7 @@ def test_dynamo_transport_routes_sampling_params_cache_salt_and_priority_to_nvex
             model="test-model",
             tools=[{"type": "function", "function": {"name": "echo"}}],
             sampling_params={"max_tokens": 7, "cache_salt": "ckpt-9", "priority": 5},
-            transport="dynamo_chat",
+            transport="dynamo",
             max_prompt_len=10_000,
         )
     )
@@ -701,7 +701,7 @@ def test_dynamo_transport_prefers_engine_data_over_choices_token_ids():
             model="test-model",
             tools=[{"type": "function", "function": {"name": "echo"}}],
             sampling_params={"max_tokens": 7},
-            transport="dynamo_chat",
+            transport="dynamo",
             max_prompt_len=10_000,
         )
     )
@@ -741,7 +741,7 @@ def test_dynamo_transport_raises_on_logprob_length_mismatch():
                 model="test-model",
                 tools=[{"type": "function", "function": {"name": "echo"}}],
                 sampling_params={"max_tokens": 7},
-                transport="dynamo_chat",
+                transport="dynamo",
                 max_prompt_len=10_000,
             )
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -338,7 +338,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "stream": False,
         "nvext": {
             "token_data": [1, 2, 3],
-            "extra_fields": ["engine_data", "routed_experts"],
+            "extra_fields": ["engine_data"],
             "cache_salt": "ckpt-42",
             "agent_hints": {"priority": 17},
         },
@@ -521,8 +521,8 @@ def test_dynamo_transport_merges_caller_nvext():
     )
     nvext = client.calls[0]["body"]["nvext"]
     assert nvext["token_data"] == [1, 2, 3]
-    # extra_fields union preserves caller "timing" + our "engine_data"/"routed_experts"
-    assert nvext["extra_fields"] == ["timing", "engine_data", "routed_experts"]
+    # extra_fields union preserves caller "timing" + our "engine_data"
+    assert nvext["extra_fields"] == ["timing", "engine_data"]
     # agent_hints merged: caller osl kept, priority overlaid
     assert nvext["agent_hints"] == {"osl": 4, "priority": 9}
     # unrelated caller nvext keys survive

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -278,8 +278,32 @@ def test_generate_threads_prompt_attribution_through_prebuilt_prompt_path():
     assert result["prompt_attribution"] is supplied
 
 
+class _DynamoFakeClient(_FakeClient):
+    """Dynamo-shaped response: engine fields + routed_experts under nvext (not
+    choices[0]), so the test proves routed_experts is dropped on dynamo_chat."""
+
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
+        return {
+            "id": "gen-dyn",
+            "choices": [
+                {
+                    "index": 0,
+                    "logprobs": {"content": [{"logprob": -0.1}, {"logprob": -0.2}]},
+                    "finish_reason": "stop",
+                }
+            ],
+            "nvext": {
+                "engine_data": {"completion_token_ids": [7, 8]},
+                "routed_experts": {"data": "AQI=", "shape": [2, 1, 1]},
+            },
+        }
+
+
 def test_dynamo_transport_forwards_priority_and_detokenize():
-    client = _FakeClient()
+    client = _DynamoFakeClient()
 
     result = asyncio.run(
         generate(
@@ -324,11 +348,8 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "detokenize": False,
     }
     assert result["completion_ids"] == [7, 8]
-    # routed_experts passes through unchanged (no client-side decode).
-    assert result["routed_experts"] == {
-        "data": base64.b64encode(b"\x01\x02").decode("ascii"),
-        "shape": [2, 1, 1],
-    }
+    # routed_experts is dropped on dynamo_chat (nvext shape != downstream contract).
+    assert result["routed_experts"] is None
 
 
 class _NoCompletionIdsClient(_FakeClient):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -95,10 +95,13 @@ class _FakeClient:
                 }
             ],
         }
-        return httpx.Response(
-            200,
-            content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
-        )
+        # vLLM path requests cast_to=httpx.Response; Dynamo path uses cast_to=dict.
+        if cast_to is httpx.Response:
+            return httpx.Response(
+                200,
+                content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            )
+        return payload
 
 
 def test_generate_builds_request_body_and_parses_response():
@@ -294,7 +297,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
             },
             cache_salt="ckpt-42",
             priority=17,
-            transport="dynamo_chat_nvext",
+            transport="dynamo_chat",
         )
     )
 
@@ -310,7 +313,7 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
             "cache_salt": "ckpt-42",
             "agent_hints": {"priority": 17},
         },
-        "tools": [{"type": "function", "function": {"name": "echo"}}],
+        # tools are NOT forwarded on the wire (baked into token_data instead).
         "temperature": 0.3,
         "max_completion_tokens": 7,
         "logprobs": True,
@@ -321,7 +324,60 @@ def test_dynamo_transport_forwards_priority_and_detokenize():
         "detokenize": False,
     }
     assert result["completion_ids"] == [7, 8]
-    assert result["routed_experts"] == [[[1]], [[2]]]
+    # routed_experts passes through unchanged (no client-side decode).
+    assert result["routed_experts"] == {
+        "data": base64.b64encode(b"\x01\x02").decode("ascii"),
+        "shape": [2, 1, 1],
+    }
+
+
+class _NoCompletionIdsClient(_FakeClient):
+    """Dynamo response that carries no completion token IDs."""
+
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        self.calls.append(
+            {"path": path, "cast_to": cast_to, "body": body, "options": options}
+        )
+        return {"request_id": "x", "choices": [{"index": 0, "finish_reason": "stop"}]}
+
+
+def test_dynamo_transport_raises_without_completion_ids():
+    with pytest.raises(RuntimeError, match="completion token IDs"):
+        asyncio.run(
+            generate(
+                client=_NoCompletionIdsClient(),
+                renderer=_FakeRenderer(),
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+                tools=[{"type": "function", "function": {"name": "echo"}}],
+                sampling_params={"max_tokens": 7},
+                transport="dynamo_chat",
+                max_prompt_len=10_000,
+            )
+        )
+
+
+class _BoomClient(_FakeClient):
+    async def post(self, path, *, cast_to=dict, body=None, options=None):
+        raise ValueError("boom")
+
+
+@pytest.mark.parametrize("transport", ["vllm_generate", "dynamo_chat"])
+def test_generate_propagates_post_errors_raw(transport):
+    # POST errors must propagate unchanged (no NameError from a stale handler).
+    with pytest.raises(ValueError, match="boom"):
+        asyncio.run(
+            generate(
+                client=_BoomClient(),
+                renderer=_FakeRenderer(),
+                messages=[{"role": "user", "content": "hi"}],
+                model="test-model",
+                tools=[{"type": "function", "function": {"name": "echo"}}],
+                sampling_params={"max_tokens": 7},
+                transport=transport,
+                max_prompt_len=10_000,
+            )
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -539,6 +539,31 @@ def test_trim_dynamo_routed_experts():
     assert resp4 == {"nvext": {"engine_data": {}}}
 
 
+def test_dynamo_parse_present_empty_engine_logprobs_does_not_fall_back_to_chat():
+    """A present-but-empty engine_data.completion_logprobs is authoritative
+    (logprobs off): parse must NOT fall through to the divergent chat echo."""
+    data = {
+        "choices": [
+            {
+                # chat-echo logprobs (would mismatch the engine ids)
+                "logprobs": {"content": [{"logprob": -9.9}, {"logprob": -8.8}]},
+                "finish_reason": "stop",
+            }
+        ],
+        "nvext": {
+            "engine_data": {
+                "completion_token_ids": [7, 8],
+                "completion_logprobs": [],
+            }
+        },
+    }
+    from renderers.client import _TRANSPORTS
+
+    wire = _TRANSPORTS["dynamo_chat"].parse(data)
+    assert wire.completion_ids == [7, 8]
+    assert wire.completion_logprobs == []  # engine present-empty wins over chat echo
+
+
 def test_dynamo_transport_merges_caller_nvext():
     """F2: caller-supplied nvext is merged — extra_fields union with engine_data,
     agent_hints merged with priority, unrelated caller keys preserved."""


### PR DESCRIPTION
## Description

Adds a `dynamo_chat` transport to the renderer-based `generate()` client so it can run against NVIDIA Dynamo, which serves no `/inference/v1/generate` route. Selected per-call via `transport=`; defaults to the existing vLLM path, so behavior is unchanged unless opted in.

Two transports:

- **`vllm_generate` (default)**: unchanged — `messages → render_ids() → POST /inference/v1/generate → parse_response()` (vLLM TITO surface).
- **`dynamo_chat`**: `messages → render_ids() → POST /v1/chat/completions` with `nvext.token_data` (pre-tokenized prompt) + `nvext.extra_fields=["engine_data"]`. Completion token IDs and logprobs are read back from `nvext.engine_data`.

### Dynamo wire shape (`_post_dynamo_chat`)

Mirrors the verifiers token client so the payload is identical whether a rollout goes through the token client or the renderer client. `nvext.token_data` (Dynamo skips tokenization when present); `cache_salt` → `nvext.cache_salt`, `priority` → `nvext.agent_hints.priority`; a single placeholder user message; sampling remap (`max_tokens` → `max_completion_tokens`, `logprobs=N` → `logprobs=true` + `top_logprobs=N`); passthrough fields ride the Dynamo allowlist. Tools are baked into `token_data` by the renderer (not sent on the wire).

### routed_experts (MoE expert replay) — now surfaced on dynamo_chat

(Supersedes the earlier "routed_experts intentionally NOT surfaced" note — it now is.) `parse` reads routed_experts from `nvext.routed_experts` (or `nvext.engine_data.routed_experts`) and maps it to the downstream `RoutedExpertsPayload` `{data, shape, start, dtype}`. The Dynamo worker returns full-sequence routing with `start=0`; the renderer row-trims the leading prompt rows **only when the caller explicitly sets `routed_experts_prompt_start`** — a first-turn request with no caller start stays full-sequence with `start=0` (no phantom prefix). Completion logprobs prefer `nvext.engine_data.completion_logprobs` (the same authoritative source as the engine token IDs) over the chat echo; a present-but-empty engine list is authoritative and does not fall back to chat.

### Other

- Public `RendererTransport = Literal["vllm_generate", "dynamo_chat"]` alias. A present-but-empty `completion_token_ids` is a valid zero-token completion; only a fully absent field raises. Multimodal renderers raise `NotImplementedError` on `dynamo_chat` (vLLM path / token-client TITO remain available for VLMs).

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Review

Codex adversarial review: **SIGN-OFF** (F1/F2/F3 + the N1 logprob-presence finding resolved; head `5f2a914`). All review threads resolved.

## Testing

`tests/test_client.py` covers the Dynamo request body shape (priority/detokenize/sampling remap), routed_experts parse + row-trim (explicit `prompt_start` vs first-turn full-sequence), engine-logprob preference incl. present-but-empty, and missing/empty completion IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New Dynamo wire/parse path affects RL-critical completion IDs, logprobs, and MoE `routed_experts`; strict runtime errors and no Dynamo multimodal are new failure modes for opted-in rollouts.
> 
> **Overview**
> Adds a per-call **`transport`** parameter to **`generate()`** (`"vllm"` default, `"dynamo"` opt-in). The existing vLLM TITO flow is moved into **`_VllmGenerateTransport`**; behavior stays the same when **`transport`** is omitted.
> 
> **Dynamo** uses **`_DynamoChatTransport`**: pre-tokenized prompts go to **`POST /v1/chat/completions`** via **`nvext.token_data`**, with **`cache_salt`**, **`priority`**, and **`routed_experts_prompt_start`** mapped into **`nvext`** and vLLM-only sampling keys dropped. Responses read **`nvext.engine_data`** for completion IDs and logprobs (not chat echo), normalize **`routed_experts`**, keep large blobs as zero-copy **`memoryview`**, and optionally client-trim prompt rows when an older worker returns full-sequence routing.
> 
> Multimodal on Dynamo raises **`NotImplementedError`**; missing engine completion IDs or logprob length mismatches raise **`RuntimeError`**. Tests cover wire shape, **`nvext`** merge, and parse edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57846ecf216104f9ad1d9cf01541c2400744325e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `dynamo` transport and routed-experts support to `generate()` in the renderer client
> - Adds a `transport` parameter to `generate()` in [renderers/client.py](https://github.com/PrimeIntellect-ai/renderers/pull/79/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33), defaulting to `'vllm'` (existing `/inference/v1/generate` path); passing `'dynamo'` routes to OpenAI-compatible `/v1/chat/completions` with NVIDIA Dynamo `nvext` fields.
> - Introduces a `_Transport` ABC with `_VllmGenerateTransport` and `_DynamoChatTransport` implementations; each handles body construction, POST, and response normalization into a common `_WireResult`.
> - The Dynamo transport maps sampling params (dropping vLLM-only keys), moves `cache_salt`/`priority` into `nvext`, and prefers `engine_data` fields over chat-echo fields when parsing responses.
> - Adds client-side trimming of base64-encoded `routed_experts` via `_trim_dynamo_routed_experts` when `routed_experts_prompt_start` is set and the worker has not already trimmed.
> - Risk: `generate()` with `transport='dynamo'` raises `RuntimeError` on missing `completion_token_ids` or logprob/token-ID length mismatches, where the vLLM path does not.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 57846ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->