### PR TITLE
fix(qwen): keep empty think wrapper on historical turns when thinking is disabled

### DIFF
--- a/renderers/configs.py
+++ b/renderers/configs.py
@@ -178,7 +178,13 @@ class Qwen3RendererConfig(BaseRendererConfig):
     enable_thinking: bool = True
     """When ``True``, the generation prompt includes ``<think>`` so the
     model continues into a thinking block. Mirrors the chat template's
-    ``enable_thinking`` kwarg."""
+    ``enable_thinking`` kwarg.
+
+    When ``False``, the renderer deliberately deviates from the template
+    on historical assistant turns without ``reasoning_content``: the empty
+    ``<think>\\n\\n</think>\\n\\n`` wrapper the generation prompt prefilled
+    is re-emitted instead of stripped, keeping re-renders token-stable with
+    the sampled stream (see ``renderers/qwen3.py`` module docstring)."""
 
 
 class PrimeQwen3RendererConfig(BaseRendererConfig):
@@ -196,7 +202,14 @@ class Qwen35RendererConfig(BaseRendererConfig):
     """When ``True``, the generation prompt includes ``<think>``. ``None``
     auto-detects from the tokenizer's chat-template default — Instruct
     checkpoints default off, Thinking checkpoints default on. Mirrors
-    the chat template's ``enable_thinking`` kwarg."""
+    the chat template's ``enable_thinking`` kwarg.
+
+    When resolved ``False``, the renderer deliberately deviates from the
+    template on historical assistant turns without ``reasoning_content``:
+    the empty ``<think>\\n\\n</think>\\n\\n`` wrapper the generation prompt
+    prefilled is re-emitted instead of stripped, keeping re-renders
+    token-stable with the sampled stream (see ``renderers/qwen35.py``
+    module docstring)."""
 
     add_vision_id: bool = False
     """When ``True``, prefix each ``<|vision_start|>`` placeholder with

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -286,7 +286,15 @@ def parse_qwen35(
     tool_call_end_id: int,
     tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
-    """Parse Qwen3.5 completion tokens. XML-style tool calls, token-level thinking."""
+    """Parse Qwen3.5 completion tokens. XML-style tool calls, token-level thinking.
+
+    ``reasoning_content`` contract: ``None`` means the completion carried no
+    think block at all; a string (possibly empty) means a think block was
+    present. The distinction matters for renderers with key-presence
+    semantics (PrimeQwen3Renderer): a sampled ``<think></think>`` must
+    round-trip parse → message → render back to the same tokens, so an
+    empty-but-present block is ``""``, never ``None``.
+    """
     ids = _strip_stop_tokens(token_ids, stop_ids)
 
     # Thinking: find </think> by token ID
@@ -300,12 +308,12 @@ def parse_qwen35(
         ids = ids[think_end + 1 :]
         parse_offset = think_end + 1
     elif think_id in set(ids):
-        # <think> present but no </think> — truncated reasoning
+        # <think> present but no </think> — truncated reasoning. Block
+        # present ⇒ string (see docstring), even when nothing follows the
+        # opening tag.
         think_start = _find(ids, think_id)
         reasoning = _decode(tokenizer, ids[think_start + 1 :]).strip()
-        return ParsedResponse(
-            content="", reasoning_content=reasoning or None, tool_calls=[]
-        )
+        return ParsedResponse(content="", reasoning_content=reasoning, tool_calls=[])
 
     tc_start = _find(ids, tool_call_id)
     tool_calls: list[ParsedToolCall] = []
@@ -322,9 +330,14 @@ def parse_qwen35(
     else:
         content_text = _decode(tokenizer, ids).strip()
 
+    # ``reasoning`` is None only when no think block was found; keep ""
+    # (empty-but-present block) intact so ``<think></think>`` samples
+    # round-trip — collapsing it to None made PrimeQwen3Renderer drop the
+    # block on re-render, forking the token stream for the rest of the
+    # rollout.
     return ParsedResponse(
         content=content_text,
-        reasoning_content=reasoning or None,
+        reasoning_content=reasoning,
         tool_calls=tool_calls,
     )
 

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -5,6 +5,15 @@ Key differences from Qwen3.5:
 - Tool calls use JSON format: {"name": "...", "arguments": ...}
 - Thinking blocks only inserted when loop.last OR reasoning_content present
 - Generation prompt does NOT add <think> by default
+
+One documented deviation from the Jinja template: with
+``enable_thinking=False`` the empty ``<think>\n\n</think>\n\n`` wrapper is
+re-emitted on historical assistant turns without ``reasoning_content`` (the
+template strips it from turns at or before the last user query). The
+generation prompt prefills that wrapper, so every turn sampled with thinking
+disabled contains it — stripping it on re-render would make the same
+conversation produce different tokens depending on when it is rendered.
+See ``tests/test_disabled_thinking_stability.py``.
 """
 
 from __future__ import annotations
@@ -477,7 +486,17 @@ class Qwen3Renderer:
         emit_in_template_window = msg_idx > last_query_index and (
             is_last or reasoning_content
         )
-        if emit_in_template_window:
+        # With thinking disabled, the generation prompt prefilled the empty
+        # ``<think>\n\n</think>\n\n`` wrapper, so it is part of every sampled
+        # turn's token stream. Re-emit it on historical turns — deviating
+        # from the Jinja template, which strips it from turns at or before
+        # the last user query — so re-renders stay token-stable with what
+        # the model actually sampled. Turns that carry reasoning_content
+        # were not sampled under this config; those stay template-faithful.
+        emit_thinking = emit_in_template_window or (
+            not self.config.enable_thinking and not reasoning_content
+        )
+        if emit_thinking:
             body = (
                 "<think>\n"
                 + reasoning_content.strip("\n")

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -3,6 +3,14 @@
 Produces token-for-token identical output to tokenizer.apply_chat_template() while
 also tracking which message produced each token (for per-token loss masks).
 
+One documented deviation: with ``enable_thinking=False`` the empty
+``<think>\n\n</think>\n\n`` wrapper is re-emitted on historical assistant
+turns without ``reasoning_content`` (the Jinja template strips it from turns
+at or before the last user query). The generation prompt prefills that
+wrapper, so every turn sampled with thinking disabled contains it — stripping
+it on re-render would make the same conversation produce different tokens
+depending on when it is rendered. See ``tests/test_disabled_thinking_stability.py``.
+
 Multimodal: the Qwen3.5 family is itself a VLM (HF tag ``image-text-to-text``;
 processor class ``Qwen3VLProcessor``). When a user/tool message carries an
 ``ImagePart``, the renderer emits the same ``<|vision_start|>``+N×``<|image_pad|>``
@@ -959,9 +967,18 @@ class Qwen35Renderer:
         # call tags (``<function=...>``, ``<parameter=...>``, etc.) are
         # part of the model's emitted output too — keep them
         # ``is_content=True`` per the assistant rule.
-        emit_thinking = self._should_render_thinking(
-            msg_idx, last_query_index
-        ) or getattr(self.config, "preserve_thinking", False)
+        # With thinking disabled, the generation prompt prefilled the empty
+        # ``<think>\n\n</think>\n\n`` wrapper, so it is part of every sampled
+        # turn's token stream. Re-emit it on historical turns — deviating
+        # from the Jinja template, which strips it from turns at or before
+        # the last user query — so re-renders stay token-stable with what
+        # the model actually sampled. Turns that carry reasoning_content
+        # were not sampled under this config; those stay template-faithful.
+        emit_thinking = (
+            self._should_render_thinking(msg_idx, last_query_index)
+            or getattr(self.config, "preserve_thinking", False)
+            or (not self.config.enable_thinking and not reasoning_content)
+        )
         if emit_thinking:
             # Include thinking block
             emit_special(self._think, msg_idx, is_sampled=True, is_content=True)

--- a/tests/test_disabled_thinking_stability.py
+++ b/tests/test_disabled_thinking_stability.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from functools import lru_cache
 
-import pytest
 
 from renderers import create_renderer
 from renderers.base import load_tokenizer
@@ -52,9 +51,7 @@ def _load(model_name: str):
 
 def pytest_generate_tests(metafunc):
     if "dt_model" in metafunc.fixturenames:
-        metafunc.parametrize(
-            "dt_model,dt_config", _MODELS, ids=[m for m, _ in _MODELS]
-        )
+        metafunc.parametrize("dt_model,dt_config", _MODELS, ids=[m for m, _ in _MODELS])
 
 
 def test_sampled_stream_is_prefix_of_rerender(dt_model, dt_config):
@@ -104,11 +101,7 @@ def test_wrapper_reemitted_on_historical_turn(dt_model, dt_config):
             {"role": "user", "content": "Now 3+3?"},
         ]
     )
-    turn = [
-        t
-        for t, i in zip(rendered.token_ids, rendered.message_indices)
-        if i == 1
-    ]
+    turn = [t for t, i in zip(rendered.token_ids, rendered.message_indices) if i == 1]
     text = tok.decode(turn)
     assert _EMPTY_WRAPPER in text, (
         f"{dt_model}: historical assistant turn rendered without the "

--- a/tests/test_disabled_thinking_stability.py
+++ b/tests/test_disabled_thinking_stability.py
@@ -1,0 +1,233 @@
+"""Sampled-token stability with thinking disabled (Qwen family).
+
+With ``enable_thinking=False`` the generation prompt prefills the empty
+``<think>\\n\\n</think>\\n\\n`` wrapper, so the wrapper is part of every
+sampled turn's token stream. In an agentic rollout the conversation keeps
+growing (tool responses, budget / prune-reminder user messages, ...) and may
+be re-rendered from messages. The upstream Jinja template strips the wrapper
+from assistant turns at or before the last user query, so a re-render would
+diverge token-for-token from the stream the model actually sampled — forking
+any token-identity comparison on byte-identical messages.
+
+These tests pin the renderer-side guarantee that fixes this: with thinking
+disabled, historical assistant turns without ``reasoning_content`` re-emit
+the exact gen-prompt wrapper, so the tokens a turn was sampled with are a
+prefix of every later re-render of the grown conversation, and the bridge
+and a full re-render agree.
+
+This is a deliberate, documented deviation from ``apply_chat_template`` —
+see the carve-out in ``test_renderer_config_parity.py`` and the module
+docstrings of ``renderers/qwen3.py`` / ``renderers/qwen35.py``.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pytest
+
+from renderers import create_renderer
+from renderers.base import load_tokenizer
+from renderers.configs import (
+    Qwen3RendererConfig,
+    Qwen35RendererConfig,
+    Qwen36RendererConfig,
+)
+
+# One representative model per affected renderer family, each with
+# thinking explicitly disabled.
+_MODELS = [
+    ("Qwen/Qwen3-8B", Qwen3RendererConfig(enable_thinking=False)),
+    ("Qwen/Qwen3.5-9B", Qwen35RendererConfig(enable_thinking=False)),
+    ("Qwen/Qwen3.6-35B-A3B", Qwen36RendererConfig(enable_thinking=False)),
+]
+
+_EMPTY_WRAPPER = "<think>\n\n</think>\n\n"
+
+
+@lru_cache(maxsize=None)
+def _load(model_name: str):
+    return load_tokenizer(model_name)
+
+
+def pytest_generate_tests(metafunc):
+    if "dt_model" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "dt_model,dt_config", _MODELS, ids=[m for m, _ in _MODELS]
+        )
+
+
+def test_sampled_stream_is_prefix_of_rerender(dt_model, dt_config):
+    """The rollout invariant: every generation prompt (which ends with the
+    prefilled empty wrapper) stays a byte prefix of all later re-renders of
+    the grown conversation — even after new real user queries arrive."""
+    tok = _load(dt_model)
+    renderer = create_renderer(tok, dt_config)
+
+    convo: list[dict] = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "What is the capital of France?"},
+    ]
+    prev = renderer.render_ids(convo, add_generation_prompt=True)
+    steps = [
+        (
+            {"role": "assistant", "content": "Paris."},
+            {"role": "user", "content": "You are running low on budget."},
+        ),
+        (
+            {"role": "assistant", "content": "Understood."},
+            {"role": "user", "content": "Submit your final answer now."},
+        ),
+    ]
+    for assistant, user in steps:
+        convo += [assistant, user]
+        cur = renderer.render_ids(convo, add_generation_prompt=True)
+        assert cur[: len(prev)] == prev, (
+            f"{dt_model}: re-render after appending {assistant['content']!r} "
+            "diverged from the earlier generation prompt — historical turn "
+            "lost its prefilled empty think wrapper"
+        )
+        prev = cur
+
+
+def test_wrapper_reemitted_on_historical_turn(dt_model, dt_config):
+    """A historical assistant turn (before the last real user query, no
+    reasoning_content) renders with the exact empty wrapper bytes the
+    generation prompt prefilled."""
+    tok = _load(dt_model)
+    renderer = create_renderer(tok, dt_config)
+
+    rendered = renderer.render(
+        [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+            {"role": "user", "content": "Now 3+3?"},
+        ]
+    )
+    turn = [
+        t
+        for t, i in zip(rendered.token_ids, rendered.message_indices)
+        if i == 1
+    ]
+    text = tok.decode(turn)
+    assert _EMPTY_WRAPPER in text, (
+        f"{dt_model}: historical assistant turn rendered without the "
+        f"prefilled empty think wrapper: {text!r}"
+    )
+
+
+def test_bridge_and_rerender_agree(dt_model, dt_config):
+    """Extending a sampled turn via the bridge and re-rendering the same
+    conversation from messages must produce identical tokens — the property
+    whose violation shows up as token-level forks on byte-identical
+    trajectories."""
+    tok = _load(dt_model)
+    renderer = create_renderer(tok, dt_config)
+
+    msgs = [{"role": "user", "content": "What is the capital of France?"}]
+    prompt_ids = renderer.render_ids(msgs, add_generation_prompt=True)
+    # Simulate the sampled completion: content tokens then the stop token.
+    completion_ids = tok.encode("Paris.", add_special_tokens=False) + [
+        renderer.get_stop_token_ids()[0]
+    ]
+    reminder = {"role": "user", "content": "You are running low on budget."}
+
+    bridged = renderer.bridge_to_next_turn(prompt_ids, completion_ids, [reminder])
+    assert bridged is not None, (
+        f"{dt_model}: bridge refused with thinking disabled (implied "
+        "thinking_retention='all' should allow it)"
+    )
+
+    rerender = renderer.render_ids(
+        msgs + [{"role": "assistant", "content": "Paris."}, reminder],
+        add_generation_prompt=True,
+    )
+    assert bridged.token_ids == rerender, (
+        f"{dt_model}: bridge-extended tokens and full re-render disagree:\n"
+        f"bridge:   {tok.decode(bridged.token_ids)!r}\n"
+        f"rerender: {tok.decode(rerender)!r}"
+    )
+
+
+def test_tool_cycle_rerender_stays_prefix_stable(dt_model, dt_config):
+    """Tool-call turns (empty content, no reasoning) keep the prefilled
+    wrapper too. On qwen3 the template window additionally requires
+    ``is_last or reasoning_content``, so without the deviation a mid-cycle
+    re-render would strip the wrapper from the tool-call turn even though
+    it sits after the last real user query."""
+    tok = _load(dt_model)
+    renderer = create_renderer(tok, dt_config)
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get the current weather for a city",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+
+    msgs: list[dict] = [{"role": "user", "content": "Weather in Paris?"}]
+    prev = renderer.render_ids(msgs, tools=tools, add_generation_prompt=True)
+
+    msgs += [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "get_weather", "arguments": {"city": "Paris"}}}
+            ],
+        },
+        {"role": "tool", "content": '{"temp": 20}'},
+    ]
+    cur = renderer.render_ids(msgs, tools=tools, add_generation_prompt=True)
+    assert cur[: len(prev)] == prev, (
+        f"{dt_model}: tool-call turn lost its prefilled empty think wrapper "
+        "on re-render"
+    )
+
+    msgs += [
+        {"role": "assistant", "content": "It is 20 degrees."},
+        {"role": "user", "content": "You are running low on budget."},
+    ]
+    cur2 = renderer.render_ids(msgs, tools=tools, add_generation_prompt=True)
+    assert cur2[: len(cur)] == cur
+
+
+def test_historical_reasoning_stays_template_faithful(dt_model, dt_config):
+    """Scope guard: turns that carry ``reasoning_content`` were not sampled
+    under ``enable_thinking=False``, so they keep exact template parity —
+    the deviation fires only for the empty wrapper."""
+    tok = _load(dt_model)
+    renderer = create_renderer(tok, dt_config)
+
+    msgs = [
+        {"role": "user", "content": "What is 2+2?"},
+        {
+            "role": "assistant",
+            "reasoning_content": "Adding small ints.",
+            "content": "4",
+        },
+        {"role": "user", "content": "Now 3+3?"},
+        {
+            "role": "assistant",
+            "reasoning_content": "Same idea.",
+            "content": "6",
+        },
+    ]
+    ours = renderer.render_ids(msgs)
+    theirs = list(
+        tok.apply_chat_template(
+            msgs,
+            tokenize=True,
+            return_dict=False,
+            add_generation_prompt=False,
+            enable_thinking=False,
+        )
+    )
+    assert ours == theirs

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -445,10 +445,9 @@ def _skip_for_disabled_thinking_deviation(renderer, case_id) -> bool:
     ``test_disabled_thinking_stability.py``). Cases with an assistant turn
     before the last user query therefore diverge from the processor oracle
     by exactly those wrapper tokens; skip them for parity purposes."""
-    return (
-        getattr(renderer.config, "enable_thinking", True) is False
-        and case_id
-        in ("multi_turn_two_images", "multi_turn_tool_response_images")
+    return getattr(renderer.config, "enable_thinking", True) is False and case_id in (
+        "multi_turn_two_images",
+        "multi_turn_tool_response_images",
     )
 
 

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -437,6 +437,21 @@ def _build_tool_image_cases(make_part, image):
 # ---------------------------------------------------------------------------
 
 
+def _skip_for_disabled_thinking_deviation(renderer, case_id) -> bool:
+    """With ``enable_thinking=False`` (the resolved default on the small
+    Qwen3.5 sizes) the Qwen family re-emits the empty think wrapper on
+    historical assistant turns without reasoning — a documented deviation
+    from the template for sampled-token stability (see
+    ``test_disabled_thinking_stability.py``). Cases with an assistant turn
+    before the last user query therefore diverge from the processor oracle
+    by exactly those wrapper tokens; skip them for parity purposes."""
+    return (
+        getattr(renderer.config, "enable_thinking", True) is False
+        and case_id
+        in ("multi_turn_two_images", "multi_turn_tool_response_images")
+    )
+
+
 def _supports_tool_message_images(renderer) -> bool:
     """True iff this renderer emits image placeholders inside tool-response
     content. Renderers without the feature silently drop image parts in tool
