### PR TITLE
ci(style): pin ruff-action to 0.15.12

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,9 +15,17 @@ jobs:
         uses: actions/checkout@v4
       - name: Lint
         uses: astral-sh/ruff-action@v3
+        with:
+          # Pin the ruff version so CI matches what contributors resolve
+          # locally. ruff-action defaults to the latest release, which drifts
+          # (e.g. 0.16.0 enabled stricter rules that flag pre-existing code)
+          # and turns green PRs red without any code change. Bump this
+          # deliberately alongside any lint fixes.
+          version: "0.15.12"
       - name: Format
         uses: astral-sh/ruff-action@v3
         with:
+          version: "0.15.12"
           args: "format --check"
   ty:
     name: Ty


### PR DESCRIPTION
## Summary

Pins `astral-sh/ruff-action@v3` to **ruff 0.15.12** in both the lint and format steps of `style.yml`.

## Why

`ruff-action` installs the *latest* ruff release by default. ruff **0.16.0** (released after 2026‑07‑21) enabled stricter default rules that flag **~98 pre-existing issues** across the repo (`examples/`, `renderers/__init__.py`, `renderers/base.py`, …). This turned green PRs red **without any code change** — e.g. the Laguna‑S‑2.1 routing PR (#111), whose 3-line diff introduced none of the reported errors.

- Against **0.16.0**: 98 errors, identical on `main` and on feature branches.
- Against **0.15.12** (what `uv` resolves locally): `All checks passed!`, format clean.

Pinning stops the silent drift so CI reflects the version the repo is actually maintained against. Adopting a newer ruff (and applying its fixes) can then be a deliberate, self-contained change — bump this pin alongside those fixes.

## Testing

- `uvx ruff@0.15.12 check` → All checks passed
- `uvx ruff@0.15.12 format --check` → 61 files already formatted
- YAML validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change; no application code, auth, or runtime behavior affected.
> 
> **Overview**
> **Pins Ruff to 0.15.12** in the Style workflow so lint and format jobs no longer pull the latest release by default.
> 
> Both the **Lint** and **Format** `astral-sh/ruff-action@v3` steps now set `version: "0.15.12"`, with comments explaining that unpinned CI was drifting (e.g. 0.16.0 stricter rules) and failing PRs without code changes. Future Ruff upgrades are meant to be intentional: bump this pin together with any lint fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0cea59b46caaf237681c1ba763a1e02195ed92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pin ruff-action to version 0.15.12 in CI style workflow
> Pins both the Ruff Lint and Ruff Format steps in [style.yml](.github/workflows/style.yml) to version `0.15.12` instead of the action's default latest release, preventing unexpected failures from automatic Ruff upgrades.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7c0cea5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->