### PR TITLE
fix: validate GLM tool names against the provided tools list

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -558,8 +558,15 @@ class ToolCallParseStatus(str, enum.Enum):
     """Per-attempt outcome of parsing a single ``<tool_call>`` block.
 
     The renderer parser's job is JSON-syntax → ``dict`` (the parser-level
-    contract). Schema validation — required fields, argument types, tool
-    name lookup — is the *tool*'s job and is intentionally not done here.
+    contract). Schema validation — required fields, argument types — is
+    the *tool*'s job and is intentionally not done here. Tool-*name*
+    lookup is the one exception, and only where the reference inference
+    parser does it: vLLM ≥ 0.24 aliases ``glm45``/``glm47`` to a parser
+    with ``validate_tool_names=True`` that silently drops any call whose
+    name isn't in the request's tool list. ``parse_glm`` mirrors that as
+    ``UNKNOWN_TOOL`` (when ``tools`` is passed) so train-side parsing
+    agrees with what an eval client sees from the engine — but keeps the
+    attempt visible instead of swallowing it.
     See ``ParsedToolCall.status`` for what each value means.
 
     Diverges from vLLM/SGLang on purpose. Both engines collapse parse
@@ -576,6 +583,7 @@ class ToolCallParseStatus(str, enum.Enum):
     UNCLOSED_BLOCK = "unclosed_block"  # opening delim hit EOS / stop
     MISSING_NAME = "missing_name"  # parsed structurally, but no function name
     MALFORMED_STRUCTURE = "malformed_structure"  # format-specific shape error
+    UNKNOWN_TOOL = "unknown_tool"  # name not in the provided tools list
 
 
 @dataclass

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -59,6 +59,26 @@ def _build_param_type_index(
     return index
 
 
+def _extract_tool_names(tools: list[ToolSpec] | None) -> set[str] | None:
+    """Set of declared tool names, or ``None`` when ``tools`` is empty.
+
+    ``None`` disables name validation — mirroring vLLM's
+    ``ParserEngine._is_valid_tool_name``, which returns ``True`` whenever
+    the request carries no tools. Accepts both flat ``ToolSpec`` and the
+    OpenAI ``{"type": "function", "function": {...}}`` envelope, like
+    ``_build_param_type_index`` (but independent of it: a tool with no
+    ``parameters.properties`` still counts as a known name).
+    """
+    if not tools:
+        return None
+    names: set[str] = set()
+    for tool in tools:
+        spec = tool.get("function", tool) if isinstance(tool, dict) else None
+        if isinstance(spec, dict) and isinstance(spec.get("name"), str):
+            names.add(spec["name"])
+    return names
+
+
 def _coerce_arg_value(
     text: str, param_schema: dict[str, Any] | None
 ) -> tuple[Any, bool]:
@@ -434,7 +454,23 @@ def parse_glm(
     arg_value_end_id: int,
     tools: list[ToolSpec] | None = None,
 ) -> ParsedResponse:
-    """Parse GLM completion tokens. Token-level thinking + arg_key/arg_value tool calls."""
+    """Parse GLM completion tokens. Token-level thinking + arg_key/arg_value tool calls.
+
+    When ``tools`` is passed, tool names are validated against it: a call
+    whose name isn't declared gets ``status=UNKNOWN_TOOL`` instead of
+    ``OK``. This mirrors vLLM ≥ 0.24, where the ``glm45``/``glm47`` tool
+    parsers run with ``validate_tool_names=True`` and silently drop
+    unknown-name calls (``vllm/parser/glm47_moe.py``,
+    ``ParserEngine._is_valid_tool_name``) — so a completion that yields no
+    tool call from the engine also yields no ``OK`` call here, and
+    downstream finish-reason promotion (``renderers/client.py``) agrees
+    with an OpenAI chat-completions client talking to the same engine.
+    Notably this covers the missing-``<arg_key>`` shape
+    (``<tool_call>bash\\n<arg_value>...</arg_value></tool_call>``): both
+    this parser and vLLM's resolve the whole block as the name, which then
+    fails validation. Without ``tools``, no validation happens (vLLM
+    behaves the same when the request carries no tools).
+    """
     ids = _strip_stop_tokens(token_ids, stop_ids)
 
     reasoning = None
@@ -468,6 +504,7 @@ def parse_glm(
             arg_value_end_id,
             section_offset=parse_offset + tc_start,
             param_index=_build_param_type_index(tools),
+            known_names=_extract_tool_names(tools),
         )
     else:
         content_text = _decode(tokenizer, ids).strip()
@@ -491,6 +528,7 @@ def _parse_glm_tool_calls(
     *,
     section_offset: int,
     param_index: dict[str, dict[str, dict[str, Any]]],
+    known_names: set[str] | None = None,
 ) -> list[ParsedToolCall]:
     """Parse GLM-style tool calls: name + arg_key/arg_value pairs, all by token ID."""
     tool_calls: list[ParsedToolCall] = []
@@ -548,6 +586,11 @@ def _parse_glm_tool_calls(
                         j += 1
             if not name:
                 status = ToolCallParseStatus.MISSING_NAME
+            elif known_names is not None and name not in known_names:
+                # vLLM ≥ 0.24 drops the call entirely here; we keep the
+                # attempt visible but deny it OK so consumers agree with
+                # the engine on "no tool was called."
+                status = ToolCallParseStatus.UNKNOWN_TOOL
             elif structure_broke:
                 status = ToolCallParseStatus.MALFORMED_STRUCTURE
             elif any_json_fallback:

--- a/tests/test_glm_tool_name_validation.py
+++ b/tests/test_glm_tool_name_validation.py
@@ -1,0 +1,183 @@
+"""GLM tool-name validation against the provided tools list.
+
+vLLM 0.24 re-aliased ``glm45`` from the lenient ``Glm4MoeModelToolParser``
+to ``Glm47MoeModelToolParser``, whose engine config sets
+``validate_tool_names=True`` (``vllm/parser/glm47_moe.py``): a completed
+``<tool_call>`` block whose name isn't in the request's tool list is
+silently dropped — no tool call is emitted and the response reads as a
+voluntary stop. Before this, unknown-name calls were surfaced to the
+harness, which answered with a recoverable "unknown tool" error.
+
+``parse_glm`` mirrors the ≥ 0.24 behavior when ``tools`` is passed:
+unknown names get ``status=UNKNOWN_TOOL`` — never ``OK`` — so the
+client-side stop→tool_calls finish-reason promotion
+(``renderers/client.py``) agrees with what an OpenAI chat-completions
+client sees from the engine, while the attempt itself stays visible for
+verifier / RL-loss code. Without ``tools`` there is no validation, also
+matching vLLM (``ParserEngine._is_valid_tool_name`` returns ``True``
+when the request has no tools).
+
+Cross-validated end-to-end against the real vLLM v0.23.0 and v0.24.0
+parsers (vendored from the release tags) on identical completions.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from renderers.base import ToolCallParseStatus
+
+# Both GLM renderers share ``parse_glm`` and are served by the same
+# strict vLLM parser (the ``glm45`` and ``glm47`` aliases both resolve
+# to ``Glm47MoeModelToolParser`` in vLLM ≥ 0.24).
+_MODELS = [
+    ("THUDM/GLM-4.5-Air", "auto"),
+    ("zai-org/GLM-5", "auto"),
+]
+
+_TOOLS = [
+    {
+        "name": "bash",
+        "description": "Run a shell command.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string"},
+                "timeout": {"type": "integer"},
+            },
+            "required": ["command"],
+        },
+    },
+    # A declared tool with no parameters must still count as a known
+    # name (name lookup is independent of the param-type index).
+    {"name": "submit", "description": "Finish the episode."},
+]
+
+
+@lru_cache(maxsize=None)
+def _load(model: str, renderer_name: str):
+    from renderers import config_from_name, create_renderer
+    from renderers.base import load_tokenizer
+
+    tok = load_tokenizer(model)
+    return tok, create_renderer(tok, config_from_name(renderer_name))
+
+
+def pytest_generate_tests(metafunc):
+    if "model" in metafunc.fixturenames:
+        metafunc.parametrize(
+            "model,renderer_name",
+            _MODELS,
+            ids=[m for m, _ in _MODELS],
+        )
+
+
+def _parse(model: str, renderer_name: str, text: str, tools):
+    tok, renderer = _load(model, renderer_name)
+    ids = tok.encode(text, add_special_tokens=False)
+    return renderer.parse_response(ids, tools=tools)
+
+
+def _statuses(parsed):
+    return [tc.status for tc in parsed.tool_calls]
+
+
+def test_known_name_is_ok(model, renderer_name):
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>bash\n"
+        "<arg_key>command</arg_key>\n<arg_value>pwd</arg_value>\n"
+        "</tool_call>",
+        _TOOLS,
+    )
+    assert _statuses(parsed) == [ToolCallParseStatus.OK]
+    assert parsed.tool_calls[0].name == "bash"
+    assert parsed.tool_calls[0].arguments == {"command": "pwd"}
+
+
+def test_known_name_without_parameters_is_ok(model, renderer_name):
+    parsed = _parse(model, renderer_name, "<tool_call>submit\n</tool_call>", _TOOLS)
+    assert _statuses(parsed) == [ToolCallParseStatus.OK]
+    assert parsed.tool_calls[0].name == "submit"
+
+
+def test_unknown_name_is_flagged(model, renderer_name):
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>read\n"
+        "<arg_key>lines</arg_key>\n<arg_value>10</arg_value>\n"
+        "</tool_call>",
+        _TOOLS,
+    )
+    assert _statuses(parsed) == [ToolCallParseStatus.UNKNOWN_TOOL]
+    # The attempt stays visible (unlike vLLM's silent drop): name and
+    # parsed arguments are preserved for verifier / RL-loss consumers.
+    assert parsed.tool_calls[0].name == "read"
+    assert parsed.tool_calls[0].arguments == {"lines": 10}
+
+
+def test_unknown_name_without_args_is_flagged(model, renderer_name):
+    parsed = _parse(model, renderer_name, "<tool_call>finish\n</tool_call>", _TOOLS)
+    assert _statuses(parsed) == [ToolCallParseStatus.UNKNOWN_TOOL]
+
+
+def test_missing_arg_key_block_is_flagged(model, renderer_name):
+    # No <arg_key> token ⇒ the whole block resolves as the name — both
+    # here and in vLLM's engine (unmatched terminals in TOOL_NAME state
+    # accumulate into the name) — and then fails validation.
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>bash\n<arg_value>pwd</arg_value>\n</tool_call>",
+        _TOOLS,
+    )
+    assert _statuses(parsed) == [ToolCallParseStatus.UNKNOWN_TOOL]
+    assert "bash" in (parsed.tool_calls[0].name or "")
+
+
+def test_mixed_calls_flag_only_unknown(model, renderer_name):
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>bash\n"
+        "<arg_key>command</arg_key>\n<arg_value>ls</arg_value>\n"
+        "</tool_call>"
+        "<tool_call>read\n"
+        "<arg_key>path</arg_key>\n<arg_value>x</arg_value>\n"
+        "</tool_call>",
+        _TOOLS,
+    )
+    assert _statuses(parsed) == [
+        ToolCallParseStatus.OK,
+        ToolCallParseStatus.UNKNOWN_TOOL,
+    ]
+
+
+def test_no_tools_means_no_validation(model, renderer_name):
+    # vLLM skips name validation when the request carries no tools; so
+    # do we — this also keeps tools-less parse_response calls (the
+    # common test / SFT path) byte-for-byte backward compatible.
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>read\n"
+        "<arg_key>lines</arg_key>\n<arg_value>10</arg_value>\n"
+        "</tool_call>",
+        None,
+    )
+    assert _statuses(parsed) == [ToolCallParseStatus.OK]
+
+
+def test_openai_envelope_tools_are_recognized(model, renderer_name):
+    wrapped = [{"type": "function", "function": t} for t in _TOOLS]
+    parsed = _parse(
+        model,
+        renderer_name,
+        "<tool_call>bash\n"
+        "<arg_key>command</arg_key>\n<arg_value>pwd</arg_value>\n"
+        "</tool_call>",
+        wrapped,
+    )
+    assert _statuses(parsed) == [ToolCallParseStatus.OK]


