### PR TITLE
feat(client): surface prompt_logprobs in generate() result

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -382,6 +382,10 @@ async def generate(
         "prompt_ids": list(prompt_ids),
         "completion_ids": list(completion_ids),
         "completion_logprobs": completion_logprobs,
+        # Prefill scores for the prompt tokens, present only when the caller
+        # asked (`sampling_params["prompt_logprobs"]`): one
+        # `{token_id: {"logprob": ...}} | None` entry per prompt position.
+        "prompt_logprobs": data.get("prompt_logprobs"),
         "content": parsed.content,
         "reasoning_content": parsed.reasoning_content,
         "tool_calls": parsed.tool_calls,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -91,6 +91,7 @@ class _FakeClient:
         )
         payload = {
             "request_id": "gen-test",
+            "prompt_logprobs": [None, {"2": {"logprob": -0.5}}, {"3": {"logprob": -1.25}}],
             "choices": [self.choice],
         }
         return httpx.Response(
@@ -159,6 +160,11 @@ def test_generate_builds_request_body_and_parses_response():
     assert result["prompt_ids"] == [1, 2, 3]
     assert result["completion_ids"] == [7, 8]
     assert result["completion_logprobs"] == [-0.1, -0.2]
+    assert result["prompt_logprobs"] == [
+        None,
+        {"2": {"logprob": -0.5}},
+        {"3": {"logprob": -1.25}},
+    ]
     assert result["routed_experts"]["shape"] == [2, 1, 1]
     assert isinstance(result["routed_experts"]["data"], memoryview)
     assert result["routed_experts"]["data"].tobytes() == base64.b64encode(b"\x01\x02")


### PR DESCRIPTION
The token endpoint already returns prefill scores when the caller sets sampling_params.prompt_logprobs; the client silently dropped them. Pass the field through so exact-token consumers (verifiers TrainClient.generate_tokens, teacher force-scoring in policy-composition) can read them without a second wire path.