### PR TITLE
fix: preserve truncated prefilled reasoning

### DIFF
--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -293,6 +293,7 @@ class DeepSeekV3Renderer:
             tool_call_begin_id=self._tool_call_begin,
             tool_call_end_id=self._tool_call_end,
             tool_sep_id=self._tool_sep,
+            prefilled_think=bool(self._GEN_THINK_PREFILL),
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -305,6 +305,7 @@ def parse_qwen35(
     tool_call_id: int,
     tool_call_end_id: int,
     tools: list[ToolSpec] | None = None,
+    prefilled_think: bool = False,
 ) -> ParsedResponse:
     """Parse Qwen3.5 completion tokens. XML-style tool calls, token-level thinking.
 
@@ -333,6 +334,12 @@ def parse_qwen35(
         # opening tag.
         think_start = _find(ids, think_id)
         reasoning = _decode(tokenizer, ids[think_start + 1 :]).strip()
+        return ParsedResponse(content="", reasoning_content=reasoning, tool_calls=[])
+    elif prefilled_think:
+        # The generation prompt supplied <think>, so it is not part of the
+        # completion token IDs. Without a closing tag, every sampled token is
+        # still inside that reasoning block.
+        reasoning = _decode(tokenizer, ids).strip()
         return ParsedResponse(content="", reasoning_content=reasoning, tool_calls=[])
 
     tc_start = _find(ids, tool_call_id)
@@ -988,6 +995,7 @@ def parse_deepseek_v3(
     tool_call_begin_id: int,
     tool_call_end_id: int,
     tool_sep_id: int,
+    prefilled_think: bool = False,
 ) -> ParsedResponse:
     """Parse DeepSeek V3 completion tokens.
 