### PR DESCRIPTION
## Summary

- vLLM 0.24 re-aliased the `glm45` tool parser from the lenient `Glm4MoeModelToolParser` to `Glm47MoeModelToolParser`, whose engine runs with `validate_tool_names=True` (`vllm/parser/glm47_moe.py:171`): a completed `<tool_call>` block whose name isn't in the request's tool list is silently dropped — no tool call is emitted, `tools_called=False`, and the response reads as a voluntary stop. `parse_glm` stayed lenient, so train-side parsing (renderer client) disagreed with what an OpenAI chat-completions eval client sees from the same engine.
- `parse_glm` now mirrors the ≥ 0.24 semantics when `tools` is passed: a parsed call whose name isn't declared gets the new `ToolCallParseStatus.UNKNOWN_TOOL` instead of `OK`. The attempt stays visible on `parsed.tool_calls` (unlike vLLM's silent drop) for verifier / RL-loss consumers, but the client-side `stop→tool_calls` finish-reason promotion (`renderers/client.py`) no longer fires — so both sides agree on "no tool was called". This also covers the missing-`<arg_key>` shape (`<tool_call>bash\n<arg_value>…</arg_value></tool_call>`): both parsers resolve the whole block as the name, which then fails validation.
- Without `tools`, no validation happens — matching vLLM (`ParserEngine._is_valid_tool_name` returns `True` on tool-less requests) and keeping all existing tools-less `parse_response` callers untouched.
- Applies to both `GLM45Renderer` and `GLM5Renderer` (shared `parse_glm`; vLLM's `glm45` and `glm47` aliases both resolve to the strict parser in ≥ 0.24).
- New `tests/test_glm_tool_name_validation.py` pins the semantics for GLM-4.5-Air and GLM-5.

## Verification

Cross-validated end-to-end against the **real** vLLM `v0.23.0` and `v0.24.0` parser sources (vendored from the release tags, serving-layer imports stubbed) on identical completions — token ids to the renderer, decoded text to vLLM, as in production. Comparison is at the harness-visible level: dispatched `(name, args)` pairs plus whether the episode continues (`finish_reason == "tool_calls"`).

Before (renderer tracks 0.23, diverges from 0.24):

```
case                    vllm-0.23                       vllm-0.24   renderer (OK calls)
valid_call              bash{command,timeout}  continue  same        same                            MATCH
unknown_tool_name       read{path}             continue  dropped     no OK call                      MATCH
missing_arg_key         bash{}                 continue  dropped     OK "bash\n<arg_value>pwd..."    DIVERGE
unknown_tool_json_args  read{lines:10}         continue  dropped     OK read{lines:10}               DIVERGE
unknown_tool_no_args    submit{}               continue  dropped     OK submit{}                     DIVERGE
plain_stop              —                      stop      stop        stop                            MATCH
```

After: all six cases MATCH vLLM 0.24 (unknown-name attempts surface as `unknown_tool`, valid calls still parse with schema coercion, plain stops unchanged).

Full suite: 2573 passed, 169 skipped, 1 xfailed. ruff + ty clean.

## Breaking

- `parse_glm` / `GLM45Renderer.parse_response` / `GLM5Renderer.parse_response`: when `tools` is passed, calls naming an undeclared tool now return `status=UNKNOWN_TOOL` instead of `OK`. Downstream OK-filters (including the renderer client's finish-reason promotion) stop treating them as tool turns — this is the intended parity with vLLM ≥ 0.24. Migration: callers that want the old lenient behavior can omit `tools` at parse time or additionally accept `UNKNOWN_TOOL` when filtering.
- `ToolCallParseStatus` gains a member (`UNKNOWN_TOOL = "unknown_tool"`); exhaustive matches over the enum need a new arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior change when `parse_response(..., tools=...)` is used: undeclared names no longer count as OK, affecting finish-reason promotion and any exhaustive `ToolCallParseStatus` matches; tools-less parsing is unchanged.
> 
> **Overview**
> Aligns **GLM** train-side parsing with **vLLM ≥ 0.24**, where undeclared tool names are no longer treated as successful calls.
> 
> Adds **`ToolCallParseStatus.UNKNOWN_TOOL`** and **`_extract_tool_names`** so `parse_glm` (GLM-4.5 / GLM-5) checks function names against the passed **`tools`** list when it is non-empty. Unknown names get **`UNKNOWN_TOOL`** instead of **`OK`**, so **`renderers/client.py`** stop→`tool_calls` finish-reason promotion matches an OpenAI client on the same engine, while the parse attempt stays on **`parsed.tool_calls`** for verifiers/RL. **No `tools`** ⇒ no validation (unchanged). OpenAI **`function`** envelopes and parameter-less tools count as known names.
> 
> New **`tests/test_glm_tool_name_validation.py`** covers known/unknown/mixed calls, missing-`<arg_key>` shapes, and tools-less backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6629992aa352877f1bc453957b99dd39007c0f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Validate GLM tool call names against the provided tools list
> - Adds `UNKNOWN_TOOL` to the `ToolCallParseStatus` enum in [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/114/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) to represent parsed calls whose name is not in the declared tools list.
> - Introduces `_extract_tool_names` helper in [renderers/parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/114/files#diff-4eba1ee111275cd49ea938c89bfbb7dafa7894d18a97c858fb4a9df401e85c75) to derive the set of valid tool names from the tools list, supporting both flat `ToolSpec` dicts and OpenAI-style `{'type': 'function', 'function': {...}}` envelopes.
> - When a tools list is provided, `_parse_glm_tool_calls` now assigns `status=UNKNOWN_TOOL` (instead of `OK`) for calls whose names are not declared; name and arguments are still populated. When no tools list is provided, behavior is unchanged.
> - Behavioral Change: callers that check `ParsedToolCall.status` will now see `UNKNOWN_TOOL` for unrecognized tool names when a tools list is passed to the GLM parser.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6629992.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->