### PR TITLE
Add raw multimodal content parts support

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -226,6 +226,7 @@ async def generate(
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
     max_prompt_len: int | None = None,
+    raw_multimodal: bool = False,
 ) -> dict[str, Any]:
     """Tokenize messages, call vLLM /inference/v1/generate, parse the response.
 
@@ -245,6 +246,9 @@ async def generate(
     sidecar, then serializes it to vLLM's ``features`` schema (mm_hashes,
     mm_placeholders, kwargs_data) before POSTing. The serializer imports
     ``vllm.*`` lazily so text-only consumers never pay for the import.
+    With ``raw_multimodal=True``, rendering skips image processing and the
+    request carries raw ``content_parts`` instead; vLLM must return the
+    expanded prompt as ``prompt_token_ids``.
 
     ``max_prompt_len`` controls the pre-flight overflow check. When the
     rendered prompt is strictly longer than the cap, the request is never
@@ -255,10 +259,14 @@ async def generate(
     cache a ``None`` cap and the pre-flight silently disables. Engine 4xx
     that still slip through propagate raw — converting them into a domain
     error is the calling client's job (its error shape is engine-specific).
+    Raw multimodal calls skip this pre-flight because only vLLM knows the
+    expanded prompt length.
 
-    Returns a dict with: request_id, prompt_ids, completion_ids,
-    completion_logprobs, content, reasoning_content, tool_calls,
-    finish_reason, routed_experts, multi_modal_data, prompt_attribution.
+    Returns a dict with: request_id, prompt_ids, renderer_prompt_ids,
+    completion_ids, completion_logprobs, content, reasoning_content,
+    tool_calls, finish_reason, routed_experts, multi_modal_data,
+    prompt_attribution. ``renderer_prompt_ids`` is the unexpanded logical
+    prompt on raw multimodal calls and ``None`` otherwise.
 
     ``prompt_attribution`` is the renderer's :class:`RenderedTokens` for
     the prompt — either the one this call computed via
@@ -289,7 +297,15 @@ async def generate(
                 multi_modal_data,
                 prompt_attribution,
             )
-        rendered = renderer.render(messages, tools=tools, add_generation_prompt=True)
+        render_kwargs: dict[str, Any] = {}
+        if raw_multimodal:
+            render_kwargs["process_multimodal"] = False
+        rendered = renderer.render(
+            messages,
+            tools=tools,
+            add_generation_prompt=True,
+            **render_kwargs,
+        )
         return (
             rendered.token_ids,
             renderer.get_stop_token_ids(),
@@ -301,12 +317,13 @@ async def generate(
         renderer, _prepare
     )
 
-    if max_prompt_len is None:
-        max_prompt_len = await _resolve_max_prompt_len(client, model)
-    if max_prompt_len is not None and len(prompt_ids) > max_prompt_len:
-        raise OverlongPromptError(
-            prompt_len=len(prompt_ids), max_prompt_len=max_prompt_len
-        )
+    if not raw_multimodal:
+        if max_prompt_len is None:
+            max_prompt_len = await _resolve_max_prompt_len(client, model)
+        if max_prompt_len is not None and len(prompt_ids) > max_prompt_len:
+            raise OverlongPromptError(
+                prompt_len=len(prompt_ids), max_prompt_len=max_prompt_len
+            )
 
     sp: dict[str, Any] = dict(sampling_params or {})
     sp["stop_token_ids"] = stop_token_ids
@@ -318,11 +335,14 @@ async def generate(
         "token_ids": prompt_ids,
         "sampling_params": sp,
     }
+    content_parts = _content_parts(messages) if raw_multimodal else None
     features = (
         _build_mm_features(renderer, mm_data)
-        if mm_data and not mm_data.is_empty()
+        if not raw_multimodal and mm_data and not mm_data.is_empty()
         else None
     )
+    if content_parts:
+        body["content_parts"] = content_parts
     if features is not None:
         body["features"] = features
     if cache_salt is not None:
@@ -352,6 +372,11 @@ async def generate(
 
     choice = (data.get("choices") or [{}])[0]
     completion_ids = choice.get("token_ids") or []
+    effective_prompt_ids = data.get("prompt_token_ids")
+    if content_parts and not isinstance(effective_prompt_ids, list):
+        raise MalformedGenerateResponseError(
+            "Engine response must include prompt_token_ids for raw multimodal input."
+        )
 
     completion_logprobs = _parse_completion_logprobs(choice, completion_ids)
 
@@ -379,7 +404,8 @@ async def generate(
 
     return {
         "request_id": data.get("request_id") or "",
-        "prompt_ids": list(prompt_ids),
+        "prompt_ids": list(effective_prompt_ids or prompt_ids),
+        "renderer_prompt_ids": list(prompt_ids) if content_parts else None,
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
         "content": parsed.content,
@@ -401,6 +427,27 @@ async def generate(
         # when the caller passed prompt_ids without attribution.
         "prompt_attribution": prompt_attr,
     }
+
+
+def _content_parts(messages: list[Message]) -> list[dict[str, Any]]:
+    """Flatten raw media in prompt order for vLLM's token generate endpoint."""
+    parts: list[dict[str, Any]] = []
+    for message in messages:
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, Mapping):
+                continue
+            part_type = part.get("type")
+            if part_type not in ("image_url", "audio_url", "video_url"):
+                continue
+            source = part.get(part_type)
+            url = source.get("url") if isinstance(source, Mapping) else part.get("url")
+            if not isinstance(url, str) or not url:
+                raise ValueError(f"{part_type} content part is missing a URL")
+            parts.append({"type": part_type, "url": url})
+    return parts
 
 
 def _build_mm_features(

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -244,10 +244,11 @@ async def generate(
     vLLM knows the expanded prompt length.
 
     Returns a dict with: request_id, prompt_ids, renderer_prompt_ids,
-    completion_ids, completion_logprobs, content, reasoning_content,
-    tool_calls, finish_reason, routed_experts, multi_modal_data,
-    prompt_attribution. ``renderer_prompt_ids`` is the unexpanded logical
-    prompt when ``process_multimodal=False`` and ``None`` otherwise.
+    mm_placeholders, completion_ids, completion_logprobs, content,
+    reasoning_content, tool_calls, finish_reason, routed_experts,
+    multi_modal_data, prompt_attribution. ``renderer_prompt_ids`` is the
+    unexpanded logical prompt when ``process_multimodal=False`` and ``None``
+    otherwise.
 
     ``prompt_attribution`` is the renderer's :class:`RenderedTokens` for
     the prompt — either the one this call computed via
@@ -362,6 +363,11 @@ async def generate(
         raise MalformedGenerateResponseError(
             "Engine response must include prompt_token_ids when process_multimodal=False."
         )
+    mm_placeholders = data.get("mm_placeholders")
+    if content_parts and not isinstance(mm_placeholders, dict):
+        raise MalformedGenerateResponseError(
+            "Engine response must include mm_placeholders when process_multimodal=False."
+        )
 
     completion_logprobs = _parse_completion_logprobs(choice, completion_ids)
 
@@ -389,6 +395,7 @@ async def generate(
         "request_id": data.get("request_id") or "",
         "prompt_ids": list(effective_prompt_ids or prompt_ids),
         "renderer_prompt_ids": list(prompt_ids) if content_parts else None,
+        "mm_placeholders": mm_placeholders,
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
         "content": parsed.content,

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -240,14 +240,14 @@ async def generate(
     cache a ``None`` cap and the pre-flight silently disables. Engine 4xx
     that still slip through propagate raw — converting them into a domain
     error is the calling client's job (its error shape is engine-specific).
-    Unprocessed multimodal calls skip this pre-flight because only vLLM knows
-    the expanded prompt length.
+    Calls with ``process_multimodal=False`` skip this pre-flight because only
+    vLLM knows the expanded prompt length.
 
     Returns a dict with: request_id, prompt_ids, renderer_prompt_ids,
     completion_ids, completion_logprobs, content, reasoning_content,
     tool_calls, finish_reason, routed_experts, multi_modal_data,
     prompt_attribution. ``renderer_prompt_ids`` is the unexpanded logical
-    prompt on raw multimodal calls and ``None`` otherwise.
+    prompt when ``process_multimodal=False`` and ``None`` otherwise.
 
     ``prompt_attribution`` is the renderer's :class:`RenderedTokens` for
     the prompt — either the one this call computed via
@@ -267,10 +267,10 @@ async def generate(
             "Choose a model-specific renderer instead of the default fallback."
         )
     if not process_multimodal and not getattr(
-        renderer, "supports_deferred_multimodal_processing", False
+        renderer, "supports_process_multimodal", False
     ):
         raise NotImplementedError(
-            f"{type(renderer).__name__} does not support deferred multimodal processing"
+            f"{type(renderer).__name__} does not support process_multimodal=False"
         )
 
     def _prepare():
@@ -360,7 +360,7 @@ async def generate(
     effective_prompt_ids = data.get("prompt_token_ids")
     if content_parts and not isinstance(effective_prompt_ids, list):
         raise MalformedGenerateResponseError(
-            "Engine response must include prompt_token_ids for unprocessed multimodal input."
+            "Engine response must include prompt_token_ids when process_multimodal=False."
         )
 
     completion_logprobs = _parse_completion_logprobs(choice, completion_ids)

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -207,7 +207,7 @@ async def generate(
     priority: int | None = None,
     extra_headers: dict[str, str] | None = None,
     max_prompt_len: int | None = None,
-    raw_multimodal: bool = False,
+    process_multimodal: bool = True,
 ) -> dict[str, Any]:
     """Tokenize messages, call vLLM /inference/v1/generate, parse the response.
 
@@ -227,8 +227,8 @@ async def generate(
     sidecar, then serializes it to vLLM's ``features`` schema (mm_hashes,
     mm_placeholders, kwargs_data) before POSTing. The serializer imports
     ``vllm.*`` lazily so text-only consumers never pay for the import.
-    With ``raw_multimodal=True``, rendering skips image processing and the
-    request carries raw ``content_parts`` instead; vLLM must return the
+    With ``process_multimodal=False``, rendering skips image processing and
+    the request carries ``content_parts`` instead; vLLM must return the
     expanded prompt as ``prompt_token_ids``.
 
     ``max_prompt_len`` controls the pre-flight overflow check. When the
@@ -240,8 +240,8 @@ async def generate(
     cache a ``None`` cap and the pre-flight silently disables. Engine 4xx
     that still slip through propagate raw — converting them into a domain
     error is the calling client's job (its error shape is engine-specific).
-    Raw multimodal calls skip this pre-flight because only vLLM knows the
-    expanded prompt length.
+    Unprocessed multimodal calls skip this pre-flight because only vLLM knows
+    the expanded prompt length.
 
     Returns a dict with: request_id, prompt_ids, renderer_prompt_ids,
     completion_ids, completion_logprobs, content, reasoning_content,
@@ -266,6 +266,12 @@ async def generate(
             f"{type(renderer).__name__} does not support tools. "
             "Choose a model-specific renderer instead of the default fallback."
         )
+    if not process_multimodal and not getattr(
+        renderer, "supports_deferred_multimodal_processing", False
+    ):
+        raise NotImplementedError(
+            f"{type(renderer).__name__} does not support deferred multimodal processing"
+        )
 
     def _prepare():
         if prompt_ids is not None:
@@ -279,7 +285,7 @@ async def generate(
                 prompt_attribution,
             )
         render_kwargs: dict[str, Any] = {}
-        if raw_multimodal:
+        if not process_multimodal:
             render_kwargs["process_multimodal"] = False
         rendered = renderer.render(
             messages,
@@ -296,7 +302,7 @@ async def generate(
 
     prompt_ids, stop_token_ids, mm_data, prompt_attr = _prepare()
 
-    if not raw_multimodal:
+    if process_multimodal:
         if max_prompt_len is None:
             max_prompt_len = await _resolve_max_prompt_len(client, model)
         if max_prompt_len is not None and len(prompt_ids) > max_prompt_len:
@@ -314,10 +320,10 @@ async def generate(
         "token_ids": prompt_ids,
         "sampling_params": sp,
     }
-    content_parts = _content_parts(messages) if raw_multimodal else None
+    content_parts = _content_parts(messages) if not process_multimodal else None
     features = (
         _build_mm_features(renderer, mm_data)
-        if not raw_multimodal and mm_data and not mm_data.is_empty()
+        if process_multimodal and mm_data and not mm_data.is_empty()
         else None
     )
     if content_parts:
@@ -354,7 +360,7 @@ async def generate(
     effective_prompt_ids = data.get("prompt_token_ids")
     if content_parts and not isinstance(effective_prompt_ids, list):
         raise MalformedGenerateResponseError(
-            "Engine response must include prompt_token_ids for raw multimodal input."
+            "Engine response must include prompt_token_ids for unprocessed multimodal input."
         )
 
     completion_logprobs = _parse_completion_logprobs(choice, completion_ids)

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -412,6 +412,16 @@ async def generate(
     }
 
 
+_MEDIA_URL_TYPES = {
+    "image": "image_url",
+    "image_url": "image_url",
+    "audio": "audio_url",
+    "audio_url": "audio_url",
+    "video": "video_url",
+    "video_url": "video_url",
+}
+
+
 def _content_parts(messages: list[Message]) -> list[dict[str, Any]]:
     """Flatten raw media in prompt order for vLLM's token generate endpoint."""
     parts: list[dict[str, Any]] = []
@@ -423,13 +433,19 @@ def _content_parts(messages: list[Message]) -> list[dict[str, Any]]:
             if not isinstance(part, Mapping):
                 continue
             part_type = part.get("type")
-            if part_type not in ("image_url", "audio_url", "video_url"):
+            if part_type is None:
+                part_type = next(
+                    (key for key in _MEDIA_URL_TYPES if part.get(key)), None
+                )
+            if not isinstance(part_type, str) or part_type not in _MEDIA_URL_TYPES:
                 continue
             source = part.get(part_type)
-            url = source.get("url") if isinstance(source, Mapping) else part.get("url")
+            if source is None:
+                source = part.get(_MEDIA_URL_TYPES[part_type]) or part.get("url")
+            url = source.get("url") if isinstance(source, Mapping) else source
             if not isinstance(url, str) or not url:
                 raise ValueError(f"{part_type} content part is missing a URL")
-            parts.append({"type": part_type, "url": url})
+            parts.append({"type": _MEDIA_URL_TYPES[part_type], "url": url})
     return parts
 
 

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -590,7 +590,7 @@ class KimiK25Renderer:
     The tokenizer should be ``moonshotai/Kimi-K2-Instruct`` (same as K2).
     """
 
-    supports_deferred_multimodal_processing = True
+    supports_process_multimodal = True
 
     def __init__(
         self,

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -590,6 +590,8 @@ class KimiK25Renderer:
     The tokenizer should be ``moonshotai/Kimi-K2-Instruct`` (same as K2).
     """
 
+    supports_raw_multimodal = True
+
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer,
@@ -733,6 +735,7 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        process_multimodal: bool = True,
     ) -> RenderedTokens:
         """Render messages to tokens, matching the K2.5 chat template.
 
@@ -820,7 +823,10 @@ class KimiK25Renderer:
             ``<|media_content|>``, ``<|media_end|>``, the trailing
             ``\\n``) are template-injected scaffold.
             """
-            _, out, _num_patches, h = self._process_image(part)
+            if process_multimodal:
+                _, out, _num_patches, h = self._process_image(part)
+            else:
+                out = h = None
             emit_special(
                 self._media_begin, msg_idx, is_sampled=is_sampled, is_content=False
             )
@@ -839,6 +845,9 @@ class KimiK25Renderer:
                 self._media_end, msg_idx, is_sampled=is_sampled, is_content=False
             )
             emit_text("\n", msg_idx, is_sampled=is_sampled, is_content=False)
+            if not process_multimodal:
+                return
+            assert out is not None and h is not None
             mm_hashes.setdefault("image", []).append(h)
             mm_placeholders.setdefault("image", []).append(
                 PlaceholderRange(offset=offset, length=1)
@@ -1026,6 +1035,7 @@ class KimiK25Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         previous_multi_modal_data: MultiModalData | None = None,
+        process_multimodal: bool = True,
     ) -> "RenderedTokens | None":
         if (
             not previous_prompt_ids
@@ -1114,7 +1124,10 @@ class KimiK25Renderer:
             is_sampled: bool = False,
             is_content: bool = False,
         ) -> None:
-            _, out, _num_patches, h = self._process_image(part)
+            if process_multimodal:
+                _, out, _num_patches, h = self._process_image(part)
+            else:
+                out = h = None
             emit_special(self._media_begin, msg_idx)
             emit_text("image", msg_idx)
             emit_special(self._media_content, msg_idx)
@@ -1124,6 +1137,9 @@ class KimiK25Renderer:
             emit_special(self._media_pad, msg_idx, is_content=is_content)
             emit_special(self._media_end, msg_idx)
             emit_text("\n", msg_idx)
+            if not process_multimodal:
+                return
+            assert out is not None and h is not None
             new_hashes.setdefault("image", []).append(h)
             new_placeholders.setdefault("image", []).append(
                 PlaceholderRange(offset=offset, length=1)
@@ -1187,17 +1203,17 @@ class KimiK25Renderer:
         # below never mutates the caller's previous_multi_modal_data.
         merged_hashes: dict[str, list[str]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_placeholders: dict[str, list[PlaceholderRange]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_items: dict[str, list[dict[str, Any]]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         for modality, vals in new_hashes.items():

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -590,7 +590,7 @@ class KimiK25Renderer:
     The tokenizer should be ``moonshotai/Kimi-K2-Instruct`` (same as K2).
     """
 
-    supports_raw_multimodal = True
+    supports_deferred_multimodal_processing = True
 
     def __init__(
         self,

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -121,6 +121,7 @@ def _default_enable_thinking(tokenizer) -> bool:
 class Qwen35Renderer:
     """Deterministic message → token renderer for Qwen3.5 models."""
 
+    supports_raw_multimodal = True
     _config_cls: type = Qwen35RendererConfig
 
     def __init__(
@@ -352,6 +353,7 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        process_multimodal: bool = True,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -423,7 +425,11 @@ class Qwen35Renderer:
             # image data, so they ARE body content (is_content=True);
             # the surrounding ``<|vision_start|>`` / ``<|vision_end|>``
             # specials are template scaffold.
-            _, out, n, h = self._process_image(part)
+            if process_multimodal:
+                _, out, n, h = self._process_image(part)
+            else:
+                out = h = None
+                n = 1
             vision_counts["image"] += 1
             if self.config.add_vision_id:
                 emit_text(
@@ -441,16 +447,18 @@ class Qwen35Renderer:
                     self._image_pad, msg_idx, is_sampled=False, is_content=True
                 )
             emit_special(self._vision_end, msg_idx, is_sampled=False, is_content=False)
-            mm_hashes.setdefault("image", []).append(h)
-            mm_placeholders.setdefault("image", []).append(
-                PlaceholderRange(offset=offset, length=n)
-            )
-            mm_items.setdefault("image", []).append(
-                {
-                    "pixel_values": out["pixel_values"],
-                    "image_grid_thw": out["image_grid_thw"],
-                }
-            )
+            if process_multimodal:
+                assert out is not None and h is not None
+                mm_hashes.setdefault("image", []).append(h)
+                mm_placeholders.setdefault("image", []).append(
+                    PlaceholderRange(offset=offset, length=n)
+                )
+                mm_items.setdefault("image", []).append(
+                    {
+                        "pixel_values": out["pixel_values"],
+                        "image_grid_thw": out["image_grid_thw"],
+                    }
+                )
 
         def emit_user_with_media(content_list: list[Any], msg_idx: int) -> None:
             """Emit a user message whose content list contains image parts.
@@ -684,6 +692,7 @@ class Qwen35Renderer:
         *,
         tools: list[ToolSpec] | None = None,
         previous_multi_modal_data: MultiModalData | None = None,
+        process_multimodal: bool = True,
     ) -> "RenderedTokens | None":
         if (
             not previous_prompt_ids
@@ -720,6 +729,7 @@ class Qwen35Renderer:
         # scratch correctly.
         if (
             self.config.add_vision_id
+            and process_multimodal
             and previous_multi_modal_data is None
             and self._vision_start in previous_ids
         ):
@@ -750,9 +760,11 @@ class Qwen35Renderer:
         # ``add_vision_id`` parity across turns.
         prev_image_count = 0
         prev_video_count = 0
-        if previous_multi_modal_data is not None:
+        if process_multimodal and previous_multi_modal_data is not None:
             prev_image_count = len(previous_multi_modal_data.mm_items.get("image", []))
             prev_video_count = len(previous_multi_modal_data.mm_items.get("video", []))
+        elif not process_multimodal:
+            prev_image_count = previous_ids.count(self._image_pad)
         vision_counts = {"image": prev_image_count, "video": prev_video_count}
 
         def emit_special(
@@ -795,7 +807,11 @@ class Qwen35Renderer:
                 content_mask.append(is_content)
 
         def emit_image(part: dict[str, Any], msg_idx: int = -1) -> None:
-            _, out, n, h = self._process_image(part)
+            if process_multimodal:
+                _, out, n, h = self._process_image(part)
+            else:
+                out = h = None
+                n = 1
             vision_counts["image"] += 1
             if self.config.add_vision_id:
                 emit_text(f"Picture {vision_counts['image']}: ", msg_idx)
@@ -804,16 +820,18 @@ class Qwen35Renderer:
             for _ in range(n):
                 emit_special(self._image_pad, msg_idx, is_content=True)
             emit_special(self._vision_end, msg_idx)
-            new_hashes.setdefault("image", []).append(h)
-            new_placeholders.setdefault("image", []).append(
-                PlaceholderRange(offset=offset, length=n)
-            )
-            new_items.setdefault("image", []).append(
-                {
-                    "pixel_values": out["pixel_values"],
-                    "image_grid_thw": out["image_grid_thw"],
-                }
-            )
+            if process_multimodal:
+                assert out is not None and h is not None
+                new_hashes.setdefault("image", []).append(h)
+                new_placeholders.setdefault("image", []).append(
+                    PlaceholderRange(offset=offset, length=n)
+                )
+                new_items.setdefault("image", []).append(
+                    {
+                        "pixel_values": out["pixel_values"],
+                        "image_grid_thw": out["image_grid_thw"],
+                    }
+                )
 
         def emit_user_with_media(content_list: list[Any], msg_idx: int) -> None:
             emit_special(self._im_start, msg_idx)
@@ -904,17 +922,17 @@ class Qwen35Renderer:
         # below never mutates the caller's previous_multi_modal_data.
         merged_hashes: dict[str, list[str]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_placeholders: dict[str, list[PlaceholderRange]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_items: dict[str, list[dict[str, Any]]] = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         for modality, vals in new_hashes.items():

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -122,7 +122,7 @@ def _default_enable_thinking(tokenizer) -> bool:
 class Qwen35Renderer:
     """Deterministic message → token renderer for Qwen3.5 models."""
 
-    supports_raw_multimodal = True
+    supports_deferred_multimodal_processing = True
     _config_cls: type = Qwen35RendererConfig
 
     def __init__(

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -122,7 +122,7 @@ def _default_enable_thinking(tokenizer) -> bool:
 class Qwen35Renderer:
     """Deterministic message → token renderer for Qwen3.5 models."""
 
-    supports_deferred_multimodal_processing = True
+    supports_process_multimodal = True
     _config_cls: type = Qwen35RendererConfig
 
     def __init__(

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -309,7 +309,7 @@ class Qwen3VLRenderer:
     ``thinking_retention`` still controls whether the bridge is attempted.
     """
 
-    supports_deferred_multimodal_processing = True
+    supports_process_multimodal = True
 
     def __init__(
         self,

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -309,6 +309,8 @@ class Qwen3VLRenderer:
     ``thinking_retention`` still controls whether the bridge is attempted.
     """
 
+    supports_raw_multimodal = True
+
     def __init__(
         self,
         tokenizer: PreTrainedTokenizer,
@@ -457,6 +459,7 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
+        process_multimodal: bool = True,
     ) -> RenderedTokens:
         if not messages:
             raise ValueError("No messages provided.")
@@ -480,7 +483,11 @@ class Qwen3VLRenderer:
             # image data, so they ARE body content (is_content=True);
             # the surrounding ``<|vision_start|>`` / ``<|vision_end|>``
             # markers are renderer-emitted scaffold.
-            _, out, n, h = self._process_image(part)
+            if process_multimodal:
+                _, out, n, h = self._process_image(part)
+            else:
+                out = h = None
+                n = 1
             vision_counts["image"] += 1
             if self.config.add_vision_id:
                 em.text(
@@ -493,16 +500,18 @@ class Qwen3VLRenderer:
             for _ in range(n):
                 em.special(self._image_pad, is_sampled=False, is_content=True)
             em.special(self._vision_end, is_sampled=False, is_content=False)
-            mm_hashes.setdefault("image", []).append(h)
-            mm_placeholders.setdefault("image", []).append(
-                PlaceholderRange(offset=offset, length=n)
-            )
-            mm_items.setdefault("image", []).append(
-                {
-                    "pixel_values": out["pixel_values"],
-                    "image_grid_thw": out["image_grid_thw"],
-                }
-            )
+            if process_multimodal:
+                assert out is not None and h is not None
+                mm_hashes.setdefault("image", []).append(h)
+                mm_placeholders.setdefault("image", []).append(
+                    PlaceholderRange(offset=offset, length=n)
+                )
+                mm_items.setdefault("image", []).append(
+                    {
+                        "pixel_values": out["pixel_values"],
+                        "image_grid_thw": out["image_grid_thw"],
+                    }
+                )
 
         def render_media_content(content: Any) -> None:
             """Emit a user/tool content list with media handled inline.
@@ -665,6 +674,7 @@ class Qwen3VLRenderer:
         *,
         tools: list[ToolSpec] | None = None,
         previous_multi_modal_data: MultiModalData | None = None,
+        process_multimodal: bool = True,
     ) -> "RenderedTokens | None":
         """Extend the prior turn with ``new_messages``.
 
@@ -709,6 +719,7 @@ class Qwen3VLRenderer:
         # correctly.
         if (
             self.config.add_vision_id
+            and process_multimodal
             and previous_multi_modal_data is None
             and self._vision_start in previous_ids
         ):
@@ -746,13 +757,19 @@ class Qwen3VLRenderer:
         # ``add_vision_id`` parity across turns.
         prev_image_count = 0
         prev_video_count = 0
-        if previous_multi_modal_data is not None:
+        if process_multimodal and previous_multi_modal_data is not None:
             prev_image_count = len(previous_multi_modal_data.mm_items.get("image", []))
             prev_video_count = len(previous_multi_modal_data.mm_items.get("video", []))
+        elif not process_multimodal:
+            prev_image_count = previous_ids.count(self._image_pad)
         vision_counts = {"image": prev_image_count, "video": prev_video_count}
 
         def emit_image(part: dict[str, Any]) -> None:
-            _, out, n, h = self._process_image(part)
+            if process_multimodal:
+                _, out, n, h = self._process_image(part)
+            else:
+                out = h = None
+                n = 1
             vision_counts["image"] += 1
             if self.config.add_vision_id:
                 em.text(
@@ -765,16 +782,18 @@ class Qwen3VLRenderer:
             for _ in range(n):
                 em.special(self._image_pad, is_sampled=False, is_content=True)
             em.special(self._vision_end, is_sampled=False, is_content=False)
-            new_hashes.setdefault("image", []).append(h)
-            new_placeholders.setdefault("image", []).append(
-                PlaceholderRange(offset=offset, length=n)
-            )
-            new_items.setdefault("image", []).append(
-                {
-                    "pixel_values": out["pixel_values"],
-                    "image_grid_thw": out["image_grid_thw"],
-                }
-            )
+            if process_multimodal:
+                assert out is not None and h is not None
+                new_hashes.setdefault("image", []).append(h)
+                new_placeholders.setdefault("image", []).append(
+                    PlaceholderRange(offset=offset, length=n)
+                )
+                new_items.setdefault("image", []).append(
+                    {
+                        "pixel_values": out["pixel_values"],
+                        "image_grid_thw": out["image_grid_thw"],
+                    }
+                )
 
         def render_media_content(content: Any) -> None:
             if isinstance(content, str):
@@ -833,17 +852,17 @@ class Qwen3VLRenderer:
         # caller's previous_multi_modal_data.
         merged_hashes = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_hashes.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_placeholders = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_placeholders.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         merged_items = (
             {k: list(v) for k, v in previous_multi_modal_data.mm_items.items()}
-            if previous_multi_modal_data
+            if process_multimodal and previous_multi_modal_data
             else {}
         )
         for modality, vals in new_hashes.items():

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -309,7 +309,7 @@ class Qwen3VLRenderer:
     ``thinking_retention`` still controls whether the bridge is attempted.
     """
 
-    supports_raw_multimodal = True
+    supports_deferred_multimodal_processing = True
 
     def __init__(
         self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -95,6 +95,7 @@ class _FakeClient:
         }
         if body and body.get("content_parts"):
             payload["prompt_token_ids"] = [1, 2, 2, 3]
+            payload["mm_placeholders"] = {"image": [{"offset": 1, "length": 2}]}
         return httpx.Response(
             200,
             content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
@@ -224,6 +225,7 @@ def test_generate_process_multimodal_false_sends_content_parts():
     assert "features" not in body
     assert result["renderer_prompt_ids"] == [1, 2, 3]
     assert result["prompt_ids"] == [1, 2, 2, 3]
+    assert result["mm_placeholders"] == {"image": [{"offset": 1, "length": 2}]}
 
 
 def test_generate_rejects_missing_completion_logprobs_before_parsing():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from renderers.base import (
     RenderedTokens,
     ToolCallParseStatus,
 )
-from renderers.client import _content_parts, generate
+from renderers.client import generate
 
 
 class _FakeRenderer:
@@ -224,35 +224,6 @@ def test_generate_process_multimodal_false_sends_content_parts():
     assert "features" not in body
     assert result["renderer_prompt_ids"] == [1, 2, 3]
     assert result["prompt_ids"] == [1, 2, 2, 3]
-
-
-@pytest.mark.parametrize(
-    ("media_part", "expected_part"),
-    [
-        (
-            {"type": "image_url", "image_url": "data:image/png;base64,aW1hZ2U="},
-            {"type": "image_url", "url": "data:image/png;base64,aW1hZ2U="},
-        ),
-        (
-            {"type": "image", "image": "data:image/png;base64,aW1hZ2U="},
-            {"type": "image_url", "url": "data:image/png;base64,aW1hZ2U="},
-        ),
-        (
-            {"type": "video", "video": "https://example.com/video.mp4"},
-            {"type": "video_url", "url": "https://example.com/video.mp4"},
-        ),
-    ],
-)
-def test_content_parts_normalizes_url_media(media_part, expected_part):
-    messages = [{"role": "user", "content": [media_part]}]
-    assert _content_parts(messages) == [expected_part]
-
-
-def test_content_parts_rejects_non_url_media():
-    with pytest.raises(ValueError, match="image content part is missing a URL"):
-        _content_parts(
-            [{"role": "user", "content": [{"type": "image", "image": object()}]}]
-        )
 
 
 def test_generate_rejects_missing_completion_logprobs_before_parsing():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -184,9 +184,9 @@ def test_generate_builds_request_body_and_parses_response():
     assert tc.status == ToolCallParseStatus.OK
 
 
-def test_generate_sends_unprocessed_content_parts_and_returns_effective_prompt_ids():
+def test_generate_process_multimodal_false_sends_content_parts():
     class DeferredMultimodalRenderer(_FakeRenderer):
-        supports_deferred_multimodal_processing = True
+        supports_process_multimodal = True
 
         def render(
             self,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,7 +12,7 @@ from renderers.base import (
     RenderedTokens,
     ToolCallParseStatus,
 )
-from renderers.client import generate
+from renderers.client import _content_parts, generate
 
 
 class _FakeRenderer:
@@ -224,6 +224,35 @@ def test_generate_process_multimodal_false_sends_content_parts():
     assert "features" not in body
     assert result["renderer_prompt_ids"] == [1, 2, 3]
     assert result["prompt_ids"] == [1, 2, 2, 3]
+
+
+@pytest.mark.parametrize(
+    ("media_part", "expected_part"),
+    [
+        (
+            {"type": "image_url", "image_url": "data:image/png;base64,aW1hZ2U="},
+            {"type": "image_url", "url": "data:image/png;base64,aW1hZ2U="},
+        ),
+        (
+            {"type": "image", "image": "data:image/png;base64,aW1hZ2U="},
+            {"type": "image_url", "url": "data:image/png;base64,aW1hZ2U="},
+        ),
+        (
+            {"type": "video", "video": "https://example.com/video.mp4"},
+            {"type": "video_url", "url": "https://example.com/video.mp4"},
+        ),
+    ],
+)
+def test_content_parts_normalizes_url_media(media_part, expected_part):
+    messages = [{"role": "user", "content": [media_part]}]
+    assert _content_parts(messages) == [expected_part]
+
+
+def test_content_parts_rejects_non_url_media():
+    with pytest.raises(ValueError, match="image content part is missing a URL"):
+        _content_parts(
+            [{"role": "user", "content": [{"type": "image", "image": object()}]}]
+        )
 
 
 def test_generate_rejects_missing_completion_logprobs_before_parsing():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -184,8 +184,10 @@ def test_generate_builds_request_body_and_parses_response():
     assert tc.status == ToolCallParseStatus.OK
 
 
-def test_generate_sends_raw_content_parts_and_returns_effective_prompt_ids():
-    class RawRenderer(_FakeRenderer):
+def test_generate_sends_unprocessed_content_parts_and_returns_effective_prompt_ids():
+    class DeferredMultimodalRenderer(_FakeRenderer):
+        supports_deferred_multimodal_processing = True
+
         def render(
             self,
             messages,
@@ -202,7 +204,7 @@ def test_generate_sends_raw_content_parts_and_returns_effective_prompt_ids():
     result = asyncio.run(
         generate(
             client=client,
-            renderer=RawRenderer(),
+            renderer=DeferredMultimodalRenderer(),
             messages=[
                 {
                     "role": "user",
@@ -213,7 +215,7 @@ def test_generate_sends_raw_content_parts_and_returns_effective_prompt_ids():
                 }
             ],
             model="test-model",
-            raw_multimodal=True,
+            process_multimodal=False,
         )
     )
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -93,6 +93,8 @@ class _FakeClient:
             "request_id": "gen-test",
             "choices": [self.choice],
         }
+        if body and body.get("content_parts"):
+            payload["prompt_token_ids"] = [1, 2, 2, 3]
         return httpx.Response(
             200,
             content=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
@@ -180,6 +182,46 @@ def test_generate_builds_request_body_and_parses_response():
     assert tc.name == "echo"
     assert tc.arguments == {"text": "hello"}
     assert tc.status == ToolCallParseStatus.OK
+
+
+def test_generate_sends_raw_content_parts_and_returns_effective_prompt_ids():
+    class RawRenderer(_FakeRenderer):
+        def render(
+            self,
+            messages,
+            *,
+            tools=None,
+            add_generation_prompt=False,
+            process_multimodal=True,
+        ):
+            assert process_multimodal is False
+            return RenderedTokens(token_ids=[1, 2, 3])
+
+    client = _FakeClient()
+    image_url = "data:image/png;base64,aW1hZ2U="
+    result = asyncio.run(
+        generate(
+            client=client,
+            renderer=RawRenderer(),
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "look"},
+                        {"type": "image_url", "image_url": {"url": image_url}},
+                    ],
+                }
+            ],
+            model="test-model",
+            raw_multimodal=True,
+        )
+    )
+
+    body = client.calls[0]["body"]
+    assert body["content_parts"] == [{"type": "image_url", "url": image_url}]
+    assert "features" not in body
+    assert result["renderer_prompt_ids"] == [1, 2, 3]
+    assert result["prompt_ids"] == [1, 2, 2, 3]
 
 
 def test_generate_rejects_missing_completion_logprobs_before_parsing():


### PR DESCRIPTION
## Summary

- use `process_multimodal=False` as the single opt-in for deferring image processing while preserving renderer-owned text and tool formatting
- send ordered raw media as content_parts to the vLLM token-generation endpoint
- normalize canonical, direct-URL, and native renderer media parts at that boundary
- use the effective prompt_token_ids returned by vLLM while retaining the logical renderer prompt for strict RL extension
- preserve the existing eager multimodal path by default, including SFT callers

## Stack

- Verifiers: https://github.com/PrimeIntellect-ai/verifiers/pull/2417
- Prime RL: https://github.com/PrimeIntellect-ai/prime-rl/pull/3320
- Upstream vLLM content-parts support: https://github.com/vllm-project/vllm/pull/51478

## Validation

- `uv run pytest -q tests/test_client.py` (21 passed, 5 skipped)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `process_multimodal` mode to defer media processing to engine in `client.generate`
> - `client.generate` gains a `process_multimodal` flag (default `True`). When `False`, it skips local feature building, sends media as raw `content_parts`, and expects the engine response to include `prompt_token_ids` and `mm_placeholders`.
> - A new `_content_parts` helper scans message content arrays and normalizes media parts into canonical `{type, url}` dicts, raising `ValueError` if a media part lacks a usable URL.
> - Renderers `KimiK25Renderer`, `Qwen35Renderer`, and `Qwen3VLRenderer` advertise `supports_process_multimodal = True` and accept `process_multimodal` in `render` (and `bridge_to_next_turn` for KimiK25). When `False`, they emit placeholder tokens without producing multimodal tensors.
> - Behavioral Change: callers passing `process_multimodal=False` to `client.generate` against a renderer without `supports_process_multimodal` get `NotImplementedError`; engine responses missing `prompt_token_ids` or `mm_placeholders` raise `MalformedGenerateResponseError`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d1bb692.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the vLLM generate request/response contract for multimodal RL paths and depends on engine support for content_parts and expanded prompt_token_ids; default eager path is unchanged.
> 
> **Overview**
> Adds **`process_multimodal`** (default `True`) on **`generate()`** and supported vision renderers so callers can keep renderer-owned text/tool formatting while **deferring image tensor work to vLLM**.
> 
> With **`process_multimodal=False`**, renderers emit placeholder tokens without **`_process_image`**, the client posts ordered media URLs as **`content_parts`** (via **`_content_parts`**) instead of **`features`**, and the **max prompt length** pre-flight is skipped. The response must include **`prompt_token_ids`** and **`mm_placeholders`**; results use the engine-expanded **`prompt_ids`**, expose **`renderer_prompt_ids`** for the logical prompt, and surface **`mm_placeholders`** for downstream RL bridging.
> 
> **Kimi K25**, **Qwen3.5**, and **Qwen3-VL** declare **`supports_process_multimodal`** and thread the flag through **`render`** and **`bridge_to_next_turn`** (including vision-id counting from pad tokens when mm metadata is omitted). The eager multimodal path and default **`generate()`** behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1bb692cf1622398e9aa88bc2898a7fd3bf3d03f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Latest main sync (2026-08-28)

- Merged `main` through `ef49eb9`.
- Validation: `uv run --locked pytest -q tests/test_client.py` (21 passed, 5 skipped) and Ruff passed.
- Removed the redundant `raw_multimodal` flag; `process_multimodal` now controls rendering and request materialization end-to-end.

## Naming cleanup

- Renamed the capability to `supports_process_multimodal` and normalized the client documentation around `process_multimodal=False`.
- `tests/test_client.py` (21 passed, 5 skipped) and Ruff passed.

## Authoritative multimodal ranges

- Require and forward vLLM `mm_placeholders` alongside expanded `prompt_token_ids` when image processing is deferred.
- This gives downstream consumers exact effective-prompt spans without inferring them from token patterns.
- Validation: `uv run pytest -q tests/test_client.py` (21 passed, 5 skipped); Ruff passed.