### PR TITLE
feat: parse kept_tokens sampling masks from /generate responses

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1937,6 +1937,7 @@ def build_trajectory_step(
         "completion_mask": [True] * len(completion_ids),
         "completion_logprobs": [0.0] * len(completion_ids),
         "routed_experts": None,
+        "kept_tokens": None,
     }
     if (
         full_rendered.multi_modal_data is not None

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -139,12 +139,8 @@ def _strip_base64_field(raw: bytes, prefix: bytes) -> tuple[bytes, memoryview | 
     return stripped, data
 
 
-def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
-    return _strip_base64_field(raw, ROUTED_EXPERTS_DATA_PREFIX)
-
-
 def parse_generate_response(raw: bytes) -> dict[str, Any]:
-    stripped, routed_data = strip_routed_experts_data(raw)
+    stripped, routed_data = _strip_base64_field(raw, ROUTED_EXPERTS_DATA_PREFIX)
     stripped, kept_ids_data = _strip_base64_field(stripped, KEPT_TOKENS_IDS_PREFIX)
     payload: dict[str, Any] = json.loads(stripped)
     if routed_data is not None:

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -32,6 +32,7 @@ from renderers.base import (
 
 _request_logger = logging.getLogger("renderers.client")
 ROUTED_EXPERTS_DATA_PREFIX = b'"routed_experts":{"data":"'
+KEPT_TOKENS_IDS_PREFIX = b'"kept_tokens":{"ids":"'
 
 
 class OverlongPromptError(Exception):
@@ -121,23 +122,35 @@ async def _maybe_offload(renderer: Renderer | RendererPool, fn):
     return fn()
 
 
-def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
-    data_start = raw.find(ROUTED_EXPERTS_DATA_PREFIX)
+def _strip_base64_field(raw: bytes, prefix: bytes) -> tuple[bytes, memoryview | None]:
+    """Splice a large base64 string field out of raw JSON bytes.
+
+    Avoids json-decoding megabytes of base64; the returned memoryview
+    references ``raw`` and is re-inserted into the parsed payload.
+    """
+    data_start = raw.find(prefix)
     if data_start < 0:
         return raw, None
 
-    data_start += len(ROUTED_EXPERTS_DATA_PREFIX)
+    data_start += len(prefix)
     data_end = raw.index(b'"', data_start)
-    routed_data = memoryview(raw)[data_start:data_end]
+    data = memoryview(raw)[data_start:data_end]
     stripped = raw[:data_start] + raw[data_end:]
-    return stripped, routed_data
+    return stripped, data
+
+
+def strip_routed_experts_data(raw: bytes) -> tuple[bytes, memoryview | None]:
+    return _strip_base64_field(raw, ROUTED_EXPERTS_DATA_PREFIX)
 
 
 def parse_generate_response(raw: bytes) -> dict[str, Any]:
     stripped, routed_data = strip_routed_experts_data(raw)
+    stripped, kept_ids_data = _strip_base64_field(stripped, KEPT_TOKENS_IDS_PREFIX)
     payload: dict[str, Any] = json.loads(stripped)
     if routed_data is not None:
         payload["choices"][0]["routed_experts"]["data"] = routed_data
+    if kept_ids_data is not None:
+        payload["choices"][0]["kept_tokens"]["ids"] = kept_ids_data
     return payload
 
 
@@ -293,6 +306,7 @@ async def generate(
     completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
 
     routed_experts = choice.get("routed_experts")
+    kept_tokens = choice.get("kept_tokens")
 
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
@@ -319,6 +333,7 @@ async def generate(
         "tool_calls": parsed.tool_calls,
         "finish_reason": finish_reason,
         "routed_experts": routed_experts,
+        "kept_tokens": kept_tokens,
         # The mm sidecar consumed on the request side, surfaced back so
         # callers can persist it on the trajectory step for downstream
         # multi-turn bridging and training-sample construction.


### PR DESCRIPTION
Parse the `kept_tokens` field from `/inference/v1/generate` responses: the kept-set sampling masks (token ids that survived top-p/top-k truncation, one set per completion token) consumed by prime-rl's sampling replay training (PrimeIntellect-ai/prime-rl#2979, DeepSeek V3.2 "Keep Sampling Mask").

- Generalize the routed-experts byte-splice into `_strip_base64_field` (both splices call it directly; the `strip_routed_experts_data` wrapper is gone) and reuse it to splice the large base64 `ids` blob out of the raw response bytes before `json.loads`, re-inserting it as a memoryview — same fast path routed_experts uses.
- Surface `kept_tokens` (`{ids, counts}`) on the `generate()` result dict; `None` on the re-render fallback path.

Validated end to end in prime-rl's GPU ablations (reverse-text + 200-step hendrycks sanity at `top_p 0.97 / top_k 512`): 100% mask coverage on sampled tokens, ~32 B/token payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Parse `kept_tokens` sampling masks from `/generate` responses
> - Adds a `_strip_base64_field` helper in [client.py](https://github.com/PrimeIntellect-ai/renderers/pull/102/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) that extracts any base64-encoded field from raw JSON bytes by prefix, replacing the previous `routed_experts`-specific function.
> - Updates `parse_generate_response` to extract and re-insert both `routed_experts.data` and `kept_tokens.ids` as memoryviews after JSON parsing.
> - Threads `kept_tokens` from the choice payload through `generate()` so callers receive it in the returned dict.
> - Adds `kept_tokens: None` as a default field in `build_trajectory_step` in [base.py](https://github.com/PrimeIntellect-ai/renderers/pull/102/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b6635d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized client parsing and dict plumbing with no auth or sampling logic changes; main risk is malformed JSON if engine response shape diverges from the expected `kept_tokens.ids` prefix.
> 
> **Overview**
> Adds end-to-end support for **`kept_tokens`** (top-p/top-k keep-set masks from `/inference/v1/generate`) so training stacks like prime-rl can replay sampling masks without decoding huge base64 blobs through `json.loads`.
> 
> In **`client.py`**, the routed-experts byte splice is generalized to **`_strip_base64_field`**, which is applied twice in **`parse_generate_response`**—for `routed_experts.data` and for **`kept_tokens.ids`**—then each blob is reattached as a **`memoryview`**. **`generate()`** now passes through **`kept_tokens`** on its result dict, mirroring **`routed_experts`**.
> 
> In **`base.py`**, **`build_trajectory_step`** initializes **`kept_tokens: None`** on the re-render fallback trajectory step so the field is always present when live generate data is not used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6635d261caf524fee46ea04cb5e52e7c04f064a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->