@@ -1006,6 +1014,12 @@ def parse_deepseek_v3(
     # DeepSeek-V3 renders </think> as multi-token text, hence the decode-based
     # boundary finder rather than a token-id anchor.
     reasoning_end = _reasoning_end_token_index(tokenizer, ids)
+    if prefilled_think and reasoning_end == 0:
+        # DeepSeek-R1's generation prompt supplies <think> outside the
+        # completion. If the model is cut off before </think>, every sampled
+        # token remains reasoning — including any draft tool-call markers.
+        reasoning = _decode(tokenizer, ids).strip()
+        return ParsedResponse(content="", reasoning_content=reasoning, tool_calls=[])
 
     tc_section_start = _find(ids, tool_calls_begin_id, reasoning_end)
     tool_calls: list[ParsedToolCall] = []

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -671,6 +671,7 @@ class Qwen35Renderer:
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
             tools=tools,
+            prefilled_think=bool(self.config.enable_thinking),
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/tests/test_prefilled_think_parsing.py
+++ b/tests/test_prefilled_think_parsing.py
@@ -1,0 +1,87 @@
+"""Regression coverage for generation prompts that pre-open ``<think>``."""
+
+from renderers import (
+    DeepSeekR1Renderer,
+    DeepSeekV3Renderer,
+    Qwen35Renderer,
+    Qwen35RendererConfig,
+)
+
+
+class _TokenizerStub:
+    """Small reversible tokenizer with single-ID special tokens."""
+
+    name_or_path = "Qwen/Qwen3.5-4B"
+    unk_token_id = -1
+
+    def __init__(self):
+        self._special_ids: dict[str, int] = {}
+
+    def convert_tokens_to_ids(self, token: str) -> int:
+        return self._special_ids.setdefault(token, 1_000 + len(self._special_ids))
+
+    def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        if text.startswith("<｜") and text.endswith("｜>"):
+            return [self.convert_tokens_to_ids(text)]
+        return list(text.encode())
+
+    def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
+        del skip_special_tokens
+        return bytes(token for token in ids if token < 256).decode()
+
+
+def test_qwen35_truncated_prefilled_think_is_reasoning():
+    tokenizer = _TokenizerStub()
+    renderer = Qwen35Renderer(tokenizer, Qwen35RendererConfig(enable_thinking=True))
+
+    parsed = renderer.parse_response(tokenizer.encode("Let me work through this."))
+
+    assert parsed.reasoning_content == "Let me work through this."
+    assert parsed.content == ""
+    assert parsed.tool_calls == []
+
+
+def test_qwen35_without_think_prefill_keeps_plain_content():
+    tokenizer = _TokenizerStub()
+    renderer = Qwen35Renderer(tokenizer, Qwen35RendererConfig(enable_thinking=False))
+
+    parsed = renderer.parse_response(tokenizer.encode("The answer is 4."))
+
+    assert parsed.reasoning_content is None
+    assert parsed.content == "The answer is 4."
+
+
+def test_deepseek_r1_truncated_prefilled_think_is_reasoning():
+    tokenizer = _TokenizerStub()
+    renderer = DeepSeekR1Renderer(tokenizer)
+
+    parsed = renderer.parse_response(tokenizer.encode("Let me work through this."))
+
+    assert parsed.reasoning_content == "Let me work through this."
+    assert parsed.content == ""
+    assert parsed.tool_calls == []
+
+
+def test_deepseek_r1_does_not_parse_tool_calls_inside_truncated_reasoning():
+    tokenizer = _TokenizerStub()
+    renderer = DeepSeekR1Renderer(tokenizer)
+    tool_calls_begin = tokenizer.encode("<｜tool▁calls▁begin｜>")
+
+    parsed = renderer.parse_response(
+        tokenizer.encode("I might call a tool next.") + tool_calls_begin
+    )
+
+    assert parsed.reasoning_content == "I might call a tool next."
+    assert parsed.content == ""
+    assert parsed.tool_calls == []
+
+
+def test_deepseek_v3_without_think_prefill_keeps_plain_content():
+    tokenizer = _TokenizerStub()
+    renderer = DeepSeekV3Renderer(tokenizer)
+
+    parsed = renderer.parse_response(tokenizer.encode("The answer is 4."))
+
+    assert parsed.reasoning_content is None
+    assert parsed.content == "The answer is 4."


### PR DESCRIPTION
## Summary

- distinguish generation prompts that pre-open `<think>` from plain completions
- keep truncated Qwen3.5 and DeepSeek-R1 reasoning out of final answer content
- prevent draft DeepSeek tool markers inside unfinished reasoning from becoming tool calls
- preserve Qwen3.5 thinking-disabled and DeepSeek-V3 behavior

Fixes #137

## Testing

- `pytest tests/test_prefilled_think_parsing.py -q` — 5 passed
- `ruff check renderers/parsing.py renderers/qwen35.py renderers/deepseek_v3.py tests/test_prefilled_think_parsing.py`
- `ruff format --check renderers/parsing.py renderers/qwen35.py renderers/deepseek_v3.py tests/test_prefilled_think_parsing.py`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix truncated prefilled reasoning to return as `reasoning_content` instead of assistant content
> - Adds a `prefilled_think` parameter to `parse_deepseek_v3` and `parse_qwen35` in [parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/138/files#diff-4eba1ee111275cd49ea938c89bfbb7dafa7894d18a97c858fb4a9df401e85c75). When `True` and the completion ends before `</think>`, all sampled tokens are returned as `reasoning_content` with empty `content` and `tool_calls`.
> - `DeepSeekV3Renderer` and `Qwen35Renderer` pass `prefilled_think=True` when their think-prefill config is active, so truncated generations mid-reasoning are no longer misclassified as assistant content or tool calls.
> - Adds tests in [test_prefilled_think_parsing.py](https://github.com/PrimeIntellect-ai/renderers/pull/138/files#diff-9626178b7f01a39ad592133b84cb34c7f79488986b21bfb50a14493a1975ea31) covering truncated reasoning for DeepSeekR1 and Qwen3.5, including a case where tool-call markers inside truncated reasoning are correctly ignored.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2419c21.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->