### PR TITLE
feat(client)!: tool_calls mirrors the engine; attempts move to tool_call_attempts

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -362,19 +362,23 @@ async def generate(
     routed_experts = choice.get("routed_experts")
     kept_tokens = choice.get("kept_tokens")
 
+    # An engine's chat-completions endpoint only ever emits calls it accepted:
+    # vLLM's glm45/glm47 parsers run with ``validate_tool_names=True`` and drop
+    # the rest. ``tool_calls`` mirrors that — the calls a caller should execute —
+    # so an agent loop behaves the same whether it generated through this client
+    # or through the engine. Every attempt, accepted or not, stays available on
+    # ``tool_call_attempts`` for the uses engines can't serve: schema-adherence
+    # rubrics and selective token masking over non-OK spans.
+    #
     # /inference/v1/generate returns finish_reason in {"stop","length",...} —
     # never "tool_calls" (a chat-completions concept). Promote stop→tool_calls
-    # when we extracted at least one well-formed tool call client-side, so
-    # OpenAI-compatible agent loops continue past the tool turn instead of
-    # treating the response as final. Malformed attempts (INVALID_JSON,
-    # UNCLOSED_BLOCK, ...) don't qualify — those still surface on
-    # ``parsed.tool_calls`` so verifiers can inspect them, but they don't
-    # trigger the tool-loop continuation.
+    # when we extracted at least one executable call, so OpenAI-compatible agent
+    # loops continue past the tool turn instead of treating the response as final.
     finish_reason = choice.get("finish_reason")
-    ok_tool_calls = [
+    emitted_tool_calls = [
         tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK
     ]
-    if ok_tool_calls and finish_reason == "stop":
+    if emitted_tool_calls and finish_reason == "stop":
         finish_reason = "tool_calls"
 
     return {
@@ -384,7 +388,8 @@ async def generate(
         "completion_logprobs": completion_logprobs,
         "content": parsed.content,
         "reasoning_content": parsed.reasoning_content,
-        "tool_calls": parsed.tool_calls,
+        "tool_calls": emitted_tool_calls,
+        "tool_call_attempts": parsed.tool_calls,
         "finish_reason": finish_reason,
         "routed_experts": routed_experts,
         "kept_tokens": kept_tokens,


### PR DESCRIPTION
## Problem

`generate()` returned **every** parsed attempt under `tool_calls`:

```python
ok_tool_calls = [tc for tc in parsed.tool_calls if tc.status == ToolCallParseStatus.OK]
if ok_tool_calls and finish_reason == "stop":
    finish_reason = "tool_calls"
return {..., "tool_calls": parsed.tool_calls, ...}   # all attempts
```

The client already computes the executable subset for the finish-reason promotion, then discards it. So any consumer that wants "the calls an engine would have emitted" has to re-derive it from `ToolCallParseStatus` — putting engine-parity knowledge in every consumer instead of in the layer that owns it.

Consumers that *don't* do that end up executing calls the chat-completions path drops. vLLM's `glm45`/`glm47` parsers run with `validate_tool_names=True`, so an undeclared tool name yields no call from the engine but a live `ToolCall` from this client. In verifiers' train client that difference is load-bearing: on the renderer path a hallucinated tool name became a recoverable `error: unknown tool 'read'` turn and the episode continued; through chat-completions the harness saw no tool call, treated the message as final, and ended the episode.

That asymmetry is trainable. In a GLM-4.5-Air SWE run the policy's turn-1 malformed-call rate drifted **18% → 56% over 220 steps** — nearly free on the renderer path — while held-out SWE-bench Verified fell **26% → 15%**, ~94% of the decline from episodes dying on an unparsed tool call.

## Change

`tool_calls` now carries the executable subset (what an engine would emit). Every attempt, with `status`, moves to `tool_call_attempts`.

Attempts are still exposed rather than dropped, because that's the information engines can't give you — schema-adherence rubrics and selective token masking over non-OK spans, per `ParsedToolCall.token_span`.

This also generalises: `parse_glm` is currently the only parser doing name validation, but any family that adopts it inherits parity with no consumer changes.

## Breaking

Callers reading `result["tool_calls"]` for the full attempt record should read `tool_call_attempts`. Callers that want executable calls — the common case, and what OpenAI semantics imply — need no change and get the correct behaviour by default.

Paired with a verifiers change that drops its local status filter and relies on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking return-shape change for `tool_calls` affects every consumer of `generate()`; behavior change is intentional but can break training/verifier code that assumed all attempts lived on `tool_calls`.
> 
> **Overview**
> **Breaking:** `renderers.client.generate()` now splits tool-call results so agent loops match chat-completions / vLLM behavior.
> 
> `tool_calls` contains only **`ToolCallParseStatus.OK`** entries—the subset an engine would emit (e.g. after `validate_tool_names=True` on GLM parsers). All parsed attempts, including malformed or rejected names, move to **`tool_call_attempts`**. `stop` → `tool_calls` finish-reason promotion still keys off that same executable subset (`emitted_tool_calls`).
> 
> Callers that executed or audited every parse via `tool_calls` should switch to `tool_call_attempts`; callers that only need runnable tools get engine parity without re-filtering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4c238162857f65e9ab09f4b00782c070b66dcfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split `tool_calls` into executable-only calls and all attempts in client renderer
> - `tool_calls` in the response payload now contains only executable (status == OK) tool calls, mirroring engine behavior.
> - Introduces a new `tool_call_attempts` field in the response that includes all parsed attempts, including malformed or rejected ones.
> - Finish reason promotion from `stop` to `tool_calls` continues to trigger only when at least one executable call is present.
> - Behavioral Change: Callers relying on `tool_calls` to contain all parsed attempts (including non-OK ones) must switch to `tool_call_attempts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4c2381.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->