### PR TITLE
fix(renderers): bridge merge must not mutate prior multi_modal_data

### DIFF
--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -1183,18 +1183,20 @@ class KimiK25Renderer:
             emit_text("<think></think>", -1)
 
         # Merge prev mm_data (earlier-turn images) with the new turn's items.
+        # Copy the per-modality lists (not just the outer dict) so appending
+        # below never mutates the caller's previous_multi_modal_data.
         merged_hashes: dict[str, list[str]] = (
-            dict(previous_multi_modal_data.mm_hashes)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_placeholders: dict[str, list[PlaceholderRange]] = (
-            dict(previous_multi_modal_data.mm_placeholders)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_items: dict[str, list[dict[str, Any]]] = (
-            dict(previous_multi_modal_data.mm_items)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
             if previous_multi_modal_data
             else {}
         )

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -834,18 +834,20 @@ class Qwen35Renderer:
             emit_text("\n\n", -1)
 
         # Merge prev mm_data (images from earlier turns) with the new turn's.
+        # Copy the per-modality lists (not just the outer dict) so appending
+        # below never mutates the caller's previous_multi_modal_data.
         merged_hashes: dict[str, list[str]] = (
-            dict(previous_multi_modal_data.mm_hashes)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_placeholders: dict[str, list[PlaceholderRange]] = (
-            dict(previous_multi_modal_data.mm_placeholders)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_items: dict[str, list[dict[str, Any]]] = (
-            dict(previous_multi_modal_data.mm_items)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
             if previous_multi_modal_data
             else {}
         )

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -828,19 +828,21 @@ class Qwen3VLRenderer:
         em.text("assistant\n", is_sampled=False, is_content=False)
         em.finalize()
 
-        # Merge prev mm_data with the new turn's items.
+        # Merge prev mm_data with the new turn's items. Copy the per-modality
+        # lists (not just the outer dict) so appending below never mutates the
+        # caller's previous_multi_modal_data.
         merged_hashes = (
-            dict(previous_multi_modal_data.mm_hashes)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_placeholders = (
-            dict(previous_multi_modal_data.mm_placeholders)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
             if previous_multi_modal_data
             else {}
         )
         merged_items = (
-            dict(previous_multi_modal_data.mm_items)
+            {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
             if previous_multi_modal_data
             else {}
         )

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -583,6 +583,12 @@ def test_multimodal_bridge_extends_and_carries_mm_data(
     ]
 
     initial_rendered = renderer.render(initial, add_generation_prompt=True)
+    prior_mm = initial_rendered.multi_modal_data
+    prior_counts = (
+        len(prior_mm.mm_placeholders.get(modality, [])),
+        len(prior_mm.mm_items.get(modality, [])),
+        len(prior_mm.mm_hashes.get(modality, [])),
+    )
     # ``previous_completion_ids`` mirrors what a sampler would emit
     # starting AFTER the prompt's assistant role opener — i.e. the
     # response text followed by ``<|im_end|>``.
@@ -631,6 +637,19 @@ def test_multimodal_bridge_extends_and_carries_mm_data(
     items = bridged_mm.mm_items.get(modality, [])
     hashes = bridged_mm.mm_hashes.get(modality, [])
     assert len(items) == 2 and len(hashes) == 2
+
+    # (2b) The prior turn's sidecar is unchanged — the bridge copies the
+    # per-modality lists, so the carried-forward item doesn't grow the
+    # caller's previous_multi_modal_data in place.
+    assert (
+        (
+            len(prior_mm.mm_placeholders.get(modality, [])),
+            len(prior_mm.mm_items.get(modality, [])),
+            len(prior_mm.mm_hashes.get(modality, [])),
+        )
+        == prior_counts
+        == (1, 1, 1)
+    ), f"{mm_model_name} / {modality}: bridge mutated previous_multi_modal_data"
 
     # (3) Extension contains the new turn's pad run, and its
     # placeholder offset lands inside the extension region.


### PR DESCRIPTION
## Summary

`MultimodalRenderer.bridge_to_next_turn` merged the carried-forward multimodal sidecar with `dict(previous_multi_modal_data.mm_*)` — which copies only the **outer** dict. The per-modality lists stayed shared with the caller, so appending this turn's items via `.setdefault(modality, []).extend(...)` **mutated the caller's `previous_multi_modal_data` in place**. A reused prior `RenderedTokens` / `MultiModalData` would silently grow extra placeholders / items / hashes after a bridge.

Fix: copy the per-modality lists (`{k: list(v) for k, v in ….items()}`) before extending.

## Scope

Cursor Bugbot flagged this on the Inkling PR (#103) for `KimiK25Renderer`; the **identical** pattern was in `Qwen3VLRenderer` and `Qwen35Renderer`, so all three are fixed here. (Inkling itself was fixed in #103.)

## Test

Extends the shared `test_multimodal_bridge_extends_and_carries_mm_data` with a **(2b)** assertion that the prior turn's sidecar counts are unchanged after bridging — it now runs green for all five multimodal checkpoints (Qwen3-VL, Qwen3.5, Qwen3.6, Kimi K2.5, Kimi K2.6). Full `tests/test_multimodal.py`: 85 passed, 3 skipped.

Comment-and-copy only; no token-stream or `bridged` output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted copy-before-extend fix with no intended change to token streams; regression covered by extended multimodal bridge test.
> 
> **Overview**
> Fixes **in-place mutation** of the caller's `previous_multi_modal_data` when multimodal renderers merge carried-forward vision sidecars during `bridge_to_next_turn`.
> 
> Previously, merging used `dict(previous_multi_modal_data.mm_*)`, which only shallow-copied the outer map—**per-modality lists stayed aliased**, so `.setdefault(modality, []).extend(...)` could append placeholders, items, and hashes to a reused prior `RenderedTokens` / `MultiModalData`. The change deep-copies each modality list (`{k: list(v) for k, v in ...}`) in **Kimi K2.5**, **Qwen3.5**, and **Qwen3-VL** before extending; bridged token output is unchanged.
> 
> Adds test **(2b)** in `test_multimodal_bridge_extends_and_carries_mm_data` asserting prior sidecar counts stay `(1, 1, 1)` after bridging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f0278b863721857b08463f2d7d35cbdd9d993e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `bridge_to_next_turn` mutation of caller-supplied `previous_multi_modal_data`
> The `bridge_to_next_turn` method in `KimiK25Renderer`, `Qwen35Renderer`, and `Qwen3VLRenderer` was shallow-copying only the outer dict when merging prior multimodal sidecar data, causing `.extend()` calls to mutate the caller's original per-modality lists. Each renderer now uses `{k: list(v) for k, v in ....items()}` to copy the inner lists, isolating the merged copy from the caller's data. A regression test in [test_multimodal.py](https://github.com/PrimeIntellect-ai/renderers/pull/104/files#diff-0a1384bf0e7f0dc0cd6aa0e8299ec938f257c0b6b8761a5a07d254ef4883d980) now asserts that per-modality counts in `previous_multi_modal_data` remain unchanged after bridging.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5f0278.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->