### PR TITLE
fix: use ungated llama tokenizer mirrors

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1152,6 +1152,17 @@ TRUSTED_REVISIONS: dict[str, str] = {
 }
 
 
+# Tokenizer repos to use when a canonical model repo is gated but an
+# audited unrestricted mirror ships byte-identical tokenizer files and
+# chat_template. The returned tokenizer keeps the caller's original
+# ``name_or_path`` so exact-match renderer resolution still uses
+# ``MODEL_RENDERER_MAP``.
+TOKENIZER_SOURCE_OVERRIDES: dict[str, str] = {
+    "meta-llama/Llama-3.2-1B-Instruct": "unsloth/Llama-3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct": "unsloth/Llama-3.2-3B-Instruct",
+}
+
+
 # Models for which ``fastokens`` is known to diverge from vanilla
 # ``transformers.AutoTokenizer`` and therefore must NOT be patched.
 # Empirical audit ran each entry of ``MODEL_RENDERER_MAP`` through both
@@ -1173,6 +1184,42 @@ FASTOKENS_INCOMPATIBLE: frozenset[str] = frozenset(
 
 _FASTOKENS_PATCH_LOCK = threading.Lock()
 _FASTOKENS_ANNOUNCED = False
+
+
+def _tokenizer_source_for(model_name_or_path: str) -> str:
+    return TOKENIZER_SOURCE_OVERRIDES.get(model_name_or_path, model_name_or_path)
+
+
+def _tokenizer_load_kwargs(model_name_or_path: str) -> dict[str, Any]:
+    revision = TRUSTED_REVISIONS.get(model_name_or_path)
+    if revision is not None:
+        return {"trust_remote_code": True, "revision": revision}
+    return {"trust_remote_code": False}
+
+
+def _preserve_requested_tokenizer_name(
+    tokenizer,
+    *,
+    requested_name_or_path: str,
+    loaded_name_or_path: str,
+):
+    if requested_name_or_path == loaded_name_or_path:
+        return tokenizer
+
+    try:
+        tokenizer.name_or_path = requested_name_or_path
+    except Exception:
+        init_kwargs = getattr(tokenizer, "init_kwargs", None)
+        if isinstance(init_kwargs, dict):
+            init_kwargs["name_or_path"] = requested_name_or_path
+
+    if getattr(tokenizer, "name_or_path", "") != requested_name_or_path:
+        raise RuntimeError(
+            f"Loaded tokenizer for {requested_name_or_path!r} from "
+            f"{loaded_name_or_path!r}, but could not preserve the requested "
+            "name_or_path for renderer auto-resolution."
+        )
+    return tokenizer
 
 
 def _patched_load(model_name_or_path: str, **kwargs):
@@ -1312,29 +1359,41 @@ def load_tokenizer(
     validation for configs with nested ``rope_parameters``), we fall
     back to loading the repo's self-contained ``tokenizer.json``
     directly — see ``_load_tokenizer_via_auto``.
-    """
-    kwargs: dict[str, Any] = {}
-    revision = TRUSTED_REVISIONS.get(model_name_or_path)
-    if revision is not None:
-        kwargs = {"trust_remote_code": True, "revision": revision}
-    else:
-        kwargs = {"trust_remote_code": False}
 
-    if not use_fastokens or model_name_or_path in FASTOKENS_INCOMPATIBLE:
-        return _load_tokenizer_via_auto(model_name_or_path, **kwargs)
+    Canonical Meta Llama-3.2 Instruct repos are gated on HuggingFace. For
+    those exact IDs we load tokenizer files from the audited unrestricted
+    ``unsloth`` mirrors instead, then restore ``tokenizer.name_or_path`` to
+    the requested Meta ID so auto-resolution still selects ``Llama3Renderer``.
+    """
+    load_name_or_path = _tokenizer_source_for(model_name_or_path)
+    kwargs = _tokenizer_load_kwargs(load_name_or_path)
+
+    if not use_fastokens or load_name_or_path in FASTOKENS_INCOMPATIBLE:
+        tok = _load_tokenizer_via_auto(load_name_or_path, **kwargs)
+        return _preserve_requested_tokenizer_name(
+            tok,
+            requested_name_or_path=model_name_or_path,
+            loaded_name_or_path=load_name_or_path,
+        )
 
     try:
-        return _patched_load(model_name_or_path, **kwargs)
+        tok = _patched_load(load_name_or_path, **kwargs)
     except Exception as exc:
         logger.info(
             "fastokens could not load %r (%s: %s); falling back to vanilla "
             "AutoTokenizer. Add this model to FASTOKENS_INCOMPATIBLE in "
             "renderers.base to suppress the retry.",
-            model_name_or_path,
+            load_name_or_path,
             type(exc).__name__,
             str(exc)[:160],
         )
-        return _load_tokenizer_via_auto(model_name_or_path, **kwargs)
+        tok = _load_tokenizer_via_auto(load_name_or_path, **kwargs)
+
+    return _preserve_requested_tokenizer_name(
+        tok,
+        requested_name_or_path=model_name_or_path,
+        loaded_name_or_path=load_name_or_path,
+    )
 
 
 def _populate_registry():
@@ -1702,12 +1761,8 @@ def _get_offset_tokenizer(tokenizer):
         if cached is not None:
             return cached
 
-        kwargs: dict[str, Any] = {}
-        revision = TRUSTED_REVISIONS.get(name_or_path)
-        if revision is not None:
-            kwargs = {"trust_remote_code": True, "revision": revision}
-        else:
-            kwargs = {"trust_remote_code": False}
+        load_name_or_path = _tokenizer_source_for(name_or_path)
+        kwargs = _tokenizer_load_kwargs(load_name_or_path)
 
         def _has_offsets(tok) -> bool:
             if not getattr(tok, "is_fast", False):
@@ -1727,7 +1782,12 @@ def _get_offset_tokenizer(tokenizer):
         # off — serialized against pool patch/unpatch via ``_FASTOKENS_PATCH_LOCK``
         # so no concurrent window can swap the shim back in mid-load — then
         # restore the prior patch state. Never cache a non-offset tokenizer.
-        offset_tok = _load_tokenizer_via_auto(name_or_path, **kwargs)
+        offset_tok = _load_tokenizer_via_auto(load_name_or_path, **kwargs)
+        offset_tok = _preserve_requested_tokenizer_name(
+            offset_tok,
+            requested_name_or_path=name_or_path,
+            loaded_name_or_path=load_name_or_path,
+        )
         if not _has_offsets(offset_tok):
             import fastokens
 
@@ -1737,7 +1797,12 @@ def _get_offset_tokenizer(tokenizer):
                     with contextlib.redirect_stdout(io.StringIO()):
                         fastokens.unpatch_transformers()
                 try:
-                    offset_tok = _load_tokenizer_via_auto(name_or_path, **kwargs)
+                    offset_tok = _load_tokenizer_via_auto(load_name_or_path, **kwargs)
+                    offset_tok = _preserve_requested_tokenizer_name(
+                        offset_tok,
+                        requested_name_or_path=name_or_path,
+                        loaded_name_or_path=load_name_or_path,
+                    )
                 finally:
                     if was_patched:
                         with contextlib.redirect_stdout(io.StringIO()):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -47,11 +47,10 @@ RENDERER_MODELS = [
     # there's just no byte-output to parity-check against. Split-specific
     # parity (V3 bare prompt vs R1 <think>+history-strip) is covered in
     # tests/test_deepseek_r1.py.
-    # Llama-3 loads via the unrestricted unsloth mirror (byte-identical
-    # chat template) so CI needs no Meta-gated HF token. Pinned to the
-    # explicit "llama-3" config because the mirror name isn't in
-    # MODEL_RENDERER_MAP (so "auto" would fall back to DefaultRenderer).
-    ("unsloth/Llama-3.2-1B-Instruct", "llama-3"),
+    # Llama-3 uses the canonical Meta ID for renderer auto-resolution, while
+    # load_tokenizer fetches the tokenizer/chat_template from the unrestricted
+    # unsloth mirror so CI needs no Meta-gated HF token.
+    ("meta-llama/Llama-3.2-1B-Instruct", "auto"),
     ("openai/gpt-oss-20b", "gpt-oss"),
     ("Qwen/Qwen2.5-0.5B-Instruct", "default"),
 ]
@@ -139,7 +138,7 @@ _LLAMA_HF_PARITY_TEST_FILES = {
 def _skip_llama_for_hf_parity_tests(request):
     callspec = getattr(request.node, "callspec", None)
     model_name = callspec.params.get("model_name") if callspec else None
-    if model_name != "unsloth/Llama-3.2-1B-Instruct":
+    if model_name != "meta-llama/Llama-3.2-1B-Instruct":
         return
     test_file = os.path.basename(str(request.node.fspath))
     if test_file in _LLAMA_HF_PARITY_TEST_FILES:

--- a/tests/test_llama_3.py
+++ b/tests/test_llama_3.py
@@ -1,10 +1,10 @@
 """Llama-3 renderer coverage.
 
 Covers ``Llama3Renderer`` and the ``meta-llama/Llama-3.2-{1B,3B}-Instruct``
-entries in ``MODEL_RENDERER_MAP``. Tokenizers are loaded via the
-unrestricted ``unsloth/Llama-3.2-{1B,3B}-Instruct`` mirrors (verified
-byte-identical chat templates) so CI doesn't need an HF token with Meta
-license access.
+entries in ``MODEL_RENDERER_MAP``. ``load_tokenizer`` uses the
+unrestricted ``unsloth/Llama-3.2-{1B,3B}-Instruct`` mirrors underneath
+(verified byte-identical chat templates) so CI doesn't need an HF token
+with Meta license access.
 """
 
 from __future__ import annotations
@@ -34,7 +34,7 @@ _MODEL_PAIRS = [
 @pytest.fixture(scope="module", params=_MODEL_PAIRS, ids=[m for m, _ in _MODEL_PAIRS])
 def llama_pair(request):
     canonical, mirror = request.param
-    tok = load_tokenizer(mirror)
+    tok = load_tokenizer(canonical)
     renderer = Llama3Renderer(tok, Llama3RendererConfig(date_string=_PINNED_DATE))
     return canonical, mirror, tok, renderer
 
@@ -56,6 +56,14 @@ def test_create_renderer_via_explicit_config(llama_pair):
     _, _, tok, _ = llama_pair
     r = create_renderer(tok, Llama3RendererConfig())
     assert isinstance(r, Llama3Renderer)
+
+
+def test_create_renderer_auto_resolves_after_mirror_load(llama_pair):
+    """``load_tokenizer(canonical_meta_id)`` loads from the unrestricted
+    mirror but preserves the canonical name needed for auto-resolution."""
+    canonical, _, tok, _ = llama_pair
+    assert tok.name_or_path == canonical
+    assert isinstance(create_renderer(tok), Llama3Renderer)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_load_tokenizer.py
+++ b/tests/test_load_tokenizer.py
@@ -9,9 +9,11 @@ repo doesn't auto-propagate.
 from __future__ import annotations
 
 import re
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from renderers.base import TRUSTED_REVISIONS, load_tokenizer
+from renderers import base
+from renderers.base import TOKENIZER_SOURCE_OVERRIDES, TRUSTED_REVISIONS, load_tokenizer
 
 
 # ---------------------------------------------------------------------------
@@ -71,6 +73,23 @@ def test_kimi_loads_with_pinned_revision(mock_from_pretrained):
 
 
 @patch("transformers.AutoTokenizer.from_pretrained")
+def test_meta_llama_loads_tokenizer_from_unsloth_mirror(mock_from_pretrained):
+    """Canonical Meta Llama repos are gated; load their tokenizer/chat
+    template from the audited unrestricted mirror while preserving the
+    canonical name for renderer auto-resolution."""
+    canonical = "meta-llama/Llama-3.2-1B-Instruct"
+    mirror = "unsloth/Llama-3.2-1B-Instruct"
+    mock_from_pretrained.return_value = SimpleNamespace(name_or_path=mirror)
+
+    tok = load_tokenizer(canonical, use_fastokens=False)
+
+    args, kwargs = mock_from_pretrained.call_args
+    assert args == (mirror,)
+    assert kwargs == {"trust_remote_code": False}
+    assert tok.name_or_path == canonical
+
+
+@patch("transformers.AutoTokenizer.from_pretrained")
 def test_unknown_path_falls_through_to_no_remote_code(mock_from_pretrained):
     """Unknown / fine-tuned model paths — including ``moonshotai/Kimi-K2*``
     look-alikes that aren't in the allow-list — must fall through to
@@ -90,6 +109,55 @@ def test_unknown_path_falls_through_to_no_remote_code(mock_from_pretrained):
         assert kwargs == {"trust_remote_code": False}, (
             f"{name}: unlisted path leaked trust_remote_code=True"
         )
+
+
+def test_tokenizer_source_overrides_are_exact_llama_mirrors():
+    """Mirror overrides are intentionally narrow: only verified
+    byte-identical Llama tokenizer/template mirrors should live here."""
+    assert TOKENIZER_SOURCE_OVERRIDES == {
+        "meta-llama/Llama-3.2-1B-Instruct": "unsloth/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct": "unsloth/Llama-3.2-3B-Instruct",
+    }
+
+
+def test_offset_tokenizer_uses_unsloth_mirror_for_meta_llama(monkeypatch):
+    """Offset-tokenizer reloads must use the same unrestricted source
+    override, otherwise Llama rendering can hit the gated Meta repo after
+    the initial tokenizer load succeeds."""
+
+    class _NoOffsets:
+        name_or_path = "meta-llama/Llama-3.2-1B-Instruct"
+
+        def __call__(self, *args, **kwargs):
+            raise NotImplementedError("fastokens shim has no offsets")
+
+    class _OffsetTokenizer:
+        is_fast = True
+
+        def __init__(self, name_or_path: str):
+            self.name_or_path = name_or_path
+
+        def __call__(self, *args, **kwargs):
+            return {"offset_mapping": [(0, 1)]}
+
+    calls = []
+
+    def _fake_load(name_or_path, **kwargs):
+        calls.append((name_or_path, kwargs))
+        return _OffsetTokenizer(name_or_path)
+
+    base._offset_tokenizers.clear()
+    monkeypatch.setattr(base, "_load_tokenizer_via_auto", _fake_load)
+
+    try:
+        tok = base._get_offset_tokenizer(_NoOffsets())
+    finally:
+        base._offset_tokenizers.clear()
+
+    assert calls == [
+        ("unsloth/Llama-3.2-1B-Instruct", {"trust_remote_code": False})
+    ]
+    assert tok.name_or_path == "meta-llama/Llama-3.2-1B-Instruct"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_load_tokenizer.py
+++ b/tests/test_load_tokenizer.py
@@ -154,9 +154,7 @@ def test_offset_tokenizer_uses_unsloth_mirror_for_meta_llama(monkeypatch):
     finally:
         base._offset_tokenizers.clear()
 
-    assert calls == [
-        ("unsloth/Llama-3.2-1B-Instruct", {"trust_remote_code": False})
-    ]
+    assert calls == [("unsloth/Llama-3.2-1B-Instruct", {"trust_remote_code": False})]
     assert tok.name_or_path == "meta-llama/Llama-3.2-1B-Instruct"
 
 

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -53,6 +53,8 @@ NO_OP_MODELS = {
     "poolside/Laguna-XS.2",
     # Llama-3 has no reasoning channel at all — preserve flags can't add
     # or drop anything, so they're pure no-ops.
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct",
     "unsloth/Llama-3.2-1B-Instruct",
 }
 
@@ -324,6 +326,8 @@ NEVER_PRESERVES_MODELS = {
     "Qwen/Qwen3-VL-30B-A3B-Instruct",
     # Llama-3 ships no <think> rendering path, so reasoning_content never
     # surfaces in the output regardless of the preserve flags.
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "meta-llama/Llama-3.2-3B-Instruct",
     "unsloth/Llama-3.2-1B-Instruct",
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Central tokenizer loading now depends on third-party mirror repos for two production model IDs; a bad mirror change could affect templates/encoding until overrides are reviewed, though trust_remote_code stays off and overrides are narrowly scoped.
> 
> **Overview**
> **Gated Meta Llama-3.2 Instruct tokenizers** can be loaded without HuggingFace license access by routing `load_tokenizer` (and offset-tokenizer reloads) through audited **`unsloth`** mirror repos while callers still pass canonical `meta-llama/Llama-3.2-*-Instruct` IDs.
> 
> Adds `TOKENIZER_SOURCE_OVERRIDES` plus helpers that pick the load repo, apply existing trust/revision policy on the mirror path, and **rewrite `tokenizer.name_or_path` back to the requested Meta ID** so `MODEL_RENDERER_MAP` auto-resolution still picks `Llama3Renderer`.
> 
> Shared test matrices now use the canonical Meta model name with `"auto"` instead of calling the mirror directly; new unit tests cover mirror selection, name preservation, and offset-tokenizer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc19a060ea8551473425e034a53c98726c99f3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix tokenizer loading for gated Meta Llama-3.2 models by routing to ungated unsloth mirrors
> - Adds `TOKENIZER_SOURCE_OVERRIDES` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/90/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) mapping canonical `meta-llama/Llama-3.2-1B-Instruct` and `3B-Instruct` IDs to their ungated `unsloth` mirrors, so tokenizer loading no longer fails for users without Hugging Face access to the gated repos.
> - Introduces `_tokenizer_source_for` and `_tokenizer_load_kwargs` helpers to apply overrides and compute trust/revision kwargs consistently across `load_tokenizer` and `_get_offset_tokenizer`.
> - Adds `_preserve_requested_tokenizer_name` to ensure the returned tokenizer's `name_or_path` always reflects the originally requested canonical model ID, not the mirror path.
> - Updates tests to use canonical `meta-llama/` IDs and adds coverage for mirror routing, name preservation, and offset-tokenizer reload behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0dc19a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->