### PR TITLE
Adopt verifiers-style dynamic versioning

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -1,12 +1,11 @@
 name: Publish Dev
 
-# Tag every commit on main as ``renderers-v<next>.dev<N>`` and publish the
-# wheel to PyPI as a pre-release. ``<next>`` is the latest release tag with
-# its patch bumped; ``<N>`` is the number of commits since that release so
-# each main commit maps to a unique PEP 440 dev version.
-#
-# Building from the freshly-created tag means hatch-vcs resolves the version
-# cleanly (no ``+gHASH`` local segment), which PyPI requires.
+# Every push to main publishes a pre-release wheel to PyPI. The version
+# is derived at build time by hatch-vcs from ``git describe`` distance
+# to the latest stable ``renderers-v<MAJOR>.<MINOR>.<PATCH>`` tag (see
+# ``[tool.hatch.version.raw-options]`` in pyproject.toml) — no per-commit
+# tag is created. ``local_scheme = "no-local-version"`` strips the
+# ``+gHASH`` segment so PyPI accepts the wheel directly.
 
 on:
   push:
@@ -17,67 +16,29 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  tag:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      tag: ${{ steps.compute.outputs.tag }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Compute next dev tag
-        id: compute
-        run: |
-          set -euo pipefail
-          LATEST_RELEASE=$(git tag --list 'renderers-v*' --sort=-v:refname \
-            | grep -Ev '(dev|rc|a[0-9]|b[0-9])' \
-            | head -1)
-          if [ -z "$LATEST_RELEASE" ]; then
-            echo "No release tag matching 'renderers-v<MAJOR.MINOR.PATCH>' found" >&2
-            exit 1
-          fi
-          BASE=${LATEST_RELEASE#renderers-v}
-          MAJOR=$(echo "$BASE" | cut -d. -f1)
-          MINOR=$(echo "$BASE" | cut -d. -f2)
-          PATCH=$(echo "$BASE" | cut -d. -f3)
-          NEXT="${MAJOR}.${MINOR}.$((PATCH + 1))"
-          N=$(git rev-list --count "${LATEST_RELEASE}..HEAD")
-          TAG="renderers-v${NEXT}.dev${N}"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
-          echo "Computed tag: ${TAG} (base=${LATEST_RELEASE}, commits=${N})"
-
-      - name: Create and push tag
-        env:
-          TAG: ${{ steps.compute.outputs.tag }}
-        run: |
-          set -euo pipefail
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag ${TAG} already exists on origin — nothing to do" >&2
-            exit 0
-          fi
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git tag -a "$TAG" -m "Automated dev release ${TAG}"
-          git push origin "$TAG"
-
+  # Build (no OIDC) → publish (OIDC only). The build job runs ``uv build``
+  # with ``contents: read`` only so a poisoned build-time dep cannot mint
+  # the OIDC token. The publish job has ``id-token: write`` and the
+  # pypi-prod environment but no source checkout — it only downloads the
+  # prebuilt artifact and runs the SHA-pinned pypa publish action.
   build:
-    needs: tag
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
         with:
+          # hatch-vcs needs the full tag history to resolve the version
+          # from the latest stable tag's distance.
           fetch-depth: 0
-          ref: refs/tags/${{ needs.tag.outputs.tag }}
 
       - uses: astral-sh/setup-uv@v7
 
       - name: Build renderers
         run: uv build
+
+      - name: Show derived version
+        run: ls -1 dist/
 
       - name: Upload dist artifacts
         uses: actions/upload-artifact@v4
@@ -102,3 +63,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,22 @@ tag-pattern = '^renderers-v(?P<version>.+)$'
 # only fires when the resolver has nothing to go on.
 fallback-version = "0.0.0"
 
+[tool.hatch.version.raw-options]
+# Only stable ``renderers-v<MAJOR>.<MINOR>.<PATCH>`` tags participate in
+# version resolution; legacy per-commit ``.devN`` tags are excluded.
+# Untagged commits get a clean PEP 440 dev version derived from distance
+# to the latest stable tag (e.g. ``0.1.8.dev46``), with no ``+gHASH``
+# local segment so PyPI accepts the wheel directly. setuptools-scm
+# refuses to bump a pre-existing ``.devN`` tag, so matching only stable
+# tags also unblocks local ``uv lock`` / ``uv build`` on untagged
+# branches. Mirrors verifiers' setup.
+local_scheme = "no-local-version"
+git_describe_command = [
+    "git", "describe", "--tags", "--long",
+    "--match", "renderers-v[0-9]*.[0-9]*.[0-9]*",
+    "--exclude", "*dev*",
+]
+
 [tool.hatch.build.hooks.vcs]
 # Write the resolved version to a Python file so it can be inspected
 # at runtime via ``renderers.__version__`` without re-parsing the

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-05-18T21:42:54.18041997Z"
+exclude-newer = "2026-06-19T02:55:59.889910839Z"
 exclude-newer-span = "P7D"
 
 [options.exclude-newer-package]
@@ -1409,7 +1409,7 @@ requires-dist = [
     { name = "jinja2" },
     { name = "numpy" },
     { name = "openai", specifier = ">=1.108.1" },
-    { name = "openai-harmony", specifier = ">=0.0.8" },
+    { name = "openai-harmony", specifier = ">=0.0.4" },
     { name = "prime-pydantic-config", specifier = ">=0.3.0.dev83" },
     { name = "tiktoken" },
     { name = "transformers", specifier = ">=4.50.0" },


### PR DESCRIPTION
## Why

Today, ``.github/workflows/publish-dev.yml`` creates a fresh ``renderers-v<next>.dev<N>`` tag on every push to main and builds from that tag. This works for the publish path but breaks local development: setuptools-scm refuses to bump a pre-existing ``.devN`` tag, so on any untagged main commit, ``uv lock`` / ``uv build`` fails with:

```
ValueError: Error getting the version from source `vcs`:
choosing custom numbers for the `.devX` distance is not supported.
The 0.1.8.dev45 can't be bumped
```

Forcing every contributor through ``SETUPTOOLS_SCM_PRETEND_VERSION=...`` to run ``uv lock`` isn't a great state. It also pollutes the tag namespace (~45 dev tags per release cycle).

[verifiers](https://github.com/PrimeIntellect-ai/verifiers) (sibling repo, same maintainers) solves the same PyPI ``+gHASH``-local-segment constraint differently — and we should match.

## What changes

### `pyproject.toml`

Add ``[tool.hatch.version.raw-options]``:

```toml
[tool.hatch.version.raw-options]
local_scheme = "no-local-version"
git_describe_command = [
    "git", "describe", "--tags", "--long",
    "--match", "renderers-v[0-9]*.[0-9]*.[0-9]*",
    "--exclude", "*dev*",
]
```

* ``local_scheme = "no-local-version"`` strips the ``+gHASH`` segment at build time. PyPI accepts the wheel directly with no pre-created tag at HEAD.
* ``git_describe_command`` restricts version resolution to stable ``renderers-v<MAJOR>.<MINOR>.<PATCH>`` tags via ``--match`` + ``--exclude "*dev*"``. setuptools-scm derives the dev version from commit distance to the last stable tag (e.g. ``0.1.8.dev49``); no pre-created tag needed.

### `.github/workflows/publish-dev.yml`

Drop the ``tag:`` job entirely (73 lines → ~30 less). The ``build:`` job now checks out main with ``fetch-depth: 0`` and runs ``uv build`` — hatch-vcs computes the version on the fly. Same publish cadence (every push → dev wheel on PyPI), no per-commit tags created.

### Existing dev tags

The ~45 ``renderers-v0.1.8.devN`` tags on the remote stay where they are; ``--exclude "*dev*"`` filters them out of ``git describe`` so they don't interfere with version resolution. Cleaning them up is optional housekeeping for a separate PR.

## Verification (locally)

```
$ uv build               # no env vars
Successfully built dist/renderers-0.1.8.dev49.tar.gz
Successfully built dist/renderers-0.1.8.dev49-py3-none-any.whl

$ uv lock                # no env vars
Resolved 91 packages in 654ms
```

## Stats

```
 .github/workflows/publish-dev.yml | 73 ++++++++++-----------------------------
 pyproject.toml                    | 16 +++++++++
 uv.lock                           |  4 +--
 3 files changed, 36 insertions(+), 57 deletions(-)
```

Net **−21 lines** (excluding the ``uv.lock`` cutoff-date refresh and an unrelated ``openai-harmony`` constraint drift fix — see below).

## `uv.lock` side effects

Two benign changes from re-running ``uv lock``:

* ``exclude-newer`` cutoff advances 2026-05-18 → 2026-06-19 (rolling 7-day cooldown catching up).
* ``openai-harmony`` constraint in the lock realigns with ``pyproject.toml``'s stated ``>=0.0.4`` (lock had drifted to ``>=0.0.8``). ``pyproject.toml`` itself is unchanged — this is the lock catching up to a long-standing source constraint.

## Outcome

* ``uv lock`` / ``uv build`` work on any main checkout without env-var workarounds.
* Same PyPI publish cadence (every main push → dev wheel).
* Aligned with verifiers / sibling PrimeIntellect-ai projects.
* ~45 fewer dev tags created per release cycle going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release versioning and PyPI publish behavior; mistakes could produce wrong wheel versions or duplicate-publish edge cases, though `skip-existing` mitigates retries.
> 
> **Overview**
> **Dev PyPI publishing** no longer creates a `renderers-v*.devN` tag on every main push. The workflow builds directly from `main` with full git history; **hatch-vcs** derives PEP 440 dev versions from distance to the latest stable `renderers-v*` tag at build time.
> 
> **`pyproject.toml`** adds `[tool.hatch.version.raw-options]`: `local_scheme = "no-local-version"` (PyPI-friendly wheels without `+gHASH`) and a custom `git_describe_command` that only considers stable release tags and excludes legacy `*dev*` tags—fixing local `uv lock` / `uv build` failures when `.devN` tags already exist.
> 
> The publish step sets **`skip-existing: true`** on the PyPI action. **`uv.lock`** refreshes the rolling `exclude-newer` cutoff and realigns `openai-harmony` with `>=0.0.4`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35d51a966a8b5431a5719ce7b05d2c34d049c032. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Adopt dynamic versioning from git tags in the dev publish workflow
> - Removes the tag job from [publish-dev.yml](.github/workflows/publish-dev.yml) that created synthetic per-commit dev tags; the build job now checks out the full git history from the branch head and derives the version via `hatch-vcs`.
> - Configures `hatch-vcs` in [pyproject.toml](https://github.com/PrimeIntellect-ai/renderers/pull/96/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711) with `local_scheme = "no-local-version"` and a `git describe` command scoped to stable `renderers-v*` tags, producing clean PEP 440 dev versions (e.g. `1.2.3.dev4`) without a `+gHASH` local segment.
> - Adds `skip-existing: true` to the PyPI publish step to avoid failures when the derived version already exists.
> - Behavioral Change: versions are now derived from distance to the latest stable tag rather than a synthetic per-commit tag; legacy `.devN` tags are excluded from version resolution.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 35d51a9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->