### PR TITLE
fix(client): update vLLM 0.26 token-serving import

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -1,4 +1,4 @@
-"""Renderer-based generate client for vLLM 0.20's /inference/v1/generate.
+"""Renderer-based generate client for vLLM's /inference/v1/generate.
 
     messages → Renderer.render_ids() → token IDs → POST /inference/v1/generate
     → completion tokens → Renderer.parse_response() → structured message
@@ -58,8 +58,7 @@ class OverlongPromptError(Exception):
         self.prompt_len = prompt_len
         self.max_prompt_len = max_prompt_len
         super().__init__(
-            f"Prompt length ({prompt_len}) exceeds maximum "
-            f"context length ({max_prompt_len})."
+            f"Prompt length ({prompt_len}) exceeds maximum context length ({max_prompt_len})."
         )
 
 
@@ -187,32 +186,26 @@ def _parse_completion_logprobs(
         expected_token = f"token_id:{completion_ids[index]}"
         if entry.get("token") != expected_token:
             raise MalformedGenerateResponseError(
-                "Engine response "
-                f"choice.logprobs.content[{index}].token must be {expected_token!r}."
+                f"Engine response choice.logprobs.content[{index}].token must be {expected_token!r}."
             )
         raw_logprob = entry.get("logprob")
         if isinstance(raw_logprob, bool) or not isinstance(raw_logprob, (int, float)):
             raise MalformedGenerateResponseError(
-                "Engine response "
-                f"choice.logprobs.content[{index}].logprob must be a number."
+                f"Engine response choice.logprobs.content[{index}].logprob must be a number."
             )
         try:
             logprob = float(raw_logprob)
         except OverflowError as exc:
             raise MalformedGenerateResponseError(
-                "Engine response "
-                f"choice.logprobs.content[{index}].logprob must be finite."
+                f"Engine response choice.logprobs.content[{index}].logprob must be finite."
             ) from exc
         if not math.isfinite(logprob):
             raise MalformedGenerateResponseError(
-                "Engine response "
-                f"choice.logprobs.content[{index}].logprob must be finite."
+                f"Engine response choice.logprobs.content[{index}].logprob must be finite."
             )
         if logprob == VLLM_LOGPROB_SENTINEL:
             raise MalformedGenerateResponseError(
-                "Engine response "
-                f"choice.logprobs.content[{index}].logprob does not contain "
-                "sampling evidence."
+                f"Engine response choice.logprobs.content[{index}].logprob does not contain sampling evidence."
             )
         completion_logprobs.append(logprob)
     return completion_logprobs
@@ -424,9 +417,9 @@ def _build_mm_features(
     model-family specific. For now we dispatch on the renderer class;
     extend the dispatch table as more multimodal renderers land.
 
-    NOTE — future engine pluggability: this encoder is vLLM 0.20-specific
+    NOTE — future engine pluggability: this encoder is vLLM-specific
     (uses ``vllm.multimodal.inputs.MultiModalKwargsItems``,
-    ``vllm.entrypoints.serve.disagg.mm_serde.encode_mm_kwargs_item``, and
+    ``vllm.entrypoints.scale_out.token_in_token_out.mm_serde.encode_mm_kwargs_item``, and
     ``_create_qwen2vl_field_factory``). When a second inference engine
     arrives (SGLang, MAX, ...) the renderer client should be parameterized
     on engine: either (a) move the encoder onto the renderer as
@@ -473,7 +466,9 @@ def _build_qwen_vl_features(
     try:
         import torch
         from transformers.feature_extraction_utils import BatchFeature
-        from vllm.entrypoints.serve.disagg.mm_serde import encode_mm_kwargs_item
+        from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import (
+            encode_mm_kwargs_item,
+        )
         from vllm.model_executor.models.qwen2_vl import _create_qwen2vl_field_factory
         from vllm.multimodal.inputs import MultiModalKwargsItems
     except ImportError as exc:


### PR DESCRIPTION
vLLM 0.26 moved the token-in/token-out serialization helpers from the serve.disagg package to scale_out.token_in_token_out. Update the lazy multimodal encoder import and its documentation so Qwen-VL feature serialization continues to work with the new release.

Validation:
- uvx --from ruff==0.15.12 ruff format --isolated --check .
- uvx --from ruff==0.15.12 ruff check --isolated renderers/client.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path and comment-only compatibility fix for vLLM 0.26; multimodal encoding logic is unchanged.
> 
> **Overview**
> Aligns Qwen-VL multimodal feature encoding with **vLLM 0.26**, which moved `encode_mm_kwargs_item` from `vllm.entrypoints.serve.disagg.mm_serde` to `vllm.entrypoints.scale_out.token_in_token_out.mm_serde`. The lazy import in `_build_qwen_vl_features` and the engine-pluggability note in `_build_mm_features` are updated accordingly.
> 
> Docs and comments no longer pin the client to “vLLM 0.20”; they describe the path generically as vLLM’s `/inference/v1/generate` integration.
> 
> A few `MalformedGenerateResponseError` and `OverlongPromptError` messages are tightened to single-line f-strings with no behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b37d40edcd9956cf6483d7d05ec7f47db9b92a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix vLLM token-serving import path for `encode_mm_kwargs_item` in `_build_qwen_vl_features`
> Updates the import path for `encode_mm_kwargs_item` in [client.py](https://github.com/PrimeIntellect-ai/renderers/pull/115/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) from `vllm.entrypoints.serve.disagg.mm_serde` to `vllm.entrypoints.scale_out.token_in_token_out.mm_serde` to match the module layout in vLLM 0.26. Also removes a version-specific reference in the module docstring and consolidates error message f-strings.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b37d40e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->