@@ -466,6 +481,8 @@ def test_multimodal_byte_parity_vs_processor(mm_model_name, modality, tiny_image
 
     for case in _build_cases(kit["make_part"], tiny_image):
         messages, add_gp = case.values
+        if _skip_for_disabled_thinking_deviation(renderer, case.id):
+            continue
 
         # Ours.
         ours = renderer.render_ids(messages, add_generation_prompt=add_gp)
@@ -709,6 +726,8 @@ def test_tool_response_image_byte_parity(mm_model_name, modality, tiny_image):
 
     for case in _build_tool_image_cases(kit["make_part"], tiny_image):
         messages, add_gp = case.values
+        if _skip_for_disabled_thinking_deviation(renderer, case.id):
+            continue
         ours = renderer.render_ids(messages, add_generation_prompt=add_gp)
         theirs = kit["processor_input_ids"](processor, messages, add_gp)
         assert ours == theirs, (
@@ -796,6 +815,8 @@ def test_add_vision_id_parity_vs_processor(
 
     for case in _build_cases(kit["make_part"], tiny_image):
         messages, add_gp = case.values
+        if _skip_for_disabled_thinking_deviation(renderer, case.id):
+            continue
         ours = renderer.render_ids(messages, add_generation_prompt=add_gp)
         theirs = _qwen_vl_processor_input_ids_with_kwargs(
             processor, messages, add_gp, add_vision_id=add_vision_id

--- a/tests/test_prime_qwen3_parity.py
+++ b/tests/test_prime_qwen3_parity.py
@@ -194,3 +194,61 @@ def test_prime_qwen3_populates_assistant_masks(model):
         == len(rendered.is_content)
         == len(rendered.token_ids)
     )
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_prime_qwen3_empty_think_roundtrip(model):
+    """A sampled empty ``<think></think>`` block round-trips
+    parse → message → re-render byte-identically with the bridged sampled
+    stream. ``parse_qwen35`` used to collapse the empty-but-present block
+    to ``reasoning_content=None``; the renderer's key-presence check then
+    dropped the block on re-render, forking every later re-render of the
+    rollout (the template keeps reasoning on ALL historical turns, and
+    renders ``reasoning_content=""`` as ``<think></think>``)."""
+    tokenizer, renderer = _load(model)
+    stop = renderer.get_stop_token_ids()[0]
+
+    prompt = [{"role": "user", "content": "Reverse abc"}]
+    prompt_ids = renderer.render_ids(prompt, add_generation_prompt=True)
+    # Tokenize the sampled turn in context so the completion carries the
+    # exact BPE merges the model would produce continuing the stream.
+    sampled = "<think></think>\ncba"
+    full = tokenizer.encode(
+        tokenizer.decode(prompt_ids) + sampled, add_special_tokens=False
+    )
+    assert full[: len(prompt_ids)] == prompt_ids
+    completion_ids = full[len(prompt_ids) :] + [stop]
+
+    parsed = renderer.parse_response(completion_ids)
+    assert parsed.reasoning_content == ""  # present-but-empty, not None
+    assert parsed.content == "cba"
+
+    assistant = {"role": "assistant", "content": parsed.content}
+    if parsed.reasoning_content is not None:
+        assistant["reasoning_content"] = parsed.reasoning_content
+    reminder = {"role": "user", "content": "Now reverse def"}
+
+    bridged = renderer.bridge_to_next_turn(prompt_ids, completion_ids, [reminder])
+    assert bridged is not None
+    rerender = renderer.render_ids(
+        [*prompt, assistant, reminder], add_generation_prompt=True
+    )
+    assert bridged.token_ids == rerender, (
+        f"{model}: bridged sampled stream and re-render disagree:\n"
+        f"bridge:   {tokenizer.decode(bridged.token_ids)!r}\n"
+        f"rerender: {tokenizer.decode(rerender)!r}"
+    )
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_prime_qwen3_no_think_parses_to_none(model):
+    """Guard: a completion with no think block at all keeps
+    ``reasoning_content=None``, so the key stays absent from stored
+    messages and no ``<think></think>`` is invented on re-render."""
+    tokenizer, renderer = _load(model)
+    stop = renderer.get_stop_token_ids()[0]
+
+    completion_ids = tokenizer.encode("cba", add_special_tokens=False) + [stop]
+    parsed = renderer.parse_response(completion_ids)
+    assert parsed.reasoning_content is None
+    assert parsed.content == "cba"

--- a/tests/test_renderer_config_parity.py
+++ b/tests/test_renderer_config_parity.py
@@ -418,6 +418,31 @@ def test_chat_template_kwarg_parity_hf(
     # config subclass that drops the field.
     assert kwarg in type(renderer.config).template_field_names()
 
+    # Documented deviation: with ``enable_thinking=False`` the Qwen family
+    # re-emits the empty ``<think>\n\n</think>\n\n`` wrapper on historical
+    # assistant turns without reasoning_content, where the Jinja template
+    # strips it. The generation prompt prefills the wrapper, so stripping
+    # it on re-render would make the sampled stream and the re-render of
+    # the same conversation disagree at the token level. ``multi_turn`` is
+    # the only shape with such a turn — except on qwen3, whose template
+    # window additionally requires ``is_last or reasoning_content``, so its
+    # non-last tool-call turn in ``tool_cycle`` is stripped too. Stability
+    # is pinned in ``test_disabled_thinking_stability.py``.
+    resolved = _resolve_renderer_name(model, renderer_name)
+    deviating_shapes = (
+        ("multi_turn", "tool_cycle") if resolved == "qwen3" else ("multi_turn",)
+    )
+    if (
+        resolved in ("qwen3", "qwen3.5", "qwen3.6")
+        and kwarg == "enable_thinking"
+        and value is False
+        and shape_id in deviating_shapes
+    ):
+        pytest.skip(
+            "deliberate template deviation: empty think wrapper kept on "
+            "historical turns for sampled-token stability"
+        )
+
     try:
         expected = _expected_hf(
             tokenizer, messages, kwarg=kwarg, value=value, **render_kwargs


### PR DESCRIPTION
## Problem

With `enable_thinking=False` the generation prompt prefills the empty `<think>\n\n</think>\n\n` wrapper before sampling, so the wrapper is part of every sampled turn's token stream. But the Jinja template strips it from assistant turns at or before the last user query — so as soon as a later real user message arrives (budget reminder, prune reminder, force-submit message, …), re-rendering the conversation from messages produces different tokens than the model actually sampled. Same messages, different literal tokens, different hash at any token-comparison layer → spurious forks on byte-identical trajectories (the ~90% byte-identical-siblings pattern observed in rollout fork analysis).

The repo already treats `enable_thinking=False` as implying `thinking_retention="all"` (bridge across user-query boundaries is safe because nothing meaningful is dropped) — but the full-render path contradicted that by dropping the wrapper.

On Qwen3 specifically it is worse: its template window requires `is_last or reasoning_content`, so even the tool-call turn *inside the current tool cycle* loses the wrapper on re-render.

## Fix

When thinking is disabled, historical assistant turns without `reasoning_content` re-emit the exact gen-prompt wrapper instead of stripping it — in `qwen3.py` and `qwen35.py` (Qwen3.6 inherits the Qwen3.5 path). Turns that carry `reasoning_content` were not sampled under this config and stay template-faithful, so the deviation is scoped to exactly the tokens the model saw.

This is a **deliberate, documented deviation from `apply_chat_template`**, noted in the module/config docstrings. Parity tests carve out exactly the deviating cells:
- `test_renderer_config_parity.py`: `multi_turn` × `enable_thinking=False` for qwen3/qwen3.5/qwen3.6, plus `tool_cycle` for qwen3 only.
- `test_multimodal.py`: the two cases with pre-last-query assistant turns, on the small Qwen3.5 sizes whose polarity defaults to `False`.

## Survey of the other renderers

All 18 renderer modules were audited for the same pattern:
- **Token-stable already**: glm5/glm5.1 (lone `</think>` both paths), kimi_k2.5 (`<think></think>` both paths), hy3 (`no_think` wrapper both paths), nemotron3 (wrapper re-emitted unconditionally), laguna XS-2.1, gpt_oss (nothing prefilled), and deepseek_v3/r1, kimi_k2, llama_3, qwen3_vl, prime_qwen3, minimax_m2, default (no thinking-disabled prefill).
- **Adjacent mask-only quirk (not touched here)**: glm45 and laguna XS.2 emit the empty wrapper with `is_sampled=True` on re-render while the gen prompt marks it `is_sampled=False` — tokens are identical, only the attribution bit differs. Left out to keep this diff minimal; can follow up if we want the SFT masks exact.

## Tests

New `tests/test_disabled_thinking_stability.py` (15 cases across Qwen3-8B / Qwen3.5-9B / Qwen3.6-35B-A3B) pins:
- every generation prompt stays a token prefix of all later re-renders of the grown conversation (the rollout invariant whose violation was the fork);
- the wrapper is present in historical turns' token spans;
- `bridge_to_next_turn` output == full re-render for the same conversation;
- tool-cycle prefix stability (the qwen3-specific case);
- reasoning-bearing histories keep exact template parity (scope guard).

Verified the new tests fail 9/15 without the renderer fix. Full suite: **2583 passed, 127 skipped, 1 xfailed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes assistant rendering and parsing semantics for Qwen3 family rollouts with thinking disabled; impact is scoped to empty-wrapper turns and is heavily tested, but token output intentionally diverges from HF templates in those cases.
> 
> **Overview**
> Fixes **token-stream forks** when `enable_thinking=False`: the generation prompt prefills an empty `<think>\n\n</think>\n\n` wrapper, but Jinja would strip that wrapper from historical assistant turns once new user messages arrive. Re-renders then no longer match what the model sampled.
> 
> **Qwen3** and **Qwen3.5** (and **Qwen3.6** via inheritance) now **re-emit** that empty wrapper on historical assistant turns that lack `reasoning_content`, while turns with real reasoning stay template-faithful. This is an intentional, documented deviation from `apply_chat_template`.
> 
> **`parse_qwen35`** stops collapsing an empty-but-present think block to `reasoning_content=None`, so Prime Qwen3 parse → message → render round-trips (e.g. sampled `<think></think>`) stay byte-stable.
> 
> Adds **`test_disabled_thinking_stability.py`**, Prime Qwen3 empty-think round-trip tests, and parity/multimodal skips for the known deviation cells.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 633df7805542474d4595fb365a42eda261b8d018. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Qwen3/Qwen3.5 renderers to re-emit empty `<think>` wrapper on historical turns when thinking is disabled
> - When `enable_thinking=False`, historical assistant turns without `reasoning_content` now re-emit an empty `<think>\n\n</think>\n\n` wrapper in [qwen3.py](https://github.com/PrimeIntellect-ai/renderers/pull/105/files#diff-76dbf4052da7a3c71ea1931cc88a038f97e9430154bc884482961cd5a3ba8da9) and [qwen35.py](https://github.com/PrimeIntellect-ai/renderers/pull/105/files#diff-6ffae20154d6e887d44f7b667c5460ca3cf17b23fd5ed2768c0293580cd9f83a) to keep re-renders token-stable with the original sampled stream.
> - `parse_qwen35` in [parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/105/files#diff-4eba1ee111275cd49ea938c89bfbb7dafa7894d18a97c858fb4a9df401e85c75) now preserves `reasoning_content` as an empty string `""` (rather than `None`) when a `<think>` block is detected but contains no content.
> - New tests in [test_disabled_thinking_stability.py](https://github.com/PrimeIntellect-ai/renderers/pull/105/files#diff-bfd21b4a6f5074698337d78c98c73665ec12c66ae7268a67ba9f2a0fa78f26ec) assert prefix and round-trip token stability for Qwen3, Qwen3.5, and Qwen3.6 with `enable_thinking=False`.
> - Behavioral Change: multimodal parity tests and chat-template kwarg parity tests now skip specific multi-turn cases where the renderer intentionally deviates from the Jinja template output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 633df78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->