### PR TITLE
fix: render null message content as empty, not the literal string "None"

### DIFF
--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -96,7 +96,7 @@ class GLM45Renderer:
     @staticmethod
     def _visible_text(content: Any) -> str:
         if content is None:
-            return "None"
+            return ""
         if isinstance(content, str):
             return content
         if isinstance(content, list):

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -113,7 +113,7 @@ class GLM5Renderer:
     @staticmethod
     def _visible_text(content: Any) -> str:
         if content is None:
-            return "None"
+            return ""
         if isinstance(content, str):
             return content
         if isinstance(content, list):

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -90,7 +90,7 @@ class MiniMaxM2Renderer:
     @staticmethod
     def _visible_text(content: Any) -> str:
         if content is None:
-            return "None"
+            return ""
         if isinstance(content, str):
             return content
         if isinstance(content, list):

--- a/tests/test_render_ids.py
+++ b/tests/test_render_ids.py
@@ -188,6 +188,11 @@ def test_tool_call_with_content(model_name, tokenizer, renderer):
 
 
 def test_tool_call_no_content(model_name, tokenizer, renderer):
+    """Null content renders as empty. Templates that handle ``None`` sanely
+    keep byte parity as usual; templates that mishandle it — GLM-4.5/5 and
+    MiniMax-M2 Jinja-print the literal string "None", Qwen3-VL crashes
+    iterating it — get the intended divergence instead: the renderer output
+    must match the template fed ``content=""``."""
     msgs = [
         {"role": "user", "content": "Weather in Paris?"},
         {
@@ -198,29 +203,15 @@ def test_tool_call_no_content(model_name, tokenizer, renderer):
             ],
         },
     ]
+    rendered = renderer.render_ids(msgs, tools=TOOLS)
     try:
         expected = _expected(tokenizer, msgs, tools=TOOLS)
-    except TypeError as exc:
-        # Qwen3-VL upstream chat-template bug. The assistant branch only
-        # checks `is string` and then unconditionally iterates the else,
-        # so `content=None` raises TypeError on `for x in None`:
-        #
-        #   {%- if message.content is string %}
-        #       {{- message.content }}
-        #   {%- else %}
-        #       {%- for content_item in message.content %}   ← crash
-        #           {%- if 'text' in content_item %}
-        #               {{- content_item.text }}
-        #           ...
-        #
-        # Same pattern in the user-role branch. The fix upstream would be
-        # `{%- elif message.content %}` to skip iteration on falsy content.
-        # Until Qwen ships a fixed template this is xfail; the imperative
-        # xfail auto-promotes to xpass when upstream is fixed.
-        import pytest
-
-        pytest.xfail(f"{model_name}: apply_chat_template raised {exc!r}")
-    assert renderer.render_ids(msgs, tools=TOOLS) == expected
+    except TypeError:
+        expected = None  # template crashes on None content (Qwen3-VL)
+    if expected is not None and rendered == expected:
+        return
+    normalized = [dict(m, content=m["content"] or "") for m in msgs]
+    assert rendered == _expected(tokenizer, normalized, tools=TOOLS)
 
 
 def test_multiple_tool_calls(model_name, tokenizer, renderer):


### PR DESCRIPTION
## Bug

`GLM45Renderer`, `GLM5Renderer`, and `MiniMaxM2Renderer` render `content: None` as the **literal string `"None"`**. Since every OpenAI-shape assistant tool-call turn carries `content: None`, each such turn injects a spurious `None` line into the rendered text.

### Repro

```python
from transformers import AutoTokenizer
from renderers import GLM45RendererConfig, create_renderer

tok = AutoTokenizer.from_pretrained("zai-org/GLM-4.5-Air")
r = create_renderer(tok, GLM45RendererConfig())
out = r.render_ids(
    [
        {"role": "user", "content": "Weather in Paris?"},
        {"role": "assistant", "content": None,
         "tool_calls": [{"function": {"name": "get_weather", "arguments": {"city": "Paris"}}}]},
    ],
    tools=[{"type": "function", "function": {"name": "get_weather",
            "parameters": {"type": "object", "properties": {"city": {"type": "string"}}}}}],
)
print(repr(tok.decode(out.token_ids)))
```

Before (main):
```
…<|assistant|>\n<think></think>\nNone\n<tool_call>get_weather\n<arg_key>city</arg_key>…
```
After (this PR):
```
…<|assistant|>\n<think></think>\n<tool_call>get_weather\n<arg_key>city</arg_key>…
```

### Root cause

`_visible_text()` returns `"None"` for `None` — byte-faithful to the upstream zai template, whose `visible_text` macro hits the unguarded `{%- else -%}{{- content }}` branch (Jinja prints `None` as `None`) and whose assistant branch then emits it because `'None'.strip()` is truthy. So the template itself has the bug; the renderer inherited it via parity. `hy3.py` already rendered null as empty — the three renderers now match that.

### How it affected SFT

Found while debugging the GLM-4.5-Air SWE SFT run (research-prod `sft-air-swe`): the training set is 48k OpenAI-shape agentic trajectories, so **every assistant tool-call turn** (~dozens per trajectory, median 42 turns) trained the model on `…</think>\nNone\n<tool_call>…`. The reconstructed training sample:

```
Let me first look at the file in question.</think>
None
<tool_call>ipython
<arg_key>code</arg_key>
…
```

At eval the model occasionally reproduced the artifact (1/189 assistant messages in the step-300 eval traces emitted a literal `None` line). Wasted tokens and format noise on every tool-call turn of every GLM-rendered SFT run.

### Remaining skew (deliberate, flagged)

Serving-side, vLLM applies the upstream Jinja template, which still prints `None` for null-content history turns — so after this PR, training (renderer) and serving (template) diverge on that case until either the zai template guards null content or clients normalize `content: null → ""` in requests. The parity test encodes this intentionally: byte parity against `template(None)` where the template handles null sanely (e.g. Inkling skips the content block), and against `template("")` where it prints or crashes (GLM-4.5/5, MiniMax-M2 print; Qwen3-VL raises `TypeError`, previously an xfail).

## Tests

`tests/test_render_ids.py` (492 passed, 49 skipped) including `test_tool_call_no_content` across all 26 model×renderer pairs; `tests/test_glm_tool_name_validation.py` unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix null message content rendering as empty string in GLM and MiniMax renderers
> Updates `_visible_text` in three renderers to return `""` instead of the literal string `"None"` when message content is `None`.
>
> - [renderers/glm45.py](https://github.com/PrimeIntellect-ai/renderers/pull/131/files#diff-c7605da21d080370572a63b80ed0f2e821d86f004033eece0702403fa11d53cc), [renderers/glm5.py](https://github.com/PrimeIntellect-ai/renderers/pull/131/files#diff-ea815eabc68be7ad80142392cb15c63ca5771e7f55e029afeb81c15d776c7774), and [renderers/minimax_m2.py](https://github.com/PrimeIntellect-ai/renderers/pull/131/files#diff-1d3aced5d86b412c4801266d2e87657664a29c07479d0a4fa41d0f133cebf74a) all apply the same fix in their `_visible_text` utility
> - [tests/test_render_ids.py](https://github.com/PrimeIntellect-ai/renderers/pull/131/files#diff-0b8f7e7a23cd7ea8d46211339894c851d7a37d4dd64be2290f84c3888a747a81) replaces the `pytest.xfail` path with normalization that replaces falsy content with empty strings before asserting
> - Behavioral Change: messages with `None` content that previously rendered the literal text `"None"` now render as empty content across all three renderers
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4bf285.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->