### PR TITLE
fix(client): reject malformed sampled-token evidence

### DIFF
--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -39,7 +39,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     trim_to_turn_close,
 )
-from renderers.client import OverlongPromptError
+from renderers.client import MalformedGenerateResponseError, OverlongPromptError
 from renderers.configs import (
     AutoRendererConfig,
     BaseRendererConfig,
@@ -152,6 +152,7 @@ __all__ = [
     "Llama3Renderer",
     "Llama3RendererConfig",
     "MULTIMODAL_MODELS",
+    "MalformedGenerateResponseError",
     "Message",
     "MiniMaxM2Renderer",
     "MiniMaxM2RendererConfig",

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -63,6 +63,10 @@ class OverlongPromptError(Exception):
         )
 
 
+class MalformedGenerateResponseError(ValueError):
+    """The generate endpoint returned unusable sampled-token evidence."""
+
+
 # Per-process cache of resolved engine context-length caps, keyed by
 # ``(base_url, model)``. ``None`` is the "we asked the engine and it didn't
 # tell us" sentinel — distinct from "key missing" (haven't asked yet). The
@@ -155,47 +159,57 @@ def parse_generate_response(raw: bytes) -> dict[str, Any]:
 
 
 def _parse_completion_logprobs(
-    choice: Mapping[str, Any], completion_token_count: int
+    choice: Mapping[str, Any], completion_ids: list[int]
 ) -> list[float]:
     raw_logprobs = choice.get("logprobs")
     if not isinstance(raw_logprobs, Mapping):
-        raise ValueError("Engine response choice.logprobs must be an object.")
+        raise MalformedGenerateResponseError(
+            "Engine response choice.logprobs must be an object."
+        )
 
     content = raw_logprobs.get("content")
     if not isinstance(content, list):
-        raise ValueError("Engine response choice.logprobs.content must be a list.")
-    if len(content) != completion_token_count:
-        raise ValueError(
+        raise MalformedGenerateResponseError(
+            "Engine response choice.logprobs.content must be a list."
+        )
+    if len(content) != len(completion_ids):
+        raise MalformedGenerateResponseError(
             "Engine response completion token count "
-            f"({completion_token_count}) does not match logprob count ({len(content)})."
+            f"({len(completion_ids)}) does not match logprob count ({len(content)})."
         )
 
     completion_logprobs: list[float] = []
     for index, entry in enumerate(content):
         if not isinstance(entry, Mapping):
-            raise ValueError(
+            raise MalformedGenerateResponseError(
                 f"Engine response choice.logprobs.content[{index}] must be an object."
+            )
+        expected_token = f"token_id:{completion_ids[index]}"
+        if entry.get("token") != expected_token:
+            raise MalformedGenerateResponseError(
+                "Engine response "
+                f"choice.logprobs.content[{index}].token must be {expected_token!r}."
             )
         raw_logprob = entry.get("logprob")
         if isinstance(raw_logprob, bool) or not isinstance(raw_logprob, (int, float)):
-            raise ValueError(
+            raise MalformedGenerateResponseError(
                 "Engine response "
                 f"choice.logprobs.content[{index}].logprob must be a number."
             )
         try:
             logprob = float(raw_logprob)
         except OverflowError as exc:
-            raise ValueError(
+            raise MalformedGenerateResponseError(
                 "Engine response "
                 f"choice.logprobs.content[{index}].logprob must be finite."
             ) from exc
         if not math.isfinite(logprob):
-            raise ValueError(
+            raise MalformedGenerateResponseError(
                 "Engine response "
                 f"choice.logprobs.content[{index}].logprob must be finite."
             )
         if logprob == VLLM_LOGPROB_SENTINEL:
-            raise ValueError(
+            raise MalformedGenerateResponseError(
                 "Engine response "
                 f"choice.logprobs.content[{index}].logprob does not contain "
                 "sampling evidence."
@@ -346,7 +360,7 @@ async def generate(
     choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
 
-    completion_logprobs = _parse_completion_logprobs(choice, len(completion_ids))
+    completion_logprobs = _parse_completion_logprobs(choice, completion_ids)
 
     parsed = await _maybe_offload(
         renderer, lambda: renderer.parse_response(completion_ids, tools=tools)

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 from collections.abc import Mapping
 from typing import Any, cast
 
@@ -33,6 +34,9 @@ from renderers.base import (
 _request_logger = logging.getLogger("renderers.client")
 ROUTED_EXPERTS_DATA_PREFIX = b'"routed_experts":{"data":"'
 KEPT_TOKENS_IDS_PREFIX = b'"kept_tokens":{"ids":"'
+# vLLM uses this value both when sampled-token evidence is missing and as a
+# lower-bound clamp, so receiving it cannot prove the real logprob was returned.
+VLLM_LOGPROB_SENTINEL = -9999.0
 
 
 class OverlongPromptError(Exception):
@@ -148,6 +152,56 @@ def parse_generate_response(raw: bytes) -> dict[str, Any]:
     if kept_ids_data is not None:
         payload["choices"][0]["kept_tokens"]["ids"] = kept_ids_data
     return payload
+
+
+def _parse_completion_logprobs(
+    choice: Mapping[str, Any], completion_token_count: int
+) -> list[float]:
+    raw_logprobs = choice.get("logprobs")
+    if not isinstance(raw_logprobs, Mapping):
+        raise ValueError("Engine response choice.logprobs must be an object.")
+
+    content = raw_logprobs.get("content")
+    if not isinstance(content, list):
+        raise ValueError("Engine response choice.logprobs.content must be a list.")
+    if len(content) != completion_token_count:
+        raise ValueError(
+            "Engine response completion token count "
+            f"({completion_token_count}) does not match logprob count ({len(content)})."
+        )
+
+    completion_logprobs: list[float] = []
+    for index, entry in enumerate(content):
+        if not isinstance(entry, Mapping):
+            raise ValueError(
+                f"Engine response choice.logprobs.content[{index}] must be an object."
+            )
+        raw_logprob = entry.get("logprob")
+        if isinstance(raw_logprob, bool) or not isinstance(raw_logprob, (int, float)):
+            raise ValueError(
+                "Engine response "
+                f"choice.logprobs.content[{index}].logprob must be a number."
+            )
+        try:
+            logprob = float(raw_logprob)
+        except OverflowError as exc:
+            raise ValueError(
+                "Engine response "
+                f"choice.logprobs.content[{index}].logprob must be finite."
+            ) from exc
+        if not math.isfinite(logprob):
+            raise ValueError(
+                "Engine response "
+                f"choice.logprobs.content[{index}].logprob must be finite."
+            )
+        if logprob == VLLM_LOGPROB_SENTINEL:
+            raise ValueError(
+                "Engine response "
+                f"choice.logprobs.content[{index}].logprob does not contain "
+                "sampling evidence."
+            )
+        completion_logprobs.append(logprob)
+    return completion_logprobs
 
 
 async def generate(
@@ -292,14 +346,11 @@ async def generate(
     choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
 
+    completion_logprobs = _parse_completion_logprobs(choice, len(completion_ids))
+
     parsed = await _maybe_offload(
         renderer, lambda: renderer.parse_response(completion_ids, tools=tools)
     )
-
-    # ChatCompletionLogProbs flatten: {"content": [{"logprob": ...}, ...]}
-    raw_logprobs = choice.get("logprobs") or {}
-    content_lp = raw_logprobs.get("content") if isinstance(raw_logprobs, dict) else None
-    completion_logprobs = [float(c.get("logprob") or 0.0) for c in content_lp or []]
 
     routed_experts = choice.get("routed_experts")
     kept_tokens = choice.get("kept_tokens")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -67,38 +67,47 @@ class _FakeClient:
     def __init__(self):
         self.calls = []
         self.base_url = "http://fake-host:8000/v1"
+        routed_experts = np.array([[[1]], [[2]]], dtype=np.uint8)
+        self.choice = {
+            "index": 0,
+            "token_ids": [7, 8],
+            "logprobs": {
+                "content": [
+                    {"token": "token_id:7", "logprob": -0.1},
+                    {"token": "token_id:8", "logprob": -0.2},
+                ]
+            },
+            "finish_reason": "stop",
+            "routed_experts": {
+                "data": base64.b64encode(routed_experts.tobytes()).decode("ascii"),
+                "shape": list(routed_experts.shape),
+            },
+        }
 
     async def post(self, path, *, cast_to=dict, body=None, options=None):
         self.calls.append(
             {"path": path, "cast_to": cast_to, "body": body, "options": options}
         )
-        routed_experts = np.array([[[1]], [[2]]], dtype=np.uint8)
         payload = {
             "request_id": "gen-test",
-            "choices": [
-                {
-                    "index": 0,
-                    "token_ids": [7, 8],
-                    "logprobs": {
-                        "content": [
-                            {"token": "token_id:7", "logprob": -0.1},
-                            {"token": "token_id:8", "logprob": -0.2},
-                        ]
-                    },
-                    "finish_reason": "stop",
-                    "routed_experts": {
-                        "data": base64.b64encode(routed_experts.tobytes()).decode(
-                            "ascii"
-                        ),
-                        "shape": list(routed_experts.shape),
-                    },
-                }
-            ],
+            "choices": [self.choice],
         }
         return httpx.Response(
             200,
             content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
         )
+
+
+def _run_generate(client, renderer=None):
+    return asyncio.run(
+        generate(
+            client=client,
+            renderer=renderer or _FakeRenderer(),
+            messages=[{"role": "user", "content": "hi"}],
+            model="test-model",
+            tools=[{"type": "function", "function": {"name": "echo"}}],
+        )
+    )
 
 
 def test_generate_builds_request_body_and_parses_response():
@@ -170,6 +179,67 @@ def test_generate_builds_request_body_and_parses_response():
     assert tc.name == "echo"
     assert tc.arguments == {"text": "hello"}
     assert tc.status == ToolCallParseStatus.OK
+
+
+def test_generate_rejects_missing_completion_logprobs_before_parsing():
+    client = _FakeClient()
+    client.choice.pop("logprobs")
+    renderer = _FakeRenderer()
+
+    with pytest.raises(ValueError, match=r"choice\.logprobs must be an object"):
+        _run_generate(client, renderer)
+
+    assert not hasattr(renderer, "_last_parse_tools")
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [{}, {"logprob": None}, {"logprob": "-0.1"}, {"logprob": True}],
+    ids=["missing", "null", "string", "boolean"],
+)
+def test_generate_rejects_non_numeric_completion_logprobs(entry):
+    client = _FakeClient()
+    client.choice["logprobs"]["content"][0] = entry
+
+    with pytest.raises(ValueError, match=r"content\[0\]\.logprob must be a number"):
+        _run_generate(client)
+
+
+def test_generate_rejects_completion_logprob_count_mismatch():
+    client = _FakeClient()
+    client.choice["logprobs"]["content"] = [{"token": "token_id:7", "logprob": -0.1}]
+
+    with pytest.raises(
+        ValueError,
+        match=r"completion token count \(2\) does not match logprob count \(1\)",
+    ):
+        _run_generate(client)
+
+
+@pytest.mark.parametrize("logprob", [float("nan"), float("inf"), float("-inf")])
+def test_generate_rejects_non_finite_completion_logprobs(logprob):
+    client = _FakeClient()
+    client.choice["logprobs"]["content"][0]["logprob"] = logprob
+
+    with pytest.raises(ValueError, match=r"content\[0\]\.logprob must be finite"):
+        _run_generate(client)
+
+
+def test_generate_rejects_vllm_missing_logprob_sentinel():
+    client = _FakeClient()
+    client.choice["logprobs"]["content"][0]["logprob"] = -9999.0
+
+    with pytest.raises(ValueError, match=r"does not contain sampling evidence"):
+        _run_generate(client)
+
+
+def test_generate_preserves_zero_completion_logprob():
+    client = _FakeClient()
+    client.choice["logprobs"]["content"][0]["logprob"] = 0.0
+
+    result = _run_generate(client)
+
+    assert result["completion_logprobs"] == [0.0, -0.2]
 
 
 class _MalformedToolRenderer(_FakeRenderer):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ import json
 import httpx
 import numpy as np
 import pytest
+from renderers import MalformedGenerateResponseError
 from renderers.base import (
     ParsedResponse,
     ParsedToolCall,
@@ -186,7 +187,10 @@ def test_generate_rejects_missing_completion_logprobs_before_parsing():
     client.choice.pop("logprobs")
     renderer = _FakeRenderer()
 
-    with pytest.raises(ValueError, match=r"choice\.logprobs must be an object"):
+    with pytest.raises(
+        MalformedGenerateResponseError,
+        match=r"choice\.logprobs must be an object",
+    ):
         _run_generate(client, renderer)
 
     assert not hasattr(renderer, "_last_parse_tools")
@@ -194,14 +198,22 @@ def test_generate_rejects_missing_completion_logprobs_before_parsing():
 
 @pytest.mark.parametrize(
     "entry",
-    [{}, {"logprob": None}, {"logprob": "-0.1"}, {"logprob": True}],
+    [
+        {"token": "token_id:7"},
+        {"token": "token_id:7", "logprob": None},
+        {"token": "token_id:7", "logprob": "-0.1"},
+        {"token": "token_id:7", "logprob": True},
+    ],
     ids=["missing", "null", "string", "boolean"],
 )
 def test_generate_rejects_non_numeric_completion_logprobs(entry):
     client = _FakeClient()
     client.choice["logprobs"]["content"][0] = entry
 
-    with pytest.raises(ValueError, match=r"content\[0\]\.logprob must be a number"):
+    with pytest.raises(
+        MalformedGenerateResponseError,
+        match=r"content\[0\]\.logprob must be a number",
+    ):
         _run_generate(client)
 
 
@@ -210,7 +222,7 @@ def test_generate_rejects_completion_logprob_count_mismatch():
     client.choice["logprobs"]["content"] = [{"token": "token_id:7", "logprob": -0.1}]
 
     with pytest.raises(
-        ValueError,
+        MalformedGenerateResponseError,
         match=r"completion token count \(2\) does not match logprob count \(1\)",
     ):
         _run_generate(client)
@@ -221,7 +233,10 @@ def test_generate_rejects_non_finite_completion_logprobs(logprob):
     client = _FakeClient()
     client.choice["logprobs"]["content"][0]["logprob"] = logprob
 
-    with pytest.raises(ValueError, match=r"content\[0\]\.logprob must be finite"):
+    with pytest.raises(
+        MalformedGenerateResponseError,
+        match=r"content\[0\]\.logprob must be finite",
+    ):
         _run_generate(client)
 
 
@@ -229,7 +244,21 @@ def test_generate_rejects_vllm_missing_logprob_sentinel():
     client = _FakeClient()
     client.choice["logprobs"]["content"][0]["logprob"] = -9999.0
 
-    with pytest.raises(ValueError, match=r"does not contain sampling evidence"):
+    with pytest.raises(
+        MalformedGenerateResponseError,
+        match=r"does not contain sampling evidence",
+    ):
+        _run_generate(client)
+
+
+def test_generate_rejects_logprob_token_id_mismatch():
+    client = _FakeClient()
+    client.choice["logprobs"]["content"][0]["token"] = "token_id:8"
+
+    with pytest.raises(
+        MalformedGenerateResponseError,
+        match=r"content\[0\]\.token must be 'token_id:7'",
+    ):
         _run_generate(client)
 
 


### PR DESCRIPTION
## Summary

- validate `/inference/v1/generate` sampled-token evidence before renderer parsing
- require exactly one logprob entry for each completion token, identified as that exact `token_id:<id>`
- reject missing, malformed, Boolean, non-numeric, non-finite, or ambiguous `-9999.0` evidence
- expose `MalformedGenerateResponseError` so callers can distinguish an unusable provider response from other failures

## Why

The generate response contains parallel `token_ids` and `logprobs.content` fields. Matching their lengths alone does not prove that a logprob belongs to the sampled token at that position.

The vLLM endpoint [labels each entry with `token_id:<id>`](https://github.com/vllm-project/vllm/blob/b23bd73f540175f9e117eaee5029cd7d8df63964/vllm/entrypoints/scale_out/token_in_token_out/serving.py#L478-L497). It also uses `-9999.0` both as the [default when evidence is absent](https://github.com/vllm-project/vllm/blob/b23bd73f540175f9e117eaee5029cd7d8df63964/vllm/entrypoints/openai/chat_completion/protocol.py#L75-L78) and as a [lower-bound clamp](https://github.com/vllm-project/vllm/blob/b23bd73f540175f9e117eaee5029cd7d8df63964/vllm/entrypoints/scale_out/token_in_token_out/serving.py#L481-L497). That value therefore cannot prove the original sampled-token logprob and must fail closed.

Validation belongs before renderer parsing because this is a provider wire-contract invariant. Downstream rollout and training code should not receive incomplete or misbound sampling evidence as a successful generation.

## Compatibility

Malformed responses now raise `MalformedGenerateResponseError`, a `ValueError` subclass. This intentionally tightens behavior while retaining compatibility with callers that already handle `ValueError`. The exported subtype lets downstream clients map this provider failure explicitly.

## Verification

- `uv run pytest tests/test_client.py -q` — 20 passed, 2 skipped
- `uv run ruff check renderers/client.py renderers/__init__.py tests/test_client.py`
- `uv run ruff format --check renderers/client.py renderers/__init__.py tests/test_client.py`
- hosted checks on Python 3.10–3.13, Ty, and Ruff pass on the identical head

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rollout/training paths that relied on silently accepting bad or placeholder logprobs will now error at generation time, which is intentional but can surface more provider failures.
> 
> **Overview**
> **Tightens how completion logprobs are read** from `/inference/v1/generate` responses. Instead of coercing missing `logprobs` to `0.0`, the client runs **`_parse_completion_logprobs`** before `renderer.parse_response`.
> 
> Validation requires one `choice.logprobs.content` entry per completion token, each labeled **`token_id:<id>`** matching that position’s sampled id, with a finite numeric `logprob`. It **rejects vLLM’s `-9999.0` sentinel** when it indicates missing sampling evidence. Failures raise the new exported **`MalformedGenerateResponseError`** (`ValueError` subclass).
> 
> Tests cover malformed/missing logprobs, count and token-id mismatches, non-finite values, and that invalid responses fail **before** renderer parsing; valid **`0.0`** logprobs still pass through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ce506d84f0e6945dbd7aa53725494f930d53f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject malformed sampled-token evidence in `generate` with `MalformedGenerateResponseError`
> - Adds `MalformedGenerateResponseError` (a `ValueError` subclass) to [`renderers/client.py`](https://github.com/PrimeIntellect-ai/renderers/pull/108/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) and exports it from the `renderers` package.
> - Introduces `_parse_completion_logprobs` to strictly validate per-token logprobs: checks structural alignment with `token_ids`, rejects non-numeric/non-finite values, and rejects the vLLM missing-evidence sentinel (`-9999.0`).
> - `generate()` now calls `_parse_completion_logprobs` instead of loosely extracting logprobs, raising `MalformedGenerateResponseError` on any validation failure while preserving exact zero values.
> - Behavioral Change: callers that previously received defaulted/coerced logprob values will now get an exception when the engine response is malformed or missing sampling evidence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ce506.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->