### PR TITLE
feat: normalize provider tool specifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Hand-coded renderers ship for `qwen3`, `qwen3-vl`, `qwen3.5`, `qwen3.6`, `glm-5`
 class Renderer(Protocol):
     def render(messages, *, tools=None, add_generation_prompt=False) -> RenderedTokens: ...
     def render_ids(messages, *, tools=None, add_generation_prompt=False) -> list[int]: ...
-    def parse_response(token_ids) -> ParsedResponse: ...
+    def parse_response(token_ids, *, tools=None) -> ParsedResponse: ...
     def get_stop_token_ids() -> list[int]: ...
     def bridge_to_next_turn(prev_prompt_ids, prev_completion_ids, new_messages, *, tools=None) -> RenderedTokens | None: ...
 ```
@@ -61,6 +61,21 @@ class Renderer(Protocol):
 - `RenderedTokens` carries `token_ids` **and** `message_indices` — one entry per token attributing each to its source message (`-1` for structural scaffolding). Lets `build_training_sample` build a per-token loss mask in one render.
 - `ParsedResponse` is `(content, reasoning_content, tool_calls)`. It scans token ids for special-token boundaries (e.g. id `151657` for `<tool_call>` on Qwen3) — a literal `"<tool_call>"` in user content tokenizes to ordinary text ids and never matches.
 - Round-trip: rendering `[user, assistant(content, reasoning, tool_calls)]`, slicing the assistant completion, and feeding it through `parse_response` returns an equivalent structured message. Tested per-renderer in `tests/test_roundtrip.py`.
+
+### Tool definitions
+
+Renderer entry points accept the common wire shapes for client-executed JSON-schema functions:
+
+- legacy / verifiers and Gemini function declarations: `{name, description, parameters}`
+- OpenAI Chat Completions: `{type: "function", function: {...}}`
+- OpenAI Responses and Gemini Interactions: `{type: "function", name, description, parameters, strict}`
+- Anthropic: `{name, description, input_schema}`
+- MCP: `{name, description, inputSchema}`
+- Pydantic-style objects exposing `model_dump()`
+
+`normalize_tool_spec()` exposes the conversion directly. All supported shapes become the existing Chat-style envelope before rendering or schema-aware response parsing, so switching provider payloads does not change the model's token stream. Inputs are deep-copied and never mutated.
+
+Hosted and non-JSON function protocols—such as OpenAI web search, file search, remote MCP, custom-text, namespace, shell, and computer tools—raise `UnsupportedToolSpecError`. Those tools need model-specific execution semantics and cannot be faithfully rewritten as ordinary client functions.
 
 ### `bridge_to_next_turn` (the core contract)
 

--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -67,6 +67,20 @@ from renderers.configs import (
     Qwen3VLRendererConfig,
     RendererConfig,
 )
+from renderers.tools import (
+    AnthropicToolSpec,
+    CanonicalToolSpec,
+    ChatCompletionToolSpec,
+    FunctionSpec,
+    KnownToolSpec,
+    MCPToolSpec,
+    normalize_tool_spec,
+    normalize_tool_specs,
+    ResponsesFunctionToolSpec,
+    ToolSpecError,
+    ToolSpecInput,
+    UnsupportedToolSpecError,
+)
 
 # Concrete renderer classes are lazy-loaded so that consumers needing
 # only the config layer (``RendererConfig`` discriminated union) don't
@@ -121,9 +135,12 @@ def __dir__() -> list[str]:
 
 __all__ = [
     "AutoRendererConfig",
+    "AnthropicToolSpec",
     "BaseRendererConfig",
     "Content",
     "ContentPart",
+    "CanonicalToolSpec",
+    "ChatCompletionToolSpec",
     "DeepSeekR1Renderer",
     "DeepSeekR1RendererConfig",
     "DeepSeekV3Renderer",
@@ -138,6 +155,8 @@ __all__ = [
     "GLM5RendererConfig",
     "GptOssRenderer",
     "GptOssRendererConfig",
+    "FunctionSpec",
+    "KnownToolSpec",
     "Hy3Renderer",
     "Hy3RendererConfig",
     "ImagePart",
@@ -154,6 +173,7 @@ __all__ = [
     "MULTIMODAL_MODELS",
     "MalformedGenerateResponseError",
     "Message",
+    "MCPToolSpec",
     "MiniMaxM2Renderer",
     "MiniMaxM2RendererConfig",
     "MultiModalData",
@@ -182,12 +202,16 @@ __all__ = [
     "Renderer",
     "RendererConfig",
     "RendererPool",
+    "ResponsesFunctionToolSpec",
     "TextPart",
     "ThinkingPart",
     "ToolCall",
     "ToolCallFunction",
     "ToolCallParseStatus",
     "ToolSpec",
+    "ToolSpecError",
+    "ToolSpecInput",
+    "UnsupportedToolSpecError",
     "VideoPart",
     "__version__",
     "attribute_text_segments",
@@ -198,6 +222,8 @@ __all__ = [
     "create_renderer_pool",
     "extract_message_tool_names",
     "is_multimodal",
+    "normalize_tool_spec",
+    "normalize_tool_specs",
     "reject_assistant_in_extension",
     "trim_to_turn_close",
 ]

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -17,6 +17,8 @@ from typing import (
     runtime_checkable,
 )
 
+from renderers.tools import ToolSpec
+
 if TYPE_CHECKING:
     from renderers.configs import (
         AutoRendererConfig,
@@ -95,14 +97,6 @@ class ToolCall(TypedDict, total=False):
     type: str  # "function"
     id: str
     function: ToolCallFunction
-
-
-class ToolSpec(TypedDict):
-    """Tool specification (OpenAI function-calling format)."""
-
-    name: str
-    description: str
-    parameters: dict[str, Any]
 
 
 class Message(TypedDict, total=False):

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -30,6 +30,7 @@ from renderers.base import (
 )
 from renderers.configs import DeepSeekV3RendererConfig
 from renderers.parsing import parse_deepseek_v3
+from renderers.tools import normalize_tool_specs
 
 # Fullwidth vertical bar used in DeepSeek special token names.
 _SEP = "\uff5c"  # ｜  (U+FF5C)
@@ -125,6 +126,7 @@ class DeepSeekV3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -26,6 +26,7 @@ from renderers.parsers import (
     get_reasoning_parser,
     get_tool_parser,
 )
+from renderers.tools import normalize_tool_specs
 
 
 def _decode_tool_call_arguments(messages: list) -> list:
@@ -124,6 +125,7 @@ class DefaultRenderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        tools = normalize_tool_specs(tools)
         # Incremental rendering to get per-token message attribution
         token_ids: list[int] = []
         message_indices: list[int] = []

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -28,6 +28,7 @@ from renderers.base import (
 )
 from renderers.configs import GLM45RendererConfig
 from renderers.parsing import parse_glm
+from renderers.tools import normalize_tool_specs
 
 _TOOLS_HEADER = (
     "\n# Tools\n\n"
@@ -125,6 +126,7 @@ class GLM45Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -29,6 +29,7 @@ from renderers.base import (
 )
 from renderers.configs import GLM5RendererConfig, GLM51RendererConfig
 from renderers.parsing import parse_glm
+from renderers.tools import normalize_tool_specs
 
 _TOOLS_HEADER = (
     "\n# Tools\n\n"
@@ -151,6 +152,7 @@ class GLM5Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -64,6 +64,7 @@ from renderers.base import (
 )
 from renderers.configs import GptOssRendererConfig
 from renderers.parsing import parse_gpt_oss
+from renderers.tools import normalize_tool_specs
 
 
 def _reasoning_effort(effort: str | None) -> ReasoningEffort:
@@ -269,6 +270,7 @@ class GptOssRenderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/hy3.py
+++ b/renderers/hy3.py
@@ -42,6 +42,7 @@ from renderers.base import (
 )
 from renderers.configs import Hy3RendererConfig, ResolvedThinkingRetention
 from renderers.parsing import parse_hy3
+from renderers.tools import normalize_tool_specs
 
 # Special-token strings, constructed exactly as the Jinja template does
 # (``'<｜hy_eos{}｜>'.format(':opensource')`` etc.) so ``convert_tokens_to_ids``
@@ -277,6 +278,7 @@ class Hy3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         # fallback_strategy="reasoning_toolcall_retry" suppresses the gen prompt.
         if self._force_no_gen_prompt:

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -31,6 +31,7 @@ from renderers.base import (
 )
 from renderers.configs import KimiK2RendererConfig
 from renderers.parsing import parse_kimi_k2
+from renderers.tools import normalize_tool_specs
 
 _DEFAULT_SYSTEM = "You are Kimi, an AI assistant created by Moonshot AI."
 
@@ -122,6 +123,7 @@ class KimiK2Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         # Preserve the caller's list — ``message_roles`` and per-token
         # attribution refer to this frame (not the post-normalisation

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from typing import Any, cast
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
@@ -44,6 +44,7 @@ from renderers.base import (
 )
 from renderers.configs import KimiK25RendererConfig
 from renderers.parsing import _reasoning_end_token_index, parse_kimi_k2_section
+from renderers.tools import normalize_tool_specs
 from renderers.qwen3_vl import (
     _image_hash,
     _is_image_part,
@@ -393,7 +394,7 @@ def _encode_tools_typescript(tools: list[ToolSpec]) -> str:
             func_def_dict = tool
         if not func_def_dict:
             continue
-        func_def = _function_to_typescript(func_def_dict)
+        func_def = _function_to_typescript(cast(dict[str, Any], func_def_dict))
         if func_def:
             functions.append(func_def)
     if not functions:
@@ -749,6 +750,7 @@ class KimiK25Renderer:
         """
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         # Hist/suffix split — assistants up to and including the last
         # non-tool-call assistant strip reasoning_content, those after

--- a/renderers/laguna_xs2.py
+++ b/renderers/laguna_xs2.py
@@ -58,6 +58,7 @@ from renderers.base import (
 )
 from renderers.configs import LagunaXS2RendererConfig, LagunaXS21RendererConfig
 from renderers.parsing import parse_laguna_xs2
+from renderers.tools import normalize_tool_specs
 
 _DEFAULT_SYSTEM_MESSAGE = (
     "You are a helpful, conversationally-fluent assistant made by Poolside. "
@@ -177,6 +178,7 @@ class LagunaXS2Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []
@@ -646,6 +648,7 @@ class LagunaXS21Renderer(LagunaXS2Renderer):
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/llama_3.py
+++ b/renderers/llama_3.py
@@ -57,6 +57,7 @@ from renderers.base import (
 )
 from renderers.configs import Llama3RendererConfig
 from renderers.parsing import parse_llama_3
+from renderers.tools import normalize_tool_specs
 
 # ---------------------------------------------------------------------------
 # Constants — must match the Jinja chat template's literal strings exactly.
@@ -183,6 +184,7 @@ class Llama3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -30,6 +30,7 @@ from renderers.base import (
 )
 from renderers.configs import MiniMaxM2RendererConfig
 from renderers.parsing import parse_minimax
+from renderers.tools import normalize_tool_specs
 
 _TOOLS_HEADER = (
     "\n\n# Tools\n"
@@ -112,6 +113,7 @@ class MiniMaxM2Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -15,7 +15,8 @@ Nemotron 3 uses the same <|im_start|>/<|im_end|> format as Qwen3.5 but differs i
 from __future__ import annotations
 
 import json
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, cast
 
 from transformers.tokenization_utils import PreTrainedTokenizer
 
@@ -33,6 +34,7 @@ from renderers.base import (
 )
 from renderers.configs import Nemotron3RendererConfig, Nemotron3UltraRendererConfig
 from renderers.parsing import parse_qwen35
+from renderers.tools import normalize_tool_specs
 
 # ---------------------------------------------------------------------------
 # Tool system prompt constants
@@ -60,7 +62,7 @@ _TOOLS_INSTRUCTIONS = (
 )
 
 
-def _render_extra_keys(obj: dict[str, Any], handled_keys: set[str]) -> list[str]:
+def _render_extra_keys(obj: Mapping[str, Any], handled_keys: set[str]) -> list[str]:
     """Render extra dict keys as XML, mirroring the HF template's render_extra_keys macro.
 
     Dicts and lists are JSON-encoded; scalars are string-coerced.
@@ -208,7 +210,7 @@ class Nemotron3Renderer:
         # Accept the OpenAI-style ``{"type":"function","function":{...}}``
         # envelope by unwrapping before formatting.
         if "function" in tool and isinstance(tool["function"], dict):
-            tool = tool["function"]
+            tool = cast(ToolSpec, tool["function"])
         lines = [
             "<function>",
             f"<name>{tool['name']}</name>",
@@ -279,6 +281,7 @@ class Nemotron3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         original_messages = list(messages)
         # Always ensure an empty system message is present.

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -20,6 +20,7 @@ import json
 from typing import Any
 
 from renderers.base import ParsedResponse, ParsedToolCall, ToolCallParseStatus, ToolSpec
+from renderers.tools import normalize_tool_specs
 
 
 # ── Schema-aware argument coercion ──────────────────────────────────
@@ -39,16 +40,15 @@ def _build_param_type_index(
     """Map tool name → param name → param JSON-schema fragment.
 
     Accepts both flat ``ToolSpec`` (``{name, description, parameters}``)
-    and the OpenAI envelope (``{"type": "function", "function": {...}}``)
-    so callers can pass either shape.
+    and every function-compatible provider shape accepted by
+    :func:`renderers.tools.normalize_tool_specs`.
     """
-    if not tools:
+    normalized_tools = normalize_tool_specs(tools)
+    if not normalized_tools:
         return {}
     index: dict[str, dict[str, dict[str, Any]]] = {}
-    for tool in tools:
-        spec = tool.get("function", tool) if isinstance(tool, dict) else None
-        if not isinstance(spec, dict):
-            continue
+    for tool in normalized_tools:
+        spec = tool["function"]
         name = spec.get("name")
         if not isinstance(name, str):
             continue
@@ -64,17 +64,17 @@ def _extract_tool_names(tools: list[ToolSpec] | None) -> set[str] | None:
 
     ``None`` disables name validation — mirroring vLLM's
     ``ParserEngine._is_valid_tool_name``, which returns ``True`` whenever
-    the request carries no tools. Accepts both flat ``ToolSpec`` and the
-    OpenAI ``{"type": "function", "function": {...}}`` envelope, like
-    ``_build_param_type_index`` (but independent of it: a tool with no
-    ``parameters.properties`` still counts as a known name).
+    the request carries no tools. Accepts every function-compatible provider
+    shape handled by ``_build_param_type_index`` (but is independent of it: a
+    tool with no ``parameters.properties`` still counts as a known name).
     """
-    if not tools:
+    normalized_tools = normalize_tool_specs(tools)
+    if not normalized_tools:
         return None
     names: set[str] = set()
-    for tool in tools:
-        spec = tool.get("function", tool) if isinstance(tool, dict) else None
-        if isinstance(spec, dict) and isinstance(spec.get("name"), str):
+    for tool in normalized_tools:
+        spec = tool["function"]
+        if isinstance(spec.get("name"), str):
             names.add(spec["name"])
     return names
 

--- a/renderers/prime_qwen3.py
+++ b/renderers/prime_qwen3.py
@@ -22,6 +22,7 @@ from renderers.base import (
 )
 from renderers.configs import PrimeQwen3RendererConfig
 from renderers.parsing import parse_qwen35
+from renderers.tools import normalize_tool_specs
 
 _DEFAULT_TOOL_SYSTEM = "You are Qwen, a helpful AI assistant that can interact with a computer to solve tasks."
 _TOOLS_HEADER = "\n\n# Tools\n\nYou have access to the following functions:\n\n<tools>"
@@ -237,6 +238,7 @@ class PrimeQwen3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         builder = _TokenBuilder(self._tokenizer)
         first_is_system = messages[0].get("role") == "system"

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -36,6 +36,7 @@ from renderers.base import (
 )
 from renderers.configs import Qwen3RendererConfig
 from renderers.parsing import parse_qwen3
+from renderers.tools import normalize_tool_specs
 
 _TOOLS_HEADER = (
     "# Tools\n\n"
@@ -130,6 +131,7 @@ class Qwen3Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -43,6 +43,7 @@ from renderers.base import (
 )
 from renderers.configs import Qwen35RendererConfig
 from renderers.parsing import parse_qwen35
+from renderers.tools import normalize_tool_specs
 from renderers.qwen3_vl import (
     _image_hash,
     _is_image_part,
@@ -318,6 +319,7 @@ class Qwen35Renderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         tokens: list[int] = []
         indices: list[int] = []

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -51,6 +51,7 @@ from renderers.base import (
 )
 from renderers.configs import Qwen3VLRendererConfig
 from renderers.parsing import parse_qwen3
+from renderers.tools import normalize_tool_specs
 
 _TOOLS_HEADER = (
     "# Tools\n\n"
@@ -460,6 +461,7 @@ class Qwen3VLRenderer:
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
+        tools = normalize_tool_specs(tools)
 
         em = _Emitter(self._encode, tokenizer=self._tokenizer)
         mm_hashes: dict[str, list[str]] = {}

--- a/renderers/tools.py
+++ b/renderers/tools.py
@@ -1,0 +1,238 @@
+"""Tool-definition types and normalization.
+
+Renderers only know how to describe client-executed, JSON-schema function
+tools in a model prompt.  Provider APIs expose that same concept through
+several wire shapes, so normalize those shapes once before model-specific
+formatting begins.
+
+The canonical representation deliberately matches the OpenAI Chat
+Completions envelope.  Existing renderer templates already consume that
+shape, which lets callers use other provider shapes without changing the
+rendered token stream.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from typing import Any, Literal, Protocol, TypeAlias, TypedDict, cast
+
+
+class _OptionalFunctionFields(TypedDict, total=False):
+    description: str
+    parameters: dict[str, Any] | None
+    strict: bool | None
+    defer_loading: bool
+    allowed_callers: list[str]
+
+
+class FunctionSpec(_OptionalFunctionFields):
+    """Canonical body of a client-executed JSON-schema function tool."""
+
+    name: str
+
+
+class ChatCompletionToolSpec(TypedDict):
+    """OpenAI Chat Completions function-tool envelope."""
+
+    type: Literal["function"]
+    function: FunctionSpec
+
+
+class ResponsesFunctionToolSpec(_OptionalFunctionFields):
+    """OpenAI Responses flat function-tool definition."""
+
+    type: Literal["function"]
+    name: str
+
+
+class _OptionalDescription(TypedDict, total=False):
+    description: str
+
+
+class _OptionalAnthropicFields(_OptionalDescription, total=False):
+    strict: bool
+    defer_loading: bool
+    input_examples: list[dict[str, Any]]
+    cache_control: dict[str, Any]
+
+
+class AnthropicToolSpec(_OptionalAnthropicFields):
+    """Anthropic Messages function-tool definition."""
+
+    name: str
+    input_schema: dict[str, Any]
+
+
+class _OptionalMCPFields(_OptionalDescription, total=False):
+    title: str
+    outputSchema: dict[str, Any]
+    annotations: dict[str, Any]
+    _meta: dict[str, Any]
+
+
+class MCPToolSpec(_OptionalMCPFields):
+    """Model Context Protocol function-tool definition."""
+
+    name: str
+    inputSchema: dict[str, Any]
+
+
+class ToolSpec(_OptionalFunctionFields, total=False):
+    """Provider-agnostic tool mapping accepted by renderer entry points.
+
+    This remains a constructible ``TypedDict`` for compatibility with the
+    original flat tool contract, while also describing the keys used by Chat
+    Completions, Responses, Anthropic, and MCP function tools.
+    """
+
+    type: str
+    function: FunctionSpec
+    name: str
+    input_schema: dict[str, Any]
+    inputSchema: dict[str, Any]
+    input_examples: list[dict[str, Any]]
+    cache_control: dict[str, Any]
+    title: str
+    outputSchema: dict[str, Any]
+    annotations: dict[str, Any]
+    _meta: dict[str, Any]
+
+
+class ToolSpecModel(Protocol):
+    """Pydantic-style object that can expose a tool definition mapping."""
+
+    def model_dump(self, **kwargs: Any) -> Mapping[str, Any]: ...
+
+
+KnownToolSpec: TypeAlias = (
+    FunctionSpec
+    | ChatCompletionToolSpec
+    | ResponsesFunctionToolSpec
+    | AnthropicToolSpec
+    | MCPToolSpec
+)
+ToolSpecInput: TypeAlias = ToolSpec | Mapping[str, Any] | ToolSpecModel
+CanonicalToolSpec: TypeAlias = ChatCompletionToolSpec
+
+
+class ToolSpecError(ValueError):
+    """A tool definition cannot be normalized safely."""
+
+
+class UnsupportedToolSpecError(ToolSpecError):
+    """The tool requires a protocol the renderer cannot serialize."""
+
+
+def _as_mapping(tool: ToolSpecInput) -> Mapping[str, Any]:
+    if isinstance(tool, Mapping):
+        return cast(Mapping[str, Any], tool)
+
+    model_dump = getattr(tool, "model_dump", None)
+    if not callable(model_dump):
+        raise ToolSpecError("tool definitions must be mappings or expose model_dump()")
+    try:
+        dumped = model_dump(mode="python", exclude_none=True)
+    except TypeError:
+        dumped = model_dump()
+    if not isinstance(dumped, Mapping):
+        raise ToolSpecError("tool model_dump() must return a mapping")
+    return dumped
+
+
+def _function_body(raw_tool: Mapping[str, Any]) -> dict[str, Any]:
+    tool_type = raw_tool.get("type")
+    nested = raw_tool.get("function")
+
+    if nested is not None:
+        if tool_type not in (None, "function"):
+            raise ToolSpecError(
+                f"a nested function definition cannot use tool type {tool_type!r}"
+            )
+        if not isinstance(nested, Mapping):
+            raise ToolSpecError("tool.function must be a mapping")
+        function = deepcopy(dict(nested))
+    else:
+        if tool_type not in (None, "function"):
+            raise UnsupportedToolSpecError(
+                f"tool type {tool_type!r} is not a client-executed JSON-schema "
+                "function tool; hosted, custom-text, and namespace tools need "
+                "a model-specific execution protocol"
+            )
+        function = deepcopy(dict(raw_tool))
+        function.pop("type", None)
+
+    name = function.get("name")
+    if not isinstance(name, str) or not name:
+        raise ToolSpecError("function tool name must be a non-empty string")
+
+    description = function.get("description")
+    if description is None:
+        function.pop("description", None)
+    elif not isinstance(description, str):
+        raise ToolSpecError("function tool description must be a string")
+
+    schema_aliases = [
+        key for key in ("parameters", "input_schema", "inputSchema") if key in function
+    ]
+    if len(schema_aliases) > 1:
+        first = function[schema_aliases[0]]
+        if any(function[key] != first for key in schema_aliases[1:]):
+            raise ToolSpecError(
+                "function tool provides conflicting parameter schemas: "
+                + ", ".join(schema_aliases)
+            )
+    if schema_aliases:
+        schema = function[schema_aliases[0]]
+        if schema is not None and not isinstance(schema, Mapping):
+            raise ToolSpecError("function tool parameters must be a mapping or None")
+        for key in ("parameters", "input_schema", "inputSchema"):
+            function.pop(key, None)
+        function["parameters"] = deepcopy(dict(schema)) if schema is not None else None
+
+    strict = function.get("strict")
+    if strict is not None and not isinstance(strict, bool):
+        raise ToolSpecError("function tool strict must be bool or None")
+
+    defer_loading = function.get("defer_loading")
+    if defer_loading is not None and not isinstance(defer_loading, bool):
+        raise ToolSpecError("function tool defer_loading must be bool")
+
+    allowed_callers = function.get("allowed_callers")
+    if allowed_callers is not None and (
+        not isinstance(allowed_callers, list)
+        or not all(isinstance(caller, str) for caller in allowed_callers)
+    ):
+        raise ToolSpecError("function tool allowed_callers must be a list of strings")
+
+    return function
+
+
+def normalize_tool_spec(tool: ToolSpecInput) -> CanonicalToolSpec:
+    """Return a detached Chat-style envelope for one function tool.
+
+    Supported inputs are the legacy/verifiers flat shape, OpenAI Chat
+    Completions and Responses function tools, Anthropic ``input_schema``
+    tools, MCP ``inputSchema`` tools, and Pydantic-style objects containing
+    any of those mappings.
+    """
+
+    function = cast(FunctionSpec, _function_body(_as_mapping(tool)))
+    return {"type": "function", "function": function}
+
+
+def normalize_tool_specs(
+    tools: Iterable[ToolSpecInput] | None,
+) -> list[ToolSpec] | None:
+    """Normalize a tool collection without retaining caller-owned objects."""
+
+    if tools is None:
+        return None
+
+    normalized: list[ToolSpec] = []
+    for index, tool in enumerate(tools):
+        try:
+            normalized.append(cast(ToolSpec, normalize_tool_spec(tool)))
+        except ToolSpecError as exc:
+            raise type(exc)(f"tools[{index}]: {exc}") from exc
+    return normalized

--- a/tests/test_tool_normalization.py
+++ b/tests/test_tool_normalization.py
@@ -1,0 +1,183 @@
+"""Provider tool definitions normalize to one renderer-facing contract."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+from openai.types.chat import ChatCompletionFunctionToolParam
+from openai.types.responses import FunctionToolParam
+
+from renderers import (
+    ToolSpec,
+    ToolSpecError,
+    UnsupportedToolSpecError,
+    normalize_tool_spec,
+    normalize_tool_specs,
+)
+from renderers.parsing import _build_param_type_index, _extract_tool_names
+
+
+FUNCTION = {
+    "name": "get_weather",
+    "description": "Return the weather for a city.",
+    "parameters": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+CANONICAL = {"type": "function", "function": FUNCTION}
+
+TOOL_SHAPES = {
+    "flat": FUNCTION,
+    "openai-chat": CANONICAL,
+    "openai-responses": {"type": "function", **FUNCTION},
+    "anthropic": {
+        "name": FUNCTION["name"],
+        "description": FUNCTION["description"],
+        "input_schema": FUNCTION["parameters"],
+    },
+    "mcp": {
+        "name": FUNCTION["name"],
+        "description": FUNCTION["description"],
+        "inputSchema": FUNCTION["parameters"],
+    },
+}
+
+
+@pytest.mark.parametrize(
+    "tool",
+    TOOL_SHAPES.values(),
+    ids=TOOL_SHAPES,
+)
+def test_function_tool_wire_shapes_normalize_identically(tool):
+    assert normalize_tool_spec(tool) == CANONICAL
+
+
+def test_legacy_tool_spec_remains_constructible():
+    assert ToolSpec(**FUNCTION) == FUNCTION
+
+
+def test_openai_sdk_chat_and_responses_request_types_are_supported():
+    chat = ChatCompletionFunctionToolParam(type="function", function=FUNCTION)
+    responses = FunctionToolParam(type="function", **FUNCTION)
+
+    assert normalize_tool_spec(chat) == CANONICAL
+    assert normalize_tool_spec(responses) == CANONICAL
+
+
+@pytest.mark.parametrize("tool", TOOL_SHAPES.values(), ids=TOOL_SHAPES)
+def test_provider_shapes_feed_schema_aware_parsing(tool):
+    assert _build_param_type_index([tool]) == {
+        "get_weather": {"city": {"type": "string"}}
+    }
+    assert _extract_tool_names([tool]) == {"get_weather"}
+
+
+def test_normalization_preserves_function_options_and_extensions():
+    tool = {
+        "type": "function",
+        "name": "lookup",
+        "parameters": None,
+        "strict": False,
+        "defer_loading": True,
+        "allowed_callers": ["programmatic_tool_calling"],
+    }
+
+    assert normalize_tool_spec(tool) == {
+        "type": "function",
+        "function": {
+            "name": "lookup",
+            "parameters": None,
+            "strict": False,
+            "defer_loading": True,
+            "allowed_callers": ["programmatic_tool_calling"],
+        },
+    }
+
+
+def test_normalization_does_not_retain_or_mutate_caller_data():
+    original = deepcopy(CANONICAL)
+    normalized = normalize_tool_spec(original)
+
+    normalized["function"]["parameters"]["properties"]["city"]["type"] = "integer"
+
+    assert original == CANONICAL
+
+
+class _ToolModel:
+    def __init__(self):
+        self.kwargs = None
+
+    def model_dump(self, **kwargs):
+        self.kwargs = kwargs
+        return {"type": "function", **FUNCTION, "strict": None}
+
+
+def test_pydantic_style_tool_objects_are_supported():
+    tool = _ToolModel()
+
+    assert normalize_tool_spec(tool) == {
+        "type": "function",
+        "function": {**FUNCTION, "strict": None},
+    }
+    assert tool.kwargs == {"mode": "python", "exclude_none": True}
+
+
+@pytest.mark.parametrize(
+    "tool_type",
+    [
+        "apply_patch",
+        "code_interpreter",
+        "computer",
+        "computer_use_preview",
+        "custom",
+        "file_search",
+        "image_generation",
+        "local_shell",
+        "mcp",
+        "namespace",
+        "programmatic_tool_calling",
+        "shell",
+        "skills",
+        "tool_search",
+        "web_search",
+        "web_search_preview",
+    ],
+)
+def test_non_function_tool_protocols_fail_loudly(tool_type):
+    with pytest.raises(UnsupportedToolSpecError, match=repr(tool_type)):
+        normalize_tool_spec({"type": tool_type})
+
+
+@pytest.mark.parametrize(
+    ("tool", "message"),
+    [
+        ({"description": "missing name"}, "name"),
+        ({"name": ""}, "name"),
+        ({"name": "x", "description": 42}, "description"),
+        ({"name": "x", "parameters": []}, "parameters"),
+        ({"name": "x", "strict": "yes"}, "strict"),
+        ({"name": "x", "defer_loading": 1}, "defer_loading"),
+        ({"name": "x", "allowed_callers": "direct"}, "allowed_callers"),
+        (
+            {"name": "x", "parameters": {}, "input_schema": {"type": "object"}},
+            "conflicting",
+        ),
+    ],
+)
+def test_invalid_function_tools_fail_at_the_boundary(tool, message):
+    with pytest.raises(ToolSpecError, match=message):
+        normalize_tool_spec(tool)
+
+
+def test_collection_errors_identify_the_bad_tool_index():
+    with pytest.raises(UnsupportedToolSpecError, match=r"tools\[1\]"):
+        normalize_tool_specs([FUNCTION, {"type": "web_search"}])
+
+
+def test_none_and_empty_collections_remain_distinct():
+    assert normalize_tool_specs(None) is None
+    assert normalize_tool_specs([]) == []

--- a/tests/test_tool_shape_parity.py
+++ b/tests/test_tool_shape_parity.py
@@ -1,0 +1,39 @@
+"""All renderers treat function-compatible provider shapes identically."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pytest
+
+from tests.golden_corpus import GOLDEN_CASES, SYSTEM_AND_USER, GoldenCase, _renderer_for
+from tests.model_assets import load_test_tokenizer
+from tests.test_tool_normalization import TOOL_SHAPES
+
+
+pytestmark = [pytest.mark.network, pytest.mark.model_parity]
+
+
+@lru_cache(maxsize=None)
+def _load_case(case: GoldenCase):
+    tokenizer = load_test_tokenizer(case.model_name)
+    return _renderer_for(case, tokenizer)
+
+
+@pytest.mark.parametrize("case", GOLDEN_CASES, ids=lambda case: case.slug)
+@pytest.mark.parametrize("shape", TOOL_SHAPES)
+def test_provider_tool_shapes_render_identically(case, shape):
+    renderer = _load_case(case)
+    expected = renderer.render(
+        SYSTEM_AND_USER,
+        tools=[TOOL_SHAPES["openai-chat"]],
+        add_generation_prompt=True,
+    )
+
+    actual = renderer.render(
+        SYSTEM_AND_USER,
+        tools=[TOOL_SHAPES[shape]],
+        add_generation_prompt=True,
+    )
+
+    assert actual == expected


### PR DESCRIPTION
## Summary

- add one canonical normalization boundary for client-executed JSON-schema function tools
- accept legacy/verifiers, OpenAI Chat Completions, OpenAI Responses, Anthropic, MCP, Gemini-compatible, and Pydantic-style inputs
- integrate normalization across every renderer and schema-aware response parser
- reject hosted, custom-text, namespace, shell, computer, and other non-function protocols with an explicit capability error
- preserve the existing Chat-style rendered token contract and legacy `ToolSpec(...)` construction
- document the supported provider shapes and export typed public helpers

## Why

Equivalent function tools use different wire schemas across providers. Renderers previously handled a mixture of flat and Chat-style definitions locally, so Responses, Anthropic, and MCP inputs could be rendered inconsistently or lose schema information during parsing. Normalizing once at the boundary keeps model-specific renderers provider-agnostic and makes unsupported execution protocols fail loudly instead of being silently misrepresented.

## Stack

This is stacked on #118 (`codex/freeze-golden-corpus`). The frozen golden corpus is unchanged by this PR.

## Validation

- `uv run ruff check .`
- `uv run ty check renderers` (exit 0; existing advisory diagnostics only)
- offline suite: 130 passed
- pinned text-model suite: 2,586 passed, 110 skipped, 1 expected failure
- pinned multimodal suite: 73 passed, 17 skipped
- focused provider-shape parity: 105 passed
- normalization and actual OpenAI SDK inputs: 41 passed
- `uv build`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Normalize provider tool specifications across all renderers
> - Adds a new [renderers/tools.py](https://github.com/PrimeIntellect-ai/renderers/pull/119/files#diff-7a6dca6f16768ba7db4e21aba4126ceb6f9e5f686da8b3fe1012689468a2b572) module that defines `normalize_tool_spec()` / `normalize_tool_specs()`, canonical types (`CanonicalToolSpec`, `FunctionSpec`, etc.), and error types (`ToolSpecError`, `UnsupportedToolSpecError`).
> - Applies `normalize_tool_specs()` at the start of every renderer's `render()` method and in the `_build_param_type_index` / `_extract_tool_names` parsing helpers, replacing ad hoc envelope-unwrapping.
> - Accepts tool shapes from OpenAI Chat Completions, OpenAI Responses API, Anthropic, MCP, and Pydantic-style model objects; normalizes all to a single canonical envelope.
> - Risk: renderers now raise `ToolSpecError` or `UnsupportedToolSpecError` for invalid or unsupported tool protocols, where they previously silently accepted arbitrary inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2b19413.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->