### PR TITLE
fix(qwen3-vl): fall back to hf_hub_download for mmraw preprocessor_config.json

### DIFF
--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -280,16 +280,15 @@ def _load_preprocessor_config_json(model_name_or_path: str) -> dict[str, Any]:
         except Exception:
             pass
         if not candidates:
-            # Cache miss for a hub-style id: fall back to downloading the file
-            # (a few hundred bytes; lands in the HF cache so this is one-time
-            # per process pool). Hosted env workers render models they never
-            # loaded locally, so the cache-only lookup above rarely hits there.
-            # Offline/no-network environments fall through to the error below,
-            # which names the explicit image_* config escape hatch.
+            # Cache miss for a hub-style id (hosted workers render models they
+            # never loaded locally): download the tiny file into the HF cache.
+            # Offline, this falls through to the error below.
             try:
                 from huggingface_hub import hf_hub_download
 
-                downloaded = hf_hub_download(model_name_or_path, "preprocessor_config.json")
+                downloaded = hf_hub_download(
+                    model_name_or_path, "preprocessor_config.json"
+                )
                 candidates.append(Path(downloaded))
             except Exception:
                 pass

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -279,6 +279,20 @@ def _load_preprocessor_config_json(model_name_or_path: str) -> dict[str, Any]:
                 candidates.append(Path(cached))
         except Exception:
             pass
+        if not candidates:
+            # Cache miss for a hub-style id: fall back to downloading the file
+            # (a few hundred bytes; lands in the HF cache so this is one-time
+            # per process pool). Hosted env workers render models they never
+            # loaded locally, so the cache-only lookup above rarely hits there.
+            # Offline/no-network environments fall through to the error below,
+            # which names the explicit image_* config escape hatch.
+            try:
+                from huggingface_hub import hf_hub_download
+
+                downloaded = hf_hub_download(model_name_or_path, "preprocessor_config.json")
+                candidates.append(Path(downloaded))
+            except Exception:
+                pass
 
     for candidate in candidates:
         if candidate.is_file():
@@ -290,8 +304,9 @@ def _load_preprocessor_config_json(model_name_or_path: str) -> dict[str, Any]:
 
     raise RuntimeError(
         "Qwen raw image layout could not find preprocessor_config.json for "
-        f"{model_name_or_path!r}. Ensure the model is cached locally or set all "
-        "image_* layout fields explicitly in the renderer config."
+        f"{model_name_or_path!r}. Ensure the model is cached locally or "
+        "reachable on the Hugging Face Hub, or set all image_* layout fields "
+        "explicitly in the renderer config."
     )
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -587,6 +587,41 @@ def test_qwen3_vl_raw_layout_matches_real_processor(tmp_path, monkeypatch):
         )
 
 
+def test_qwen3_vl_preprocessor_config_hub_download_fallback(tmp_path, monkeypatch):
+    """Hub-style ids that miss the local HF cache fall back to
+    ``hf_hub_download``; download failure (offline) keeps the explicit-config
+    error."""
+    import huggingface_hub
+
+    from renderers.qwen3_vl import _load_preprocessor_config_json
+
+    config = {
+        "patch_size": 16,
+        "temporal_patch_size": 2,
+        "merge_size": 2,
+        "size": {"shortest_edge": 65536, "longest_edge": 16777216},
+    }
+    downloaded = tmp_path / "preprocessor_config.json"
+    downloaded.write_text(json.dumps(config))
+
+    def fake_download(repo_id, filename):
+        assert filename == "preprocessor_config.json"
+        return str(downloaded)
+
+    monkeypatch.setattr(huggingface_hub, "try_to_load_from_cache", lambda *a, **k: None)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", fake_download)
+    _load_preprocessor_config_json.cache_clear()
+    assert _load_preprocessor_config_json("org/uncached-model") == config
+
+    def offline_download(repo_id, filename):
+        raise OSError("offline")
+
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download", offline_download)
+    _load_preprocessor_config_json.cache_clear()
+    with pytest.raises(RuntimeError, match="could not find preprocessor_config.json"):
+        _load_preprocessor_config_json("org/uncached-model-offline")
+
+
 # ---------------------------------------------------------------------------
 # Prompt overflow handling.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The raw-image (mmraw) layout path (db5058e) resolves the model's image geometry from `preprocessor_config.json`, but `_load_preprocessor_config_json` only checks local paths and the local HF cache (`try_to_load_from_cache`). Hosted env workers render models they never loaded locally, so hub-style ids always miss the cache and **every image rollout fails**:

```
RuntimeError: Qwen raw image layout could not find preprocessor_config.json for
'Qwen/Qwen3.6-35B-A3B'. Ensure the model is cached locally or set all image_*
layout fields explicitly in the renderer config.
```

…even when the file is publicly available on the Hub. Hit in production on worldsims gflights-booking RL runs (Qwen3.6-35B-A3B); currently worked around by passing the five explicit `image_*` layout fields through `chat_template_kwargs` in the run config.

## Fix

On cache miss for a hub-style id, fall back to `hf_hub_download(model_id, "preprocessor_config.json")` — a few hundred bytes, lands in the HF cache, then memoized by the existing `lru_cache`. Offline/no-network workers fall through to the existing `RuntimeError`, whose message now also mentions Hub reachability alongside the explicit `image_*` config escape hatch.

## Test

`test_qwen3_vl_preprocessor_config_hub_download_fallback`: cache-miss → fallback download succeeds and parses; offline download failure → `RuntimeError` preserved.

```
tests/test_client.py -k 'hub_download_fallback or raw_mode_render' → 2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to config resolution for hub model IDs with existing error paths when offline; adds optional Hub network fetch on cache miss only.
> 
> **Overview**
> Fixes Qwen3-VL **mmraw** image rollouts on workers that never cached the model locally: when `preprocessor_config.json` is missing from disk and `try_to_load_from_cache` misses, **`_load_preprocessor_config_json`** now falls back to **`hf_hub_download`** (small file, then existing `lru_cache`). Offline or failed downloads still raise the same **`RuntimeError`**, with an updated message that also points to Hub reachability and explicit **`image_*`** layout overrides.
> 
> Adds **`test_qwen3_vl_preprocessor_config_hub_download_fallback`** to cover successful hub fallback and preserved failure when download is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1469353afebaa9378c89e6b61a0ed11d686872e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to `hf_hub_download` in `_load_preprocessor_config_json` for Qwen3-VL when cache misses
> Previously, `_load_preprocessor_config_json` in [qwen3_vl.py](https://github.com/PrimeIntellect-ai/renderers/pull/82/files#diff-3e0babca292a13569ed6e5b55b3b0b4aa4bb8dda3c43cd8bc2ac32df4d0fb349) would raise a `RuntimeError` if no cached `preprocessor_config.json` was found for a hub-style model ID. It now attempts `hf_hub_download` as a fallback before raising. The error message is also updated to mention that the model must be reachable on the Hugging Face Hub.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #82 opened
>
> - Reformatted code style and documentation in `_load_preprocessor_config_json` utility function [f146935]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91f3040.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->