### PR TITLE
feat(sft): opt-in final stop token in build_training_sample

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1594,6 +1594,7 @@ def build_training_sample(
     role_to_mask: Callable[[Message], bool] | None = None,
     tools: list[ToolSpec] | None = None,
     content_sft_roles: "set[str] | frozenset[str] | None" = None,
+    ensure_final_stop: bool = False,
 ) -> RenderedTrainingSample:
     """Build a :class:`RenderedTrainingSample` for supervised training.
 
@@ -1649,6 +1650,17 @@ def build_training_sample(
     or hand-coded renderers that haven't been wired up yet) ignore
     ``content_sft_roles`` silently — falling back to the original
     ``role_to_mask`` + ``sampled_mask`` behaviour.
+
+    ``ensure_final_stop`` appends the renderer's canonical stop token as
+    a trainable target when the sample ends with an assistant message
+    whose last trainable token is not already a stop. Some templates
+    (e.g. GLM) terminate an assistant turn with the *next* message's
+    role marker — or, at inference, a sampled ``<|endoftext|>`` that the
+    template never renders back into history — so a final assistant
+    turn otherwise carries no stop supervision at all. This breaks byte
+    identity with ``apply_chat_template`` on such templates by design;
+    it is a no-op for templates whose assistant close is part of the
+    message (ChatML ``<|im_end|>``, Llama ``<|eot_id|>``).
     """
     rendered = renderer.render(messages, tools=tools)
     has_sampled_info = len(rendered.sampled_mask) == len(rendered.token_ids)
@@ -1689,6 +1701,16 @@ def build_training_sample(
         else:
             loss_mask.append(role_to_mask(msg))
 
+    token_ids = list(rendered.token_ids)
+    if ensure_final_stop and messages[-1].get("role") == "assistant":
+        stop_ids = set(renderer.get_stop_token_ids())
+        last_trainable = next(
+            (k for k in range(len(loss_mask) - 1, -1, -1) if loss_mask[k]), None
+        )
+        if last_trainable is None or token_ids[last_trainable] not in stop_ids:
+            token_ids.append(renderer.get_stop_token_ids()[0])
+            loss_mask.append(True)
+
     # Surface the multimodal payload for VLM renderers. ``None`` for text
     # renderers and for text-only samples (empty media) so downstream
     # ``multi_modal_data is not None`` is a reliable "has media" check.
@@ -1701,7 +1723,7 @@ def build_training_sample(
         else None
     )
     return RenderedTrainingSample(
-        token_ids=rendered.token_ids,
+        token_ids=token_ids,
         loss_mask=loss_mask,
         multi_modal_data=mm,
         mm_token_type_ids=mm_token_type_ids,

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1702,12 +1702,13 @@ def build_training_sample(
             loss_mask.append(role_to_mask(msg))
 
     token_ids = list(rendered.token_ids)
-    # Requires sampled_mask — opaque templates (DefaultRenderer) give no
-    # reliable way to locate the assistant close.
+    # Requires sampled_mask (opaque templates hide the assistant close)
+    # and a final assistant message the role filter trains.
     if (
         ensure_final_stop
         and has_sampled_info
         and messages[-1].get("role") == "assistant"
+        and (role_to_mask is None or role_to_mask(messages[-1]))
     ):
         stop_ids = set(renderer.get_stop_token_ids())
         last_trainable = next(

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1651,16 +1651,14 @@ def build_training_sample(
     ``content_sft_roles`` silently — falling back to the original
     ``role_to_mask`` + ``sampled_mask`` behaviour.
 
-    ``ensure_final_stop`` appends the renderer's canonical stop token as
-    a trainable target when the sample ends with an assistant message
-    whose last trainable token is not already a stop. Some templates
-    (e.g. GLM) terminate an assistant turn with the *next* message's
-    role marker — or, at inference, a sampled ``<|endoftext|>`` that the
-    template never renders back into history — so a final assistant
-    turn otherwise carries no stop supervision at all. This breaks byte
-    identity with ``apply_chat_template`` on such templates by design;
-    it is a no-op for templates whose assistant close is part of the
-    message (ChatML ``<|im_end|>``, Llama ``<|eot_id|>``).
+    ``ensure_final_stop`` appends the renderer's canonical stop token
+    when the sample ends with an assistant message that the template
+    leaves unterminated. Some templates close an assistant turn only
+    via the *next* message's role marker (e.g. GLM's ``<|user|>`` /
+    ``<|observation|>``), so a final assistant message renders with no
+    stop token at all. No-op when the template already closes the turn
+    in-message (ChatML ``<|im_end|>``, Llama ``<|eot_id|>``); where it
+    fires, the output intentionally diverges from ``apply_chat_template``.
     """
     rendered = renderer.render(messages, tools=tools)
     has_sampled_info = len(rendered.sampled_mask) == len(rendered.token_ids)

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1659,6 +1659,8 @@ def build_training_sample(
     stop token at all. No-op when the template already closes the turn
     in-message (ChatML ``<|im_end|>``, Llama ``<|eot_id|>``); where it
     fires, the output intentionally diverges from ``apply_chat_template``.
+    Ignored for renderers without ``sampled_mask`` (``DefaultRenderer``) —
+    the close of an opaque template can't be located reliably.
     """
     rendered = renderer.render(messages, tools=tools)
     has_sampled_info = len(rendered.sampled_mask) == len(rendered.token_ids)
@@ -1700,7 +1702,13 @@ def build_training_sample(
             loss_mask.append(role_to_mask(msg))
 
     token_ids = list(rendered.token_ids)
-    if ensure_final_stop and messages[-1].get("role") == "assistant":
+    # Requires sampled_mask — opaque templates (DefaultRenderer) give no
+    # reliable way to locate the assistant close.
+    if (
+        ensure_final_stop
+        and has_sampled_info
+        and messages[-1].get("role") == "assistant"
+    ):
         stop_ids = set(renderer.get_stop_token_ids())
         last_trainable = next(
             (k for k in range(len(loss_mask) - 1, -1, -1) if loss_mask[k]), None

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1707,6 +1707,8 @@ def build_training_sample(
         )
         if last_trainable is None or token_ids[last_trainable] not in stop_ids:
             token_ids.append(renderer.get_stop_token_ids()[0])
+            # loss_mask=True marks the token as trainable — the appended
+            # stop is a training target, like any sampled token.
             loss_mask.append(True)
 
     # Surface the multimodal payload for VLM renderers. ``None`` for text

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1718,7 +1718,7 @@ def build_training_sample(
     if mm is not None and mm.is_empty():
         mm = None
     mm_token_type_ids = (
-        _build_mm_token_type_ids(mm.mm_placeholders, len(rendered.token_ids))
+        _build_mm_token_type_ids(mm.mm_placeholders, len(token_ids))
         if mm is not None and mm.mm_placeholders
         else None
     )

--- a/tests/test_build_helpers.py
+++ b/tests/test_build_helpers.py
@@ -64,6 +64,34 @@ def test_build_training_sample_has_trainable_tokens(model_name, tokenizer, rende
     assert len(mask) == len(ids)
 
 
+def test_build_training_sample_ensures_final_stop(model_name, tokenizer, renderer):
+    """The final assistant turn ends at a trainable renderer stop token.
+
+    Templates whose assistant close is part of the message (ChatML, Llama)
+    already satisfy this, so the sample stays byte-identical; templates
+    that terminate turns with the next message's role marker (GLM) get the
+    canonical stop appended as the training target.
+    """
+    if not renderer.render([{"role": "user", "content": "x"}]).sampled_mask:
+        return  # DefaultRenderer: no sampled_mask, role-only masking
+    msgs = [
+        {"role": "user", "content": "Hi"},
+        {"role": "assistant", "content": "Hello!"},
+    ]
+    sample = build_training_sample(renderer, msgs, ensure_final_stop=True)
+    stop_ids = set(renderer.get_stop_token_ids())
+    last_trainable = max(k for k, m in enumerate(sample.loss_mask) if m)
+    assert sample.token_ids[last_trainable] in stop_ids
+
+    baseline = build_training_sample(renderer, msgs)
+    if (
+        baseline.token_ids[max(k for k, m in enumerate(baseline.loss_mask) if m)]
+        in stop_ids
+    ):
+        # In-message close: ensure_final_stop must not change the bytes.
+        assert sample.token_ids == baseline.token_ids
+
+
 def test_build_trajectory_step_reconstructs_full(model_name, tokenizer, renderer):
     """prompt_ids + completion_ids must equal the full rendered sequence."""
     prompt = [


### PR DESCRIPTION
## Summary
- add `ensure_final_stop` to `build_training_sample`: when a sample ends with an assistant message whose last trainable token is not a renderer stop token, append the canonical stop as a trainable target
- no-op for templates whose assistant close is part of the message (ChatML `<|im_end|>`, Llama `<|eot_id|>`); restores final-turn stop supervision for GLM-style templates where the turn terminator is the next message's role marker or a sampled `<|endoftext|>` the template never re-renders
- matrix-wide test asserting the final assistant turn ends at a trainable stop and that in-message-close renderers stay byte-identical

## Validation
- `uv run pytest tests/test_build_helpers.py -q` — 101 passed, 10 skipped
- Ruff format/check (repo defaults) — passed

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `ensure_final_stop` parameter to `build_training_sample` to append a trainable stop token
> - Adds an opt-in `ensure_final_stop: bool = False` keyword argument to `build_training_sample` in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/101/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf).
> - When enabled and the last message is an assistant turn, the function checks whether the last trainable token is already a stop token; if not, it appends the renderer's first stop token id and marks it as trainable in the loss mask.
> - Behavior is unchanged when `ensure_final_stop=False` or when the final trainable token is already a stop token.
> - Risk: multi-modal `mm_token_type_ids` are sized to the original rendered length and do not include the appended stop token, which may cause a length mismatch in multi-modal samples using this flag.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #101 opened
>
> - Updated docstring for `ensure_final_stop` parameter in `build_training_sample` function [e036812]
> - Added inline comment in `build_training_sample` utility function clarifying stop token training behavior [7d362e4]
> - Changed the length argument in `_build_mm_token_type_ids` call within `build_training_sample` function from `len(rendered.token_ids)` to `len(token_ids)` [807f292]
> - Modified `build_training_sample` function in `renderers.base` to require `has_sampled_info` in addition to `ensure_final_stop` and the last message being from the assistant before appending a stop token, and updated the docstring to clarify that `ensure_final_stop` is ignored for renderers without `sampled_mask` such as `DefaultRenderer`, with an added inline comment explaining the tightened conditional logic [165a941]
> - Modified `build_training_sample` function to conditionally append and train the final stop token based on role masking filter [ec1ea8b]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fc04fba.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->