### PR TITLE
ci: bump pypa/gh-action-pypi-publish to v1.14.2 for metadata 2.5

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -62,6 +62,6 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           skip-existing: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,4 +87,4 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Why

The Publish Dev run on `main` @ 1a5bd3b failed at the **Publish to PyPI** step:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

Hatchling (unpinned in `build-system.requires`) now emits core packaging metadata **v2.5**, which the Twine bundled in gh-action-pypi-publish v1.14.0 rejects. The release `publish.yml` builds the same way, so the next `renderers-v*` tag would fail identically.

## Fix

Bump the SHA pin in both `publish.yml` and `publish-dev.yml` to **v1.14.2** (`dc37677`), which bundles Twine v7 with metadata 2.5 support ([release notes](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2)).

This unblocks the v0.1.10 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency pin on the publish step; no application or packaging logic changes beyond restoring successful PyPI uploads.
> 
> **Overview**
> **Bumps the SHA-pinned `pypa/gh-action-pypi-publish` action from v1.14.0 to v1.14.2** in both `publish-dev.yml` and `publish.yml`.
> 
> This fixes PyPI publish failures where builds produced by current Hatchling emit **core metadata v2.5**, which the Twine bundled in v1.14.0 rejects (`InvalidDistribution: '2.5' is not a valid metadata version`). v1.14.2 ships Twine v7 with metadata 2.5 support, so dev publishes on `main` and tagged `renderers-v*` releases can upload again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5b613c35ab27c85cc9de4c4352a01fba5785213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump `pypa/gh-action-pypi-publish` to v1.14.2 in publish workflows
> Updates the pinned action SHA from v1.14.0 to v1.14.2 in both [publish-dev.yml](https://github.com/PrimeIntellect-ai/renderers/pull/135/files#diff-53797140b1d5a48050381dfef00e662c847e9a11c76d8c828b5ce310a1e13ca5) and [publish.yml](https://github.com/PrimeIntellect-ai/renderers/pull/135/files#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7) to support metadata 2.5. The publish step behavior is otherwise unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d5b613c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->