### PR TITLE
fix: encode message content with split_special_tokens=True

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1819,6 +1819,7 @@ def attribute_text_segments(
     segments: "list[tuple[str, bool]]",
     *,
     overlap_is_content: bool = False,
+    split_special_tokens: bool = True,
 ) -> "list[tuple[int, bool]]":
     """Tokenize concatenated segments as a single BPE pass and return
     ``(token_id, is_content)`` pairs.
@@ -1867,7 +1868,7 @@ def attribute_text_segments(
     encoding = offset_tokenizer(
         full_text,
         add_special_tokens=False,
-        split_special_tokens=True,
+        split_special_tokens=split_special_tokens,
         return_offsets_mapping=True,
     )
     token_ids = list(encoding["input_ids"])

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1867,6 +1867,7 @@ def attribute_text_segments(
     encoding = offset_tokenizer(
         full_text,
         add_special_tokens=False,
+        split_special_tokens=True,
         return_offsets_mapping=True,
     )
     token_ids = list(encoding["input_ids"])

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -110,7 +110,9 @@ class DeepSeekV3Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     # ------------------------------------------------------------------
     # Public API

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -91,9 +91,7 @@ class GLM45Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(
-            text, add_special_tokens=False, split_special_tokens=True
-        )
+        return self._tokenizer.encode(text, add_special_tokens=False)
 
     @staticmethod
     def _visible_text(content: Any) -> str:
@@ -160,8 +158,10 @@ class GLM45Renderer:
             same way as the chat template, but attributed separately"
             without splitting the encode call (which could shift BPE
             merges at the boundary)."""
+            # split_special_tokens=False: GLM's template reads /nothink out of
+            # user content, so content must keep matching special tokens here.
             for tok_id, is_content in attribute_text_segments(
-                self._tokenizer, segments
+                self._tokenizer, segments, split_special_tokens=False
             ):
                 tokens.append(tok_id)
                 indices.append(msg_idx)
@@ -383,8 +383,10 @@ class GLM45Renderer:
             *,
             is_sampled: bool = False,
         ) -> None:
+            # split_special_tokens=False: GLM's template reads /nothink out of
+            # user content, so content must keep matching special tokens here.
             for tok_id, is_content in attribute_text_segments(
-                self._tokenizer, segments
+                self._tokenizer, segments, split_special_tokens=False
             ):
                 ext.append(tok_id)
                 ext_indices.append(msg_idx)

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -91,7 +91,9 @@ class GLM45Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _visible_text(content: Any) -> str:

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -108,7 +108,9 @@ class GLM5Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _visible_text(content: Any) -> str:

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -172,7 +172,9 @@ class GptOssRenderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     def _prefix_content_mask(
         self,

--- a/renderers/hy3.py
+++ b/renderers/hy3.py
@@ -150,7 +150,9 @@ class Hy3Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _visible_text(content: Any) -> str:

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -78,7 +78,9 @@ class KimiK2Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     def _ensure_system_message(
         self, messages: list[Message]

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -721,7 +721,9 @@ class KimiK25Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     # ------------------------------------------------------------------
     # Core render

--- a/renderers/laguna_xs2.py
+++ b/renderers/laguna_xs2.py
@@ -138,7 +138,9 @@ class LagunaXS2Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _visible_text(content: Content | None) -> str:

--- a/renderers/llama_3.py
+++ b/renderers/llama_3.py
@@ -130,7 +130,9 @@ class Llama3Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _content_str(content: Any) -> str:

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -85,7 +85,9 @@ class MiniMaxM2Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _visible_text(content: Any) -> str:

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -172,7 +172,9 @@ class Nemotron3Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     # ------------------------------------------------------------------
     # Content rendering

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -88,7 +88,9 @@ class Qwen3Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     @staticmethod
     def _query_boundary_text(content) -> str:

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -239,7 +239,9 @@ class Qwen35Renderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     # ------------------------------------------------------------------
     # Content rendering (mirrors the render_content Jinja macro)

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -370,7 +370,9 @@ class Qwen3VLRenderer:
     def _encode(self, text: str) -> list[int]:
         if not text:
             return []
-        return self._tokenizer.encode(text, add_special_tokens=False)
+        return self._tokenizer.encode(
+            text, add_special_tokens=False, split_special_tokens=True
+        )
 
     def _get_processor(self):
         if self._processor is not None:


### PR DESCRIPTION
## Problem

`_encode` passes message text to the tokenizer with `add_special_tokens=False`:

```python
return self._tokenizer.encode(text, add_special_tokens=False)
```

That flag only suppresses BOS/EOS. A special token spelled out *inside* the text is still matched and collapsed to its reserved id, so message content can synthesize control tokens.

A minimal excerpt from tool output in an SFT corpus — docs for a path-template DSL where `<...>` denotes a required entity value:

```
... can pass them inside carets. Default values can be assigned by
specifying a string after the pipe operator. E.g., {type<image>|bold} ...
```

Tokenized:

```
"{type<image>|bold}"
  today (add_special_tokens=False)   → [1123, 4994, 18, 1124, 28118, 1125]
                                                   ↑ id 18, the image placeholder
  split_special_tokens=True          → [1123, 4994, 1060, 5497, 1062, 1124, 28118, 1125]
                                                   ↑ '<', 'image', '>' as text
```

Consequence on a VLM: the model compares placeholder count against vision-feature count before `masked_scatter`. One stray token in a text-only row, packed with image rows, gave `image_tokens=8936` vs `image_features=8935` → `ValueError` → 64-GPU job down. On text-only models the same injection is silent.

## Frequency and diagnosability

- 7 affected rows in a 13.1M-row corpus (~5e-7). ~1M documents consumed before the first hit.
- Only the 2 ranks holding the pack raise; the other 62 block in a collective those 2 never join, so the collective timeout names a victim rank, not the cause.
- `torchrun --local-ranks-filter=0`: the failing ranks were local 2 and 3, so their traceback existed only in `logs/.../attempt_0/{2,3}/stdout.log`, not the job log.
- The 2 culprit ranks left the collective path, so they wrote no NCCL flight-recorder trace. 62 of 64 traces dumped, all victims.

## Change

`split_special_tokens=True` on the content-encoding path: 13 renderer `_encode` methods, plus `attribute_text_segments` in `base.py` (the second encode path, used for content/scaffold attribution — it carried one of the observed cases).

`attribute_text_segments` takes `split_special_tokens: bool = True` so a renderer can opt out where its template requires it.

No shared helper for `_encode` — renderers stay standalone, matching the library's structure.

Default-on, not opt-in: this is data parsed as control, and in most renderers the failure is silent corruption rather than a crash.

`NemotronVLRenderer` inherits `_encode` from `Nemotron3Renderer`, so it is covered by `nemotron3.py` once `feat/nemotron-vl-renderer` merges.

### GLM-4.5-Air is excluded, deliberately

`glm45.py` keeps the old behavior at all three of its encode points. Its template appends `/nothink` into user content and relies on that string collapsing to special token `151360`; a user may also type `/nothink` themselves to disable thinking. Applying the change broke 7 parity shapes (`enable_thinking=False`), e.g. `len got=20, expected=18`, diverging at the `/nothink` position.

That is the same injection mechanism, and GLM is genuinely exposed to it — but reading control out of content is upstream GLM's intended design, and this library's contract is byte-parity with `apply_chat_template`. Diverging would be the bug. Worth raising against the GLM template upstream rather than fixing here.

The parity suite is the oracle for which renderers can take the change: if parity still passes, that template never intends content-as-control. 13 of 14 pass; GLM-4.5-Air is the only failure.

## Compatibility

Changes tokenization for any corpus with literal special-token spellings in message content. Measured on 13.1M rows: 24 rows contain such spellings, 7 produce real phantom tokens.

`split_special_tokens` is supported since transformers 4.32. No try/except fallback — a tokenizer rejecting the kwarg should fail loudly rather than silently revert to the vulnerable path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tokenization for any corpus with literal special-token substrings in content (intentional fix); GLM-4.5 is explicitly excluded to avoid parity regressions on /nothink.
> 
> **Overview**
> Prevents **literal special-token spellings inside message body text** from collapsing to reserved control-token IDs during rendering. Without this, substrings like `{type<image>|bold}` in tool docs could tokenize to a VLM **image placeholder** and break vision feature alignment (or silently corrupt text-only training).
> 
> **`attribute_text_segments`** in `base.py` now forwards **`split_special_tokens`** (default **`True`**) into the offset-tokenizer encode path used for scaffold/body attribution.
> 
> **Thirteen hand-coded renderers** set **`split_special_tokens=True`** on their **`_encode`** helpers (DeepSeek V3, GLM-5, GPT-OSS, Hy3, Kimi, Laguna, Llama 3, MiniMax, Nemotron3, Qwen3/3.5/VL, etc.).
> 
> **GLM-4.5-Air** is the deliberate exception: **`attribute_text_segments`** is called with **`split_special_tokens=False`** so **`/nothink`** in user content still maps to the template’s special token and **HF parity** is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23a702930cf8ad001cd6dc5ab874801345ad9de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix message content encoding by adding `split_special_tokens=True` to tokenizer calls
> - Adds `split_special_tokens=True` to `tokenizer.encode` calls across all renderer `_encode` methods so special tokens embedded in message content are tokenized correctly rather than treated as single opaque units.
> - Updates `attribute_text_segments` in [base.py](https://github.com/PrimeIntellect-ai/renderers/pull/116/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) to accept a `split_special_tokens` parameter (default `True`) and propagates it to callers.
> - [GLM-4.5](https://github.com/PrimeIntellect-ai/renderers/pull/116/files#diff-c7605da21d080370572a63b80ed0f2e821d86f004033eece0702403fa11d53cc) is explicitly opted out (`split_special_tokens=False`) because its chat template reads special markers directly from user content, so splitting would break token attribution.
> - Behavioral Change: token IDs emitted for inputs containing special tokens will change for all updated renderers.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23a7029.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->