### PR TITLE
feat(renderers): register Qwen3.8 Flash Next

### DIFF
--- a/renderers/base.py
+++ b/renderers/base.py
@@ -1033,6 +1033,7 @@ MODEL_RENDERER_MAP: dict[str, str] = {
     "Qwen/Qwen3.6-35B-A3B": "qwen3.6",
     # Qwen3.8.
     "Qwen/Qwen3.8-27B": "qwen3.8",
+    "Qwen/Qwen3.8-Flash-Next": "qwen3.8",
     # Qwen3-VL.
     "Qwen/Qwen3-VL-4B-Instruct": "qwen3-vl",
     "Qwen/Qwen3-VL-8B-Instruct": "qwen3-vl",

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -104,6 +104,7 @@ _ENABLE_THINKING_DEFAULTS: dict[str, bool] = {
     "Qwen/Qwen3.6-35B-A3B": True,
     # Qwen3.8 keeps thinking enabled by default.
     "Qwen/Qwen3.8-27B": True,
+    "Qwen/Qwen3.8-Flash-Next": True,
 }
 
 


### PR DESCRIPTION
## Summary

- route `Qwen/Qwen3.8-Flash-Next` through the native Qwen3.8 renderer
- keep thinking enabled by default for the model

## Validation

- `uv run pytest tests/test_qwen38.py -q` (10 passed)
- `git diff --check`


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Register `Qwen/Qwen3.8-Flash-Next` in `MODEL_RENDERER_MAP` and `qwen3.8` defaults
> - Maps `Qwen/Qwen3.8-Flash-Next` to the `qwen3.8` renderer in [base.py](https://github.com/PrimeIntellect-ai/renderers/pull/145/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) so auto-selection routes it correctly
> - Sets `enable_thinking` to `True` by default for `Qwen/Qwen3.8-Flash-Next` in [qwen35.py](https://github.com/PrimeIntellect-ai/renderers/pull/145/files#diff-6ffae20154d6e887d44f7b667c5460ca3cf17b23fd5ed2768c0293580cd9f83a) when unset in config
> - Behavioral Change: requests to `Qwen/Qwen3.8-Flash-Next` now open a `` block by default unless the caller disables it
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d87e8e4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->