### PR TITLE
fix(parsing): don't parse in-<think> tool calls as real calls (#78)

### DIFF
--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -42,7 +42,7 @@ from renderers.base import (
     trim_to_turn_close,
 )
 from renderers.configs import KimiK25RendererConfig
-from renderers.parsing import parse_kimi_k2_section
+from renderers.parsing import _reasoning_end_token_index, parse_kimi_k2_section
 from renderers.qwen3_vl import (
     _image_hash,
     _is_image_part,
@@ -452,6 +452,13 @@ def _parse_kimi_k2_response(
             ids = ids[:i]
             break
 
+    # Reasoning first: a tool-call section the model drafts *inside* its
+    # <think> trace must not be parsed as a real call (regression #78 — cf.
+    # parse_qwen3). K2.5 renders </think> as text, so locate the boundary by
+    # decoding; the section scan then starts past it. content_ids still begins
+    # at 0, so the </think> text-split below recovers reasoning unchanged.
+    reasoning_end = _reasoning_end_token_index(tokenizer, ids)
+
     # Token-ID path — produces spans. Only run if every relevant special
     # token resolved at init (i.e. is in the tokenizer's vocab).
     tool_calls: list[ParsedToolCall] = []
@@ -471,6 +478,7 @@ def _parse_kimi_k2_response(
             tool_call_begin_id=tool_call_begin_id,
             tool_call_argument_begin_id=tool_call_argument_begin_id,
             tool_call_end_id=tool_call_end_id,
+            scan_start=reasoning_end,
         )
         text = (
             tokenizer.decode(content_ids, skip_special_tokens=False)
@@ -481,9 +489,13 @@ def _parse_kimi_k2_response(
         text = tokenizer.decode(ids, skip_special_tokens=False) if ids else ""
 
     # Fallback path: model emitted literal-text section delimiters (singular
-    # variant) rather than special tokens. Spans unavailable here.
+    # variant) rather than special tokens. Spans unavailable here. Start the
+    # search past the first </think> so a literal section drafted inside the
+    # reasoning trace isn't matched as a real call (regression #78).
     if not tool_calls:
-        tc_match = _TOOL_CALLS_SECTION_RE.search(text)
+        think_close = text.find("</think>")
+        search_from = think_close + len("</think>") if think_close != -1 else 0
+        tc_match = _TOOL_CALLS_SECTION_RE.search(text, search_from)
         if tc_match:
             text = text[: tc_match.start()]
             tool_section = (

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -133,6 +133,39 @@ def _decode(tokenizer, ids: list[int]) -> str:
     return tokenizer.decode(ids, skip_special_tokens=False)
 
 
+def _reasoning_end_token_index(
+    tokenizer, ids: list[int], marker: str = "</think>"
+) -> int:
+    """Token index immediately past the first ``</think>`` in ``ids``.
+
+    Returns 0 when ``ids`` has no closed reasoning region — callers treat
+    that as "scan from the start" (preserves pre-existing behavior for
+    non-thinking / truncated-reasoning completions).
+
+    Used by parsers whose ``</think>`` is *not* a single special token
+    (DeepSeek-V3, Kimi-K2.5) — where it tokenizes to several pieces and is
+    context-sensitive (the closing ``>`` merges differently depending on the
+    next char), so a token-id or fixed-subsequence search isn't reliable. We
+    instead locate the boundary in decoded text via binary search over prefix
+    decodes, which holds as long as ``decode(ids[:k])`` is prefix-stable in
+    ``k`` (true for the byte-level BPE tokenizers here; ``</think>`` is clean
+    ASCII that won't straddle a byte boundary). Single-token ``</think>``
+    parsers (Qwen3) anchor on the token id directly and don't need this.
+    """
+    if not ids or marker not in _decode(tokenizer, ids):
+        return 0
+    # Smallest prefix length (in tokens) whose decode already contains the
+    # full marker — i.e. the index just past where </think> completes.
+    lo, hi = 1, len(ids)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if marker in _decode(tokenizer, ids[:mid]):
+            hi = mid
+        else:
+            lo = mid + 1
+    return lo
+
+
 # ── Qwen3: <tool_call> JSON </tool_call> ────────────────────────────
 
 
@@ -143,11 +176,28 @@ def parse_qwen3(
     stop_ids: set[int],
     tool_call_id: int,
     tool_call_end_id: int,
+    reasoning_end_id: int | None = None,
 ) -> ParsedResponse:
     """Parse Qwen3 completion tokens. Hermes-style JSON tool calls."""
     ids = _strip_stop_tokens(token_ids, stop_ids)
 
-    tc_start = _find(ids, tool_call_id)
+    # Reasoning is resolved before tool calls. Thinking models (e.g.
+    # Qwen3-*-Thinking) routinely draft ``<tool_call>`` blocks *inside* their
+    # ``<think>...</think>`` trace while planning; those are reasoning, not
+    # real invocations. Anchoring the tool-call scan after the ``</think>``
+    # boundary keeps in-think drafts out of ``tool_calls`` (otherwise they
+    # surface as phantom/duplicate calls) and out of the reasoning/content
+    # split. Mirrors vLLM's DelegatingParser, which runs the reasoning parser
+    # first and tool-parses only the post-``</think>`` content.
+    # ``reasoning_end_id`` is the ``</think>`` token id; when it's absent
+    # (``None``) or the model never closed its reasoning, the scan falls back
+    # to the whole stream (prior behavior).
+    reasoning_end = (
+        _find(ids, reasoning_end_id) if reasoning_end_id is not None else -1
+    )
+    scan_start = reasoning_end + 1 if reasoning_end != -1 else 0
+
+    tc_start = _find(ids, tool_call_id, scan_start)
     tool_calls: list[ParsedToolCall] = []
     if tc_start != -1:
         content_ids = ids[:tc_start]
@@ -685,7 +735,15 @@ def parse_deepseek_v3(
     """
     ids = _strip_stop_tokens(token_ids, stop_ids)
 
-    tc_section_start = _find(ids, tool_calls_begin_id)
+    # Reasoning first: skip past </think> before looking for the tool-call
+    # section, so a section the model drafts *inside* its <think> trace isn't
+    # parsed as a real call (regression #78 — cf. parse_qwen3). content_ids
+    # still starts at 0, so the </think> text-split below recovers reasoning.
+    # DeepSeek-V3 renders </think> as multi-token text, hence the decode-based
+    # boundary finder rather than a token-id anchor.
+    reasoning_end = _reasoning_end_token_index(tokenizer, ids)
+
+    tc_section_start = _find(ids, tool_calls_begin_id, reasoning_end)
     tool_calls: list[ParsedToolCall] = []
     if tc_section_start != -1:
         content_ids = ids[:tc_section_start]
@@ -962,6 +1020,7 @@ def parse_kimi_k2_section(
     tool_call_begin_id: int,
     tool_call_argument_begin_id: int,
     tool_call_end_id: int,
+    scan_start: int = 0,
 ) -> tuple[list[int], list[ParsedToolCall]]:
     """Split ``ids`` into ``(content_before_section, tool_calls)`` by finding
     the Kimi-style tool-call section delimiters.
@@ -973,8 +1032,15 @@ def parse_kimi_k2_section(
     of the section and a list of ``ParsedToolCall`` covering every attempted
     block inside it; an unclosed section is still walked to whatever the model
     emitted before EOS. Returns ``(ids, [])`` when no section is present.
+
+    ``scan_start`` restricts the section search to ``ids[scan_start:]`` while
+    keeping ``content_ids = ids[:section_start]`` and all token spans relative
+    to the full ``ids``. Callers pass the post-``</think>`` index so a section
+    the model drafts inside its reasoning trace isn't parsed as a real call;
+    because ``content_ids`` still starts at 0, downstream text-based reasoning
+    extraction is unaffected (regression #78).
     """
-    section_start = _find_any(ids, tool_calls_section_begin_ids)
+    section_start = _find_any(ids, tool_calls_section_begin_ids, scan_start)
     if section_start == -1:
         return list(ids), []
     content_ids = ids[:section_start]

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -192,9 +192,7 @@ def parse_qwen3(
     # ``reasoning_end_id`` is the ``</think>`` token id; when it's absent
     # (``None``) or the model never closed its reasoning, the scan falls back
     # to the whole stream (prior behavior).
-    reasoning_end = (
-        _find(ids, reasoning_end_id) if reasoning_end_id is not None else -1
-    )
+    reasoning_end = _find(ids, reasoning_end_id) if reasoning_end_id is not None else -1
     scan_start = reasoning_end + 1 if reasoning_end != -1 else 0
 
     tc_start = _find(ids, tool_call_id, scan_start)

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -62,6 +62,7 @@ class Qwen3Renderer:
         self._tool_call_end = self._token_id("</tool_call>")
         self._tool_response = self._token_id("<tool_response>")
         self._tool_response_end = self._token_id("</tool_response>")
+        self._think_end = self._token_id("</think>")
 
     def _token_id(self, token: str) -> int:
         tid = self._tokenizer.convert_tokens_to_ids(token)
@@ -276,6 +277,7 @@ class Qwen3Renderer:
             stop_ids={self._im_end, self._endoftext},
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
+            reasoning_end_id=self._think_end,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -325,6 +325,7 @@ class Qwen3VLRenderer:
         self._tool_call_end = self._token_id("</tool_call>")
         self._tool_response = self._token_id("<tool_response>")
         self._tool_response_end = self._token_id("</tool_response>")
+        self._think_end = self._token_id("</think>")
         self._vision_start = self._token_id("<|vision_start|>")
         self._vision_end = self._token_id("<|vision_end|>")
         self._image_pad = self._token_id("<|image_pad|>")
@@ -634,6 +635,7 @@ class Qwen3VLRenderer:
             stop_ids={self._im_end, self._endoftext},
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
+            reasoning_end_id=self._think_end,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/tests/test_parse_response.py
+++ b/tests/test_parse_response.py
@@ -250,7 +250,7 @@ def test_deepseek_v3_in_think_section_is_not_a_real_call():
     def section(name: str) -> str:
         return (
             "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>"
-            f"{name}\n```json\n{{\"code\": \"print(1)\"}}\n```"
+            f'{name}\n```json\n{{"code": "print(1)"}}\n```'
             "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
         )
 

--- a/tests/test_parse_response.py
+++ b/tests/test_parse_response.py
@@ -99,6 +99,69 @@ def test_qwen3_vl_malformed_tool_call_surfaces_as_invalid_json():
 
 
 @lru_cache
+def _qwen3():
+    tokenizer = load_tokenizer("Qwen/Qwen3-0.6B")
+    renderer = create_renderer(tokenizer)
+    return tokenizer, renderer
+
+
+def test_qwen3_in_think_tool_call_is_not_a_real_call():
+    """A ``<tool_call>`` the model drafts *inside* its ``<think>`` trace must
+    stay reasoning — only the call emitted after ``</think>`` counts.
+
+    Regression for #78: Thinking models (e.g. Qwen3-*-Thinking-2507) draft
+    tool-call syntax while planning. Because ``<tool_call>`` is a real vocab
+    token, the parser used to scan the whole stream and emit the in-think
+    draft *and* the genuine post-``</think>`` call as two tool calls — a
+    phantom duplicate that made callers execute the same code twice. The scan
+    is now anchored after ``</think>``, mirroring vLLM's reasoning-then-tools
+    ordering.
+    """
+    tokenizer, renderer = _qwen3()
+    text = (
+        "<think>\nLet me draft the call:\n"
+        '<tool_call>\n{"name": "execute_code", "arguments": {"code": "print(1)"}}\n'
+        "</tool_call>\nYes, that looks right.\n</think>\n"
+        '<tool_call>\n{"name": "execute_code", "arguments": {"code": "print(1)"}}\n'
+        "</tool_call>"
+    )
+    parsed = renderer.parse_response(tokenizer.encode(text, add_special_tokens=False))
+
+    assert len(parsed.tool_calls) == 1
+    tc = parsed.tool_calls[0]
+    assert tc.status == ToolCallParseStatus.OK
+    assert tc.name == "execute_code"
+    assert tc.arguments == {"code": "print(1)"}
+    # The drafted call stays in the reasoning trace, not content.
+    assert parsed.reasoning_content is not None
+    assert "<tool_call>" in parsed.reasoning_content
+    assert parsed.content == ""
+
+
+def test_qwen3_distinct_parallel_calls_after_think_are_preserved():
+    """The fix must not over-correct: two *genuine* parallel calls emitted
+    after ``</think>`` are still both returned (no dedup), preserving the
+    faithful-transcription contract for real invocations.
+    """
+    tokenizer, renderer = _qwen3()
+    text = (
+        "<think>\nplan\n</think>\n"
+        '<tool_call>\n{"name": "execute_code", "arguments": {"code": "print(1)"}}\n'
+        "</tool_call>\n"
+        '<tool_call>\n{"name": "execute_code", "arguments": {"code": "print(2)"}}\n'
+        "</tool_call>"
+    )
+    parsed = renderer.parse_response(tokenizer.encode(text, add_special_tokens=False))
+
+    assert len(parsed.tool_calls) == 2
+    assert [tc.arguments for tc in parsed.tool_calls] == [
+        {"code": "print(1)"},
+        {"code": "print(2)"},
+    ]
+    assert parsed.reasoning_content == "plan"
+
+
+@lru_cache
 def _kimi_k25():
     tokenizer = load_tokenizer("moonshotai/Kimi-K2.5")
     renderer = create_renderer(tokenizer)
@@ -135,3 +198,79 @@ def test_kimi_k25_tool_call_carries_token_span():
     assert 0 <= start < end <= len(token_ids), (
         f"span {tc.token_span} out of range for {len(token_ids)} input tokens"
     )
+
+
+def test_kimi_k25_in_think_section_is_not_a_real_call():
+    """A tool-call section the model drafts inside its ``<think>`` trace must
+    not be parsed — only the section after ``</think>`` counts.
+
+    Regression for #78. K2.5's failure mode differed from Qwen3's: the
+    in-think section tripped the "truncated reasoning" guard and the parser
+    *dropped every tool call* (returned zero), losing the genuine call. The
+    scan is now anchored past ``</think>``.
+    """
+    tokenizer, renderer = _kimi_k25()
+    section = (
+        "<|tool_calls_section_begin|>"
+        "<|tool_call_begin|>functions.execute_code:0"
+        '<|tool_call_argument_begin|>{"code": "print(1)"}'
+        "<|tool_call_end|><|tool_calls_section_end|>"
+    )
+    text = f"<think>\nLet me draft:\n{section}\nlooks right.\n</think>\nGo.\n{section}"
+    parsed = renderer.parse_response(tokenizer.encode(text, add_special_tokens=False))
+
+    assert len(parsed.tool_calls) == 1
+    tc = parsed.tool_calls[0]
+    assert tc.status == ToolCallParseStatus.OK
+    assert tc.name == "execute_code"
+    assert tc.arguments == {"code": "print(1)"}
+    # The drafted section stays in the reasoning trace.
+    assert parsed.reasoning_content is not None
+    assert "<|tool_calls_section_begin|>" in parsed.reasoning_content
+    assert parsed.content == "Go."
+
+
+@lru_cache
+def _deepseek_v3():
+    tokenizer = load_tokenizer("deepseek-ai/DeepSeek-V3")
+    renderer = create_renderer(tokenizer)
+    return tokenizer, renderer
+
+
+def test_deepseek_v3_in_think_section_is_not_a_real_call():
+    """A tool-call section drafted inside ``<think>`` must not be parsed —
+    only the section after ``</think>`` counts.
+
+    Regression for #78. DeepSeek-V3's failure mode: it returned the *wrong*
+    call (the in-think draft) and lost reasoning, because ``</think>`` is
+    multi-token text there and the scan wasn't anchored past it.
+    """
+    tokenizer, renderer = _deepseek_v3()
+
+    def section(name: str) -> str:
+        return (
+            "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>function<｜tool▁sep｜>"
+            f"{name}\n```json\n{{\"code\": \"print(1)\"}}\n```"
+            "<｜tool▁call▁end｜><｜tool▁calls▁end｜>"
+        )
+
+    text = (
+        f"<think>\nLet me draft:\n{section('draft_tool')}\nlooks right.\n</think>\n"
+        f"Go.\n{section('real_tool')}"
+    )
+    parsed = renderer.parse_response(tokenizer.encode(text, add_special_tokens=False))
+
+    assert len(parsed.tool_calls) == 1
+    tc = parsed.tool_calls[0]
+    # Assert the *post-``</think>``* section was chosen, not the in-think draft.
+    # (Use ``startswith`` rather than ``== "real_tool"``: under transformers
+    # 5.x the DeepSeek tokenizer's decode drops the ``\n`` between name and the
+    # ```json fence, so ``_parse_deepseek_tool_calls`` folds the fence into the
+    # name — a pre-existing, #78-unrelated quirk. What matters here is *which*
+    # section won.)
+    assert tc.name is not None and tc.name.startswith("real_tool")
+    assert "draft_tool" not in tc.name
+    # The drafted section stays in the reasoning trace, not content.
+    assert parsed.reasoning_content is not None
+    assert "draft_tool" in parsed.reasoning_content
+    assert parsed.content == "Go."


### PR DESCRIPTION
## Summary

Fixes #78. Reasoning models routinely draft tool-call syntax **inside** their `<think>…</think>` trace while planning. Three parsers scanned the whole completion for tool-call delimiters and only extracted reasoning *afterward*, so those in-think drafts were mis-parsed. The symptom differs by wire format but all corrupt the tool result:

| Renderer | Symptom before |
|---|---|
| `qwen3` / `qwen3_vl` | emits the draft **and** the real call → **phantom duplicate** (the reported case — same code executed twice) |
| `kimi_k2.5` | the in-think section trips the "truncated reasoning" guard → **all tool calls dropped** (returns zero) |
| `deepseek_v3` | returns the **wrong call** (the draft) and loses reasoning |

## Root cause

The fix mirrors what vLLM's `DelegatingParser` does — run the reasoning parser **before** the tool parser, and tool-parse only the post-`</think>` content:

```python
reasoning, content = self.extract_reasoning(model_output, request)   # strip <think>…</think> first
tool_calls, content = self._extract_tool_calls(content=content, ...) # then parse tools on the leftover
```

The renderers parsers did the opposite order, so an in-`<think>` delimiter leaked into the tool scan.

## Fix

Extract reasoning first, then anchor the tool-call scan **after** `</think>`:

- **Single-token `</think>`** (Qwen3, id 151668): anchor on the token id (`reasoning_end_id`).
- **Multi-token / context-sensitive `</think>`** (DeepSeek-V3, Kimi-K2.5): locate the boundary by decoding (`_reasoning_end_token_index`, binary search over prefix decodes) — a token-id/subsequence search isn't reliable there because the closing `>` merges differently depending on the next char.

`content_ids` still starts at 0, so the existing text-based reasoning extraction is unchanged. Genuine parallel calls after `</think>` are still preserved (no dedup).

## Audit of all parsers

| Parser | Status |
|---|---|
| `qwen3`, `qwen3_vl`, `deepseek_v3`, `kimi_k2.5` | **fixed here** |
| `qwen3.5`, `glm`, `minimax`, `laguna`, `nemotron3` | already strip reasoning first — safe |
| `gpt_oss` | channel-segregated (analysis vs commentary) — safe by design |
| `llama_3` | no reasoning channel — N/A |
| `kimi_k2` (K2-Instruct) | template has no thinking path (`enable_thinking` is a documented no-op, no `<think>` prefill) — bug can't manifest, left unchanged |

## Validation

- Reproduced each bug, then confirmed the fix, against the **real** `Qwen/Qwen3-*`, `moonshotai/Kimi-K2.5`, and `deepseek-ai/DeepSeek-V3` tokenizers.
- New regression tests for qwen3 / kimi_k2.5 / deepseek_v3 (plus a guard that genuine parallel post-`</think>` calls are preserved).
- Full suite green: `567 passed, 26 skipped` across `test_parse_response`, `test_parse_response_robustness`, `test_parsers`, `test_roundtrip`, `test_preserve_thinking`.

## Note (out of scope, flagged separately)

While testing DeepSeek-V3 under the repo's pinned `transformers==5.6.2`, I found a **pre-existing, unrelated** issue: that tokenizer's `decode` drops the `\n` between a tool call's name and its ```` ```json ```` fence, so `_parse_deepseek_tool_calls` folds the fence into the function name and yields empty `arguments` — even for a normal (non-thinking) tool call. There is currently no DeepSeek-V3 tool-call parse test, so CI never caught it. Not touched here; happy to open a separate issue/PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how tool calls are extracted from thinking-model completions—affects execution and training pipelines—but behavior is backward-compatible when reasoning is absent or unclosed, with targeted regression tests.
> 
> **Overview**
> Fixes **#78**: completion parsers no longer treat tool-call syntax drafted inside `…` as real invocations.
> 
> **Qwen3 / Qwen3-VL** pass the `` token id into `parse_qwen3`, which starts `<tool_call>` scanning only after that boundary (avoids phantom duplicate calls). **DeepSeek-V3** and **Kimi K2.5** use a new `_reasoning_end_token_index` (binary search on prefix decodes) because `` is multi-token text there; Kimi also restricts regex fallback and adds `scan_start` on `parse_kimi_k2_section`. Reasoning extraction still runs on the full stream from token 0, so `reasoning_content` / `content` splits stay the same.
> 
> Regression tests cover Qwen3, Kimi K2.5, and DeepSeek-V3, including that multiple genuine post-`` calls are still returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b31f247a4644b1a35ab8d790b2b48c0dbbb07e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix parsers to ignore tool calls inside `<think>` blocks for Qwen3, DeepSeek-V3, and Kimi-K2.5
> - Adds `_reasoning_end_token_index` in [parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/80/files#diff-4eba1ee111275cd49ea938c89bfbb7dafa7894d18a97c858fb4a9df401e85c75) to find the token boundary where `</think>` ends, enabling downstream parsers to start scanning only after reasoning completes.
> - Updates `parse_qwen3`, `parse_deepseek_v3`, and `parse_kimi_k2_section` to accept a `scan_start` offset so tool-call searches skip over in-think content.
> - `Qwen3Renderer` and `Qwen3VLRenderer` now pass `reasoning_end_id` to `parse_qwen3` using the tokenized `</think>` id captured at init time.
> - Adds tests for all three model families asserting that in-think tool calls are excluded from `tool_calls` and remain in `reasoning_content`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b31f24.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->