### PR TITLE
fix: _get_offset_tokenizer immune to global fastokens patch (concurrent-pool race)

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1689,6 +1689,7 @@ def _get_offset_tokenizer(tokenizer):
             kwargs = {"trust_remote_code": True, "revision": revision}
         else:
             kwargs = {"trust_remote_code": False}
+
         def _has_offsets(tok) -> bool:
             if not getattr(tok, "is_fast", False):
                 return False

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1689,19 +1689,44 @@ def _get_offset_tokenizer(tokenizer):
             kwargs = {"trust_remote_code": True, "revision": revision}
         else:
             kwargs = {"trust_remote_code": False}
-        # Explicitly vanilla — we want HF's Rust tokenizer with offset
-        # tracking, not the fastokens shim. ``load_tokenizer`` would
-        # patch fastokens in by default; routing through
-        # ``_load_tokenizer_via_auto`` keeps the fastokens patch out
-        # of this code path while still applying the config-build
-        # fallback (RoPE-validation failures on nested
-        # ``rope_parameters``, etc.).
+        def _has_offsets(tok) -> bool:
+            if not getattr(tok, "is_fast", False):
+                return False
+            try:
+                tok("a", add_special_tokens=False, return_offsets_mapping=True)
+                return True
+            except (NotImplementedError, ValueError, TypeError):
+                return False
+
+        # We want HF's Rust tokenizer with offset tracking, not the fastokens
+        # shim. The shim is installed by a *process-global* monkeypatch that
+        # ``load_tokenizer`` toggles per pool-slot load, so a plain reload here
+        # can race a concurrent slot's open patch window and silently pick up
+        # the offset-less shim (then get cached, poisoning the process). So:
+        # load, verify offsets, and if missing, reload with the patch forced
+        # off — serialized against pool patch/unpatch via ``_FASTOKENS_PATCH_LOCK``
+        # so no concurrent window can swap the shim back in mid-load — then
+        # restore the prior patch state. Never cache a non-offset tokenizer.
         offset_tok = _load_tokenizer_via_auto(name_or_path, **kwargs)
-        if not getattr(offset_tok, "is_fast", False):
+        if not _has_offsets(offset_tok):
+            import fastokens
+
+            with _FASTOKENS_PATCH_LOCK:
+                was_patched = bool(getattr(fastokens, "_patched", False))
+                if was_patched:
+                    with contextlib.redirect_stdout(io.StringIO()):
+                        fastokens.unpatch_transformers()
+                try:
+                    offset_tok = _load_tokenizer_via_auto(name_or_path, **kwargs)
+                finally:
+                    if was_patched:
+                        with contextlib.redirect_stdout(io.StringIO()):
+                            fastokens.patch_transformers()
+        if not _has_offsets(offset_tok):
             raise RuntimeError(
-                f"Vanilla tokenizer for {name_or_path!r} is not a fast "
-                "tokenizer; offset_mapping is unavailable. Hand-coded "
-                "renderers require a fast tokenizer for body/scaffold "
+                f"Could not load an offset-capable tokenizer for {name_or_path!r}: "
+                "offset_mapping is unavailable even with the fastokens patch off. "
+                "Hand-coded renderers require a fast tokenizer for body/scaffold "
                 "attribution."
             )
         _offset_tokenizers[name_or_path] = offset_tok


### PR DESCRIPTION
## Problem
`load_tokenizer(use_fastokens=True)` installs a **process-global** fastokens monkeypatch for the duration of each pool-slot's `from_pretrained`, holding `_FASTOKENS_PATCH_LOCK` only around the patch/unpatch calls — not around the load itself. Under the concurrent renderer pool (`create_renderer_pool` fans loads across a thread pool), `_get_offset_tokenizer`'s "vanilla" reload (`_load_tokenizer_via_auto` → `AutoTokenizer.from_pretrained`) can run *inside* another slot's open patch window, come back with the offset-less fastokens shim, and get **cached**. From then on every offset attribution raises `NotImplementedError: fastokens does not track character offsets` (surfaced downstream as a 502 from the interception server).

Reproduced: a bare `AutoTokenizer.from_pretrained` issued during an open patch window returns an offset-less tokenizer.

## Fix
In `_get_offset_tokenizer`, after the first load, verify offsets; if missing, reload with fastokens **force-unpatched under `_FASTOKENS_PATCH_LOCK`** (restoring the prior patch state) and **re-probe before caching** — so a non-offset tokenizer is never returned or cached. Verified: a reload landing in a patch window now returns an offset-capable tokenizer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `_get_offset_tokenizer` to retry with fastokens patch disabled under a lock
> - Adds `_has_offsets(tok)` helper in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/86/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) that verifies true offset support by checking `is_fast` and attempting tokenization with `return_offsets_mapping=True`.
> - Replaces the previous `is_fast` check with `_has_offsets` for both initial load and post-reload validation.
> - If the initial tokenizer fails `_has_offsets`, retries under `_FASTOKENS_PATCH_LOCK` by temporarily unpatching `fastokens`, reloading the tokenizer, then restoring the patch — suppressing stdout during patch/unpatch.
> - Only caches a tokenizer that passes `_has_offsets`; raises `RuntimeError` otherwise.
> - Risk: the temporary unpatch is process-global, so concurrent tokenizer loads during the retry window may see inconsistent patch state despite the lock.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 057f008.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tokenizer loading and global fastokens patch coordination on a hot path for hand-coded renderers; incorrect locking or restore logic could regress attribution or pool startup, but scope is narrow to `_get_offset_tokenizer`.
> 
> **Overview**
> Fixes a **concurrent renderer pool** race where `_get_offset_tokenizer` could load and **cache** a fastokens shim tokenizer (no `offset_mapping`) if `AutoTokenizer.from_pretrained` ran while another slot had the process-global fastokens patch active—breaking hand-coded renderer body/scaffold attribution downstream.
> 
> **`_get_offset_tokenizer`** now uses a **`_has_offsets`** probe (fast tokenizer + successful `return_offsets_mapping=True`) instead of relying on `is_fast` alone. After the first vanilla load, if offsets are missing it **reloads under `_FASTOKENS_PATCH_LOCK`** with fastokens temporarily unpatch (restoring prior patch state), then **refuses to cache** until offsets are verified; otherwise it raises a clearer `RuntimeError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057f0087d805a428f70393be209134f23b1e9880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->