### PR TITLE
Centralize renderer registration metadata

### DIFF
--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -75,6 +75,7 @@ from renderers.configs import (
     Qwen3VLRendererConfig,
     RendererConfig,
 )
+from renderers.registry import RENDERER_SPECS
 
 # Concrete renderer classes are lazy-loaded so that consumers needing only the
 # config layer (``RendererConfig`` discriminated union) don't import every
@@ -84,34 +85,7 @@ from renderers.configs import (
 # names on first attribute access, while ``renderers.base._populate_registry``
 # handles lazy registration for ``create_renderer``.
 _LAZY_RENDERERS: dict[str, str] = {
-    "DeepSeekR1Renderer": "renderers.deepseek_r1",
-    "DeepSeekV3Renderer": "renderers.deepseek_v3",
-    "DeepSeekV4Renderer": "renderers.deepseek_v4",
-    "DefaultRenderer": "renderers.default",
-    "GLM45Renderer": "renderers.glm45",
-    "GLM51Renderer": "renderers.glm5",
-    "GLM5Renderer": "renderers.glm5",
-    "GptOssRenderer": "renderers.gpt_oss",
-    "Gemma4Renderer": "renderers.gemma4",
-    "Hy3Renderer": "renderers.hy3",
-    "InklingRenderer": "renderers.inkling",
-    "KimiK25Renderer": "renderers.kimi_k25",
-    "KimiK2Renderer": "renderers.kimi_k2",
-    "LagunaM1Renderer": "renderers.laguna_xs2",
-    "LagunaS21Renderer": "renderers.laguna_s21",
-    "LagunaXS21Renderer": "renderers.laguna_xs2",
-    "LagunaXS2Renderer": "renderers.laguna_xs2",
-    "Llama3Renderer": "renderers.llama_3",
-    "MiniMaxM2Renderer": "renderers.minimax_m2",
-    "Nemotron35Renderer": "renderers.nemotron3",
-    "Nemotron3Renderer": "renderers.nemotron3",
-    "Nemotron3UltraRenderer": "renderers.nemotron3",
-    "PrimeQwen3Renderer": "renderers.prime_qwen3",
-    "Qwen35Renderer": "renderers.qwen35",
-    "Qwen36Renderer": "renderers.qwen36",
-    "Qwen38Renderer": "renderers.qwen38",
-    "Qwen3Renderer": "renderers.qwen3",
-    "Qwen3VLRenderer": "renderers.qwen3_vl",
+    spec.renderer_class: spec.module for spec in RENDERER_SPECS
 }
 
 

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -15,6 +15,8 @@ from typing import (
     runtime_checkable,
 )
 
+from renderers.registry import RENDERER_SPECS
+
 if TYPE_CHECKING:
     from renderers.configs import (
         AutoRendererConfig,
@@ -914,120 +916,10 @@ RENDERER_REGISTRY: dict[str, type] = {}
 # ``DefaultRenderer`` (which uses ``apply_chat_template`` verbatim) and
 # logs a loud INFO line with the chosen fallback.
 MODEL_RENDERER_MAP: dict[str, str] = {
-    # Qwen3 — base and Instruct variants share the same chat template.
-    "Qwen/Qwen3-0.6B": "qwen3",
-    "Qwen/Qwen3-1.7B": "qwen3",
-    "Qwen/Qwen3-4B": "qwen3",
-    "Qwen/Qwen3-4B-Instruct-2507": "qwen3",
-    "Qwen/Qwen3-4B-Thinking-2507": "qwen3",
-    "Qwen/Qwen3-8B": "qwen3",
-    "Qwen/Qwen3-14B": "qwen3",
-    "Qwen/Qwen3-32B": "qwen3",
-    "Qwen/Qwen3-30B-A3B": "qwen3",
-    "Qwen/Qwen3-30B-A3B-Instruct-2507": "qwen3",
-    "Qwen/Qwen3-30B-A3B-Thinking-2507": "qwen3",
-    "Qwen/Qwen3-235B-A22B": "qwen3",
-    # PrimeIntellect Qwen3 — both sizes share the same Qwen3-Coder-style
-    # template with XML tool definitions and calls.
-    "PrimeIntellect/Qwen3-0.6B": "prime-qwen3",
-    "PrimeIntellect/Qwen3-1.7B": "prime-qwen3",
-    # Qwen3.5. All seven sizes share the same renderer. The 4B / 9B /
-    # 35B-A3B / 122B-A10B / 397B-A17B chat template defaults
-    # ``enable_thinking=true`` (open ``<think>\n`` at the gen prompt);
-    # the smaller 0.8B / 2B variants flip the polarity (default
-    # ``enable_thinking=false``, empty ``<think>\n\n</think>\n\n``).
-    # ``Qwen35Renderer`` hard-codes this polarity per model
-    # (``_ENABLE_THINKING_DEFAULTS``), so all seven sizes are
-    # token-for-token parity-tested against their own
-    # ``apply_chat_template`` — including with
-    # ``add_generation_prompt=True``.
-    "Qwen/Qwen3.5-0.8B": "qwen3.5",
-    "Qwen/Qwen3.5-2B": "qwen3.5",
-    "Qwen/Qwen3.5-4B": "qwen3.5",
-    "Qwen/Qwen3.5-9B": "qwen3.5",
-    "Qwen/Qwen3.5-35B-A3B": "qwen3.5",
-    "Qwen/Qwen3.5-122B-A10B": "qwen3.5",
-    "Qwen/Qwen3.5-397B-A17B": "qwen3.5",
-    # Qwen3.6.
-    "Qwen/Qwen3.6-35B-A3B": "qwen3.6",
-    # Qwen3.8.
-    "Qwen/Qwen3.8-27B": "qwen3.8",
-    "Qwen/Qwen3.8-Flash-Next": "qwen3.8",
-    # Qwen3-VL.
-    "Qwen/Qwen3-VL-4B-Instruct": "qwen3-vl",
-    "Qwen/Qwen3-VL-8B-Instruct": "qwen3-vl",
-    "Qwen/Qwen3-VL-30B-A3B-Instruct": "qwen3-vl",
-    # Gemma 4 instruction checkpoints share Google's canonical turn/tool
-    # grammar and dynamic Gemma4Processor image expansion. E2B/E4B omit the
-    # disabled-thinking empty-channel prefill used by the 26B/31B revision;
-    # Gemma4Renderer detects that small template variant per tokenizer.
-    "google/gemma-4-E2B-it": "gemma4",
-    "google/gemma-4-E4B-it": "gemma4",
-    "google/gemma-4-26B-A4B-it": "gemma4",
-    "google/gemma-4-31B-it": "gemma4",
-    # GLM-5 family (GLM-4.7 reuses the GLM-5 template).
-    "zai-org/GLM-5": "glm-5",
-    "zai-org/GLM-5-FP8": "glm-5",
-    "zai-org/GLM-4.7-Flash": "glm-5",
-    "zai-org/GLM-5.1": "glm-5.1",
-    # GLM-4.5.
-    "THUDM/GLM-4.5-Air": "glm-4.5",
-    "zai-org/GLM-4.5-Air": "glm-4.5",
-    # MiniMax.
-    "MiniMaxAI/MiniMax-M2": "minimax-m2",
-    "MiniMaxAI/MiniMax-M2.5": "minimax-m2",
-    # DeepSeek V3 (non-reasoning).
-    "deepseek-ai/DeepSeek-V3": "deepseek-v3",
-    "deepseek-ai/DeepSeek-V3-Base": "deepseek-v3",
-    # DeepSeek R1 (reasoning).
-    "deepseek-ai/DeepSeek-R1": "deepseek-r1",
-    "deepseek-ai/DeepSeek-R1-0528": "deepseek-r1",
-    # DeepSeek V4 Flash 0731 uses the repository's Python DSML encoder (the
-    # tokenizer intentionally ships no Jinja chat_template).
-    "deepseek-ai/DeepSeek-V4-Flash-0731": "deepseek-v4",
-    # Kimi K2 (K2.5 and K2.6 share the K2.5 template, distinct from K2).
-    "moonshotai/Kimi-K2-Instruct": "kimi-k2",
-    "moonshotai/Kimi-K2.5": "kimi-k2.5",
-    "moonshotai/Kimi-K2.6": "kimi-k2.5",
-    # Nemotron 3. Nano / Super share one chat-template variant (``nemotron-3``);
-    # the Ultra checkpoints use the Ultra variant (``nemotron-3-ultra``, distinct
-    # ``</think>`` glue). Both route to the same Nemotron3Renderer, which selects
-    # the variant from the resolved config's ``name``. BF16 and FP8 share the
-    # same tokenizer and template.
-    "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16": "nemotron-3",
-    "nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16": "nemotron-3",
-    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16": "nemotron-3-ultra",
-    "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8": "nemotron-3-ultra",
-    # Nemotron 3.5 (Lightning). Its template is the Ultra variant's minus the
-    # effort kwarg (``nemotron-3.5``).
-    "nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16": "nemotron-3.5",
-    # Llama 3.2 (Instruct). Tested against the gated meta-llama repos and
-    # the unrestricted unsloth/... mirror, which ships a byte-identical
-    # chat template. ``Llama3Renderer`` defaults ``date_string`` to
-    # "26 Jul 2024" — matching the chat template's strftime fallback —
-    # so the renderer is reproducible. Pass ``date_string=...`` at
-    # construction to pin a different date.
-    "meta-llama/Llama-3.2-1B-Instruct": "llama-3",
-    "meta-llama/Llama-3.2-3B-Instruct": "llama-3",
-    # Poolside Laguna. These checkpoints ship distinct chat templates, each
-    # mirrored by its own renderer class/config discriminator.
-    "poolside/Laguna-XS.2": "laguna-xs.2",
-    "poolside/Laguna-M.1": "laguna-m.1",
-    "poolside/Laguna-XS-2.1": "laguna-xs-2.1",
-    "poolside/Laguna-S-2.1": "laguna-s-2.1",
-    # GPT-OSS.
-    "openai/gpt-oss-20b": "gpt-oss",
-    "openai/gpt-oss-120b": "gpt-oss",
-    # Thinking Machines Inkling checkpoints share byte-identical tokenizer,
-    # chat-template, and processor assets (vision + audio; transformers >= 5.14).
-    "thinkingmachines/Inkling": "inkling",
-    "thinkingmachines/Inkling-Small": "inkling",
-    # Tencent Hunyuan Hy3 (295B-A21B MoE). The FP8 checkpoint shares the same
-    # tokenizer and chat template. Hy3-preview is deliberately unmapped: it
-    # ships an older, incompatible template (un-suffixed special tokens,
-    # ``interleaved_thinking`` instead of ``preserved_thinking``).
-    "tencent/Hy3": "hy3",
-    "tencent/Hy3-FP8": "hy3",
+    model_id: renderer.name
+    for renderer in RENDERER_SPECS
+    for model in renderer.models
+    for model_id in model.model_ids
 }
 
 
@@ -1035,46 +927,17 @@ MODEL_RENDERER_MAP: dict[str, str] = {
 # multimodal parity test matrix in ``tests/test_multimodal.py`` — each
 # ``(model, modality)`` pair gets a parity test against
 # ``processor.apply_chat_template`` + ``processor(...)``. Add a model
-# here when its renderer supports a new modality; the test matrix
-# picks it up automatically.
+# here when its renderer supports a new modality; the test matrix picks it up
+# automatically. Aliases inherit their representative's modalities.
 #
 # Modality values: ``"image"``, ``"video"``, ``"audio"``. Text is implicit
 # (every model supports it), so it doesn't appear in the set.
 MULTIMODAL_MODELS: dict[str, set[str]] = {
-    "Qwen/Qwen3-VL-4B-Instruct": {"image"},
-    "Qwen/Qwen3-VL-8B-Instruct": {"image"},
-    "Qwen/Qwen3-VL-30B-A3B-Instruct": {"image"},
-    "google/gemma-4-E2B-it": {"image"},
-    "google/gemma-4-E4B-it": {"image"},
-    "google/gemma-4-26B-A4B-it": {"image"},
-    "google/gemma-4-31B-it": {"image"},
-    # Qwen3.5 is itself a VLM family (HF tag ``image-text-to-text``,
-    # processor class ``Qwen3VLProcessor``) — same vision tokens and
-    # image-processor as Qwen3-VL, with a different tool-call format.
-    "Qwen/Qwen3.5-0.8B": {"image"},
-    "Qwen/Qwen3.5-2B": {"image"},
-    "Qwen/Qwen3.5-4B": {"image"},
-    "Qwen/Qwen3.5-9B": {"image"},
-    "Qwen/Qwen3.5-35B-A3B": {"image"},
-    "Qwen/Qwen3.5-122B-A10B": {"image"},
-    "Qwen/Qwen3.5-397B-A17B": {"image"},
-    # Qwen3.6 extends Qwen3.5's chat template; same VL bits, only
-    # tool-call argument serialization differs.
-    "Qwen/Qwen3.6-35B-A3B": {"image"},
-    # Qwen3.8 adds reasoning-effort control and preserves thinking by default.
-    "Qwen/Qwen3.8-27B": {"image"},
-    "Qwen/Qwen3.8-Flash-Next": {"image"},
-    # Kimi K2.5 / K2.6 are unified VLMs (HF tag ``image-text-to-text``)
-    # with custom processor (``KimiK25Processor`` + ``KimiK25VisionProcessor``).
-    # Vision wrap is different from Qwen-VL:
-    # ``<|media_begin|>image<|media_content|><|media_pad|><|media_end|>`` —
-    # only ONE ``<|media_pad|>`` per image in ``input_ids``; per-patch
-    # expansion happens internally in the model from ``pixel_values`` /
-    # ``grid_thws``.
-    "moonshotai/Kimi-K2.5": {"image"},
-    "moonshotai/Kimi-K2.6": {"image"},
-    "thinkingmachines/Inkling": {"image", "audio"},
-    "thinkingmachines/Inkling-Small": {"image", "audio"},
+    model_id: set(model.modalities)
+    for renderer in RENDERER_SPECS
+    for model in renderer.models
+    if model.modalities
+    for model_id in model.model_ids
 }
 
 
@@ -1300,70 +1163,11 @@ def load_tokenizer(model_name_or_path: str):
 def _populate_registry():
     if RENDERER_REGISTRY:
         return
-    from renderers.deepseek_r1 import DeepSeekR1Renderer
-    from renderers.deepseek_v3 import DeepSeekV3Renderer
-    from renderers.deepseek_v4 import DeepSeekV4Renderer
-    from renderers.default import DefaultRenderer
-    from renderers.glm5 import GLM5Renderer, GLM51Renderer
-    from renderers.glm45 import GLM45Renderer
-    from renderers.gpt_oss import GptOssRenderer
-    from renderers.gemma4 import Gemma4Renderer
-    from renderers.hy3 import Hy3Renderer
-    from renderers.inkling import InklingRenderer
-    from renderers.kimi_k2 import KimiK2Renderer
-    from renderers.kimi_k25 import KimiK25Renderer
-    from renderers.laguna_s21 import LagunaS21Renderer
-    from renderers.laguna_xs2 import (
-        LagunaM1Renderer,
-        LagunaXS2Renderer,
-        LagunaXS21Renderer,
-    )
-    from renderers.llama_3 import Llama3Renderer
-    from renderers.minimax_m2 import MiniMaxM2Renderer
-    from renderers.nemotron3 import (
-        Nemotron3Renderer,
-        Nemotron3UltraRenderer,
-        Nemotron35Renderer,
-    )
-    from renderers.prime_qwen3 import PrimeQwen3Renderer
-    from renderers.qwen3 import Qwen3Renderer
-    from renderers.qwen3_vl import Qwen3VLRenderer
-    from renderers.qwen35 import Qwen35Renderer
-    from renderers.qwen36 import Qwen36Renderer
-    from renderers.qwen38 import Qwen38Renderer
+    import importlib
 
-    RENDERER_REGISTRY.update(
-        {
-            "default": DefaultRenderer,
-            "qwen3": Qwen3Renderer,
-            "prime-qwen3": PrimeQwen3Renderer,
-            "qwen3-vl": Qwen3VLRenderer,
-            "gemma4": Gemma4Renderer,
-            "qwen3.5": Qwen35Renderer,
-            "qwen3.6": Qwen36Renderer,
-            "qwen3.8": Qwen38Renderer,
-            "glm-5": GLM5Renderer,
-            "glm-5.1": GLM51Renderer,
-            "glm-4.5": GLM45Renderer,
-            "minimax-m2": MiniMaxM2Renderer,
-            "deepseek-v3": DeepSeekV3Renderer,
-            "deepseek-r1": DeepSeekR1Renderer,
-            "deepseek-v4": DeepSeekV4Renderer,
-            "hy3": Hy3Renderer,
-            "inkling": InklingRenderer,
-            "kimi-k2": KimiK2Renderer,
-            "kimi-k2.5": KimiK25Renderer,
-            "laguna-xs.2": LagunaXS2Renderer,
-            "laguna-m.1": LagunaM1Renderer,
-            "laguna-xs-2.1": LagunaXS21Renderer,
-            "laguna-s-2.1": LagunaS21Renderer,
-            "llama-3": Llama3Renderer,
-            "nemotron-3": Nemotron3Renderer,
-            "nemotron-3-ultra": Nemotron3UltraRenderer,
-            "nemotron-3.5": Nemotron35Renderer,
-            "gpt-oss": GptOssRenderer,
-        }
-    )
+    for spec in RENDERER_SPECS:
+        module = importlib.import_module(spec.module)
+        RENDERER_REGISTRY[spec.name] = getattr(module, spec.renderer_class)
 
 
 def create_renderer(

--- a/renderers/configs.py
+++ b/renderers/configs.py
@@ -26,6 +26,8 @@ from typing import Annotated, ClassVar, Literal, Union
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_config import BaseConfig
 
+from renderers.registry import RENDERER_SPECS
+
 
 def _reject_thinking_retention_conflict(
     config: BaseConfig,
@@ -1015,40 +1017,12 @@ that renderer supports. Bogus combinations (e.g. ``add_vision_id`` under
 """
 
 
-# Map discriminator → config class. Used by ``create_renderer`` when
-# resolving ``AutoRendererConfig`` against ``MODEL_RENDERER_MAP``: the
-# resolved renderer name picks the corresponding typed config, and the
-# auto config's ``thinking_retention`` field is carried over.
+# Map discriminator → config class, derived from the central renderer
+# manifest. Used by ``create_renderer`` when resolving ``AutoRendererConfig``
+# against ``MODEL_RENDERER_MAP``.
 _CONFIG_BY_NAME: dict[str, type[BaseRendererConfig]] = {
     "auto": AutoRendererConfig,
-    "default": DefaultRendererConfig,
-    "qwen3": Qwen3RendererConfig,
-    "prime-qwen3": PrimeQwen3RendererConfig,
-    "qwen3.5": Qwen35RendererConfig,
-    "qwen3.6": Qwen36RendererConfig,
-    "qwen3.8": Qwen38RendererConfig,
-    "qwen3-vl": Qwen3VLRendererConfig,
-    "gemma4": Gemma4RendererConfig,
-    "glm-5": GLM5RendererConfig,
-    "glm-5.1": GLM51RendererConfig,
-    "glm-4.5": GLM45RendererConfig,
-    "gpt-oss": GptOssRendererConfig,
-    "hy3": Hy3RendererConfig,
-    "inkling": InklingRendererConfig,
-    "kimi-k2": KimiK2RendererConfig,
-    "kimi-k2.5": KimiK25RendererConfig,
-    "laguna-xs.2": LagunaXS2RendererConfig,
-    "laguna-m.1": LagunaM1RendererConfig,
-    "laguna-xs-2.1": LagunaXS21RendererConfig,
-    "laguna-s-2.1": LagunaS21RendererConfig,
-    "llama-3": Llama3RendererConfig,
-    "minimax-m2": MiniMaxM2RendererConfig,
-    "nemotron-3": Nemotron3RendererConfig,
-    "nemotron-3-ultra": Nemotron3UltraRendererConfig,
-    "nemotron-3.5": Nemotron35RendererConfig,
-    "deepseek-v3": DeepSeekV3RendererConfig,
-    "deepseek-r1": DeepSeekR1RendererConfig,
-    "deepseek-v4": DeepSeekV4RendererConfig,
+    **{spec.name: globals()[spec.config_class] for spec in RENDERER_SPECS},
 }
 
 

--- a/renderers/registry.py
+++ b/renderers/registry.py
@@ -1,0 +1,412 @@
+"""Declarative source of truth for renderer registration and model routing.
+
+Each :class:`RendererSpec` ties together the renderer/config pair and the
+canonical model IDs that auto-resolve to it.  A :class:`ModelSpec` names the
+checkpoint used by the parity suite and any routing-equivalent aliases.  The
+runtime registry, config lookup, lazy public imports, model routing, and
+multimodal catalog are all derived from this manifest.
+
+Import paths are stored as data to keep this module dependency-free.  That is
+what lets ``renderers.base``, ``renderers.configs``, and ``renderers.__init__``
+all consume the same manifest without introducing import cycles.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A parity-tested model and checkpoints that intentionally share its route.
+
+    ``model`` is the representative checkpoint exercised by the parity suite.
+    ``aliases`` inherit its renderer and modalities without multiplying the
+    full Cartesian parity matrix for byte-compatible or routing-equivalent
+    checkpoints.
+    """
+
+    model: str
+    aliases: tuple[str, ...] = ()
+    modalities: frozenset[str] = frozenset()
+
+    @property
+    def model_ids(self) -> tuple[str, ...]:
+        return (self.model, *self.aliases)
+
+
+@dataclass(frozen=True)
+class RendererSpec:
+    """All registration metadata for one concrete renderer."""
+
+    name: str
+    module: str
+    renderer_class: str
+    config_class: str
+    models: tuple[ModelSpec, ...] = ()
+
+
+def _model(
+    model: str,
+    *,
+    aliases: tuple[str, ...] = (),
+    modalities: frozenset[str] = frozenset(),
+) -> ModelSpec:
+    return ModelSpec(model=model, aliases=aliases, modalities=modalities)
+
+
+IMAGE = frozenset({"image"})
+IMAGE_AUDIO = frozenset({"image", "audio"})
+
+
+RENDERER_SPECS = (
+    RendererSpec(
+        "default",
+        "renderers.default",
+        "DefaultRenderer",
+        "DefaultRendererConfig",
+    ),
+    RendererSpec(
+        "qwen3",
+        "renderers.qwen3",
+        "Qwen3Renderer",
+        "Qwen3RendererConfig",
+        (
+            # These checkpoints share the same Qwen3 chat-template grammar.
+            _model(
+                "Qwen/Qwen3-8B",
+                aliases=(
+                    "Qwen/Qwen3-0.6B",
+                    "Qwen/Qwen3-1.7B",
+                    "Qwen/Qwen3-4B",
+                    "Qwen/Qwen3-4B-Instruct-2507",
+                    "Qwen/Qwen3-4B-Thinking-2507",
+                    "Qwen/Qwen3-14B",
+                    "Qwen/Qwen3-32B",
+                    "Qwen/Qwen3-30B-A3B",
+                    "Qwen/Qwen3-30B-A3B-Instruct-2507",
+                    "Qwen/Qwen3-30B-A3B-Thinking-2507",
+                    "Qwen/Qwen3-235B-A22B",
+                ),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "prime-qwen3",
+        "renderers.prime_qwen3",
+        "PrimeQwen3Renderer",
+        "PrimeQwen3RendererConfig",
+        (
+            _model("PrimeIntellect/Qwen3-0.6B"),
+            _model("PrimeIntellect/Qwen3-1.7B"),
+        ),
+    ),
+    RendererSpec(
+        "qwen3.5",
+        "renderers.qwen35",
+        "Qwen35Renderer",
+        "Qwen35RendererConfig",
+        tuple(
+            _model(model, modalities=IMAGE)
+            for model in (
+                "Qwen/Qwen3.5-0.8B",
+                "Qwen/Qwen3.5-2B",
+                "Qwen/Qwen3.5-4B",
+                "Qwen/Qwen3.5-9B",
+                "Qwen/Qwen3.5-35B-A3B",
+                "Qwen/Qwen3.5-122B-A10B",
+                "Qwen/Qwen3.5-397B-A17B",
+            )
+        ),
+    ),
+    RendererSpec(
+        "qwen3.6",
+        "renderers.qwen36",
+        "Qwen36Renderer",
+        "Qwen36RendererConfig",
+        (_model("Qwen/Qwen3.6-35B-A3B", modalities=IMAGE),),
+    ),
+    RendererSpec(
+        "qwen3.8",
+        "renderers.qwen38",
+        "Qwen38Renderer",
+        "Qwen38RendererConfig",
+        (
+            _model("Qwen/Qwen3.8-27B", modalities=IMAGE),
+            _model("Qwen/Qwen3.8-Flash-Next", modalities=IMAGE),
+        ),
+    ),
+    RendererSpec(
+        "qwen3-vl",
+        "renderers.qwen3_vl",
+        "Qwen3VLRenderer",
+        "Qwen3VLRendererConfig",
+        (
+            _model(
+                "Qwen/Qwen3-VL-4B-Instruct",
+                aliases=(
+                    "Qwen/Qwen3-VL-8B-Instruct",
+                    "Qwen/Qwen3-VL-30B-A3B-Instruct",
+                ),
+                modalities=IMAGE,
+            ),
+        ),
+    ),
+    RendererSpec(
+        "gemma4",
+        "renderers.gemma4",
+        "Gemma4Renderer",
+        "Gemma4RendererConfig",
+        tuple(
+            _model(model, modalities=IMAGE)
+            for model in (
+                "google/gemma-4-E2B-it",
+                "google/gemma-4-E4B-it",
+                "google/gemma-4-26B-A4B-it",
+                "google/gemma-4-31B-it",
+            )
+        ),
+    ),
+    RendererSpec(
+        "glm-5",
+        "renderers.glm5",
+        "GLM5Renderer",
+        "GLM5RendererConfig",
+        (
+            _model("zai-org/GLM-5", aliases=("zai-org/GLM-5-FP8",)),
+            _model("zai-org/GLM-4.7-Flash"),
+        ),
+    ),
+    RendererSpec(
+        "glm-5.1",
+        "renderers.glm5",
+        "GLM51Renderer",
+        "GLM51RendererConfig",
+        (_model("zai-org/GLM-5.1"),),
+    ),
+    RendererSpec(
+        "glm-4.5",
+        "renderers.glm45",
+        "GLM45Renderer",
+        "GLM45RendererConfig",
+        (
+            _model(
+                "THUDM/GLM-4.5-Air",
+                aliases=("zai-org/GLM-4.5-Air",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "minimax-m2",
+        "renderers.minimax_m2",
+        "MiniMaxM2Renderer",
+        "MiniMaxM2RendererConfig",
+        (
+            _model(
+                "MiniMaxAI/MiniMax-M2.5",
+                aliases=("MiniMaxAI/MiniMax-M2",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "deepseek-v3",
+        "renderers.deepseek_v3",
+        "DeepSeekV3Renderer",
+        "DeepSeekV3RendererConfig",
+        (
+            _model(
+                "deepseek-ai/DeepSeek-V3",
+                aliases=("deepseek-ai/DeepSeek-V3-Base",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "deepseek-r1",
+        "renderers.deepseek_r1",
+        "DeepSeekR1Renderer",
+        "DeepSeekR1RendererConfig",
+        (
+            _model(
+                "deepseek-ai/DeepSeek-R1",
+                aliases=("deepseek-ai/DeepSeek-R1-0528",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "deepseek-v4",
+        "renderers.deepseek_v4",
+        "DeepSeekV4Renderer",
+        "DeepSeekV4RendererConfig",
+        (_model("deepseek-ai/DeepSeek-V4-Flash-0731"),),
+    ),
+    RendererSpec(
+        "kimi-k2",
+        "renderers.kimi_k2",
+        "KimiK2Renderer",
+        "KimiK2RendererConfig",
+        (_model("moonshotai/Kimi-K2-Instruct"),),
+    ),
+    RendererSpec(
+        "kimi-k2.5",
+        "renderers.kimi_k25",
+        "KimiK25Renderer",
+        "KimiK25RendererConfig",
+        (
+            _model("moonshotai/Kimi-K2.5", modalities=IMAGE),
+            _model("moonshotai/Kimi-K2.6", modalities=IMAGE),
+        ),
+    ),
+    RendererSpec(
+        "nemotron-3",
+        "renderers.nemotron3",
+        "Nemotron3Renderer",
+        "Nemotron3RendererConfig",
+        (
+            _model("nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"),
+            _model("nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16"),
+        ),
+    ),
+    RendererSpec(
+        "nemotron-3-ultra",
+        "renderers.nemotron3",
+        "Nemotron3UltraRenderer",
+        "Nemotron3UltraRendererConfig",
+        (
+            _model(
+                "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-BF16",
+                aliases=("nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B-FP8",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "nemotron-3.5",
+        "renderers.nemotron3",
+        "Nemotron35Renderer",
+        "Nemotron35RendererConfig",
+        (_model("nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-BF16"),),
+    ),
+    RendererSpec(
+        "llama-3",
+        "renderers.llama_3",
+        "Llama3Renderer",
+        "Llama3RendererConfig",
+        (
+            _model("meta-llama/Llama-3.2-1B-Instruct"),
+            _model("meta-llama/Llama-3.2-3B-Instruct"),
+        ),
+    ),
+    RendererSpec(
+        "laguna-xs.2",
+        "renderers.laguna_xs2",
+        "LagunaXS2Renderer",
+        "LagunaXS2RendererConfig",
+        (_model("poolside/Laguna-XS.2"),),
+    ),
+    RendererSpec(
+        "laguna-m.1",
+        "renderers.laguna_xs2",
+        "LagunaM1Renderer",
+        "LagunaM1RendererConfig",
+        (_model("poolside/Laguna-M.1"),),
+    ),
+    RendererSpec(
+        "laguna-xs-2.1",
+        "renderers.laguna_xs2",
+        "LagunaXS21Renderer",
+        "LagunaXS21RendererConfig",
+        (_model("poolside/Laguna-XS-2.1"),),
+    ),
+    RendererSpec(
+        "laguna-s-2.1",
+        "renderers.laguna_s21",
+        "LagunaS21Renderer",
+        "LagunaS21RendererConfig",
+        (_model("poolside/Laguna-S-2.1"),),
+    ),
+    RendererSpec(
+        "gpt-oss",
+        "renderers.gpt_oss",
+        "GptOssRenderer",
+        "GptOssRendererConfig",
+        (
+            _model(
+                "openai/gpt-oss-20b",
+                aliases=("openai/gpt-oss-120b",),
+            ),
+        ),
+    ),
+    RendererSpec(
+        "inkling",
+        "renderers.inkling",
+        "InklingRenderer",
+        "InklingRendererConfig",
+        (
+            _model("thinkingmachines/Inkling", modalities=IMAGE_AUDIO),
+            _model("thinkingmachines/Inkling-Small", modalities=IMAGE_AUDIO),
+        ),
+    ),
+    RendererSpec(
+        "hy3",
+        "renderers.hy3",
+        "Hy3Renderer",
+        "Hy3RendererConfig",
+        (
+            _model(
+                "tencent/Hy3",
+                aliases=("tencent/Hy3-FP8",),
+            ),
+        ),
+    ),
+)
+
+
+def _validate_specs() -> None:
+    renderer_names: set[str] = set()
+    renderer_classes: set[str] = set()
+    model_ids: set[str] = set()
+
+    for renderer in RENDERER_SPECS:
+        if renderer.name in renderer_names:
+            raise ValueError(f"Duplicate renderer name: {renderer.name!r}")
+        renderer_names.add(renderer.name)
+
+        if renderer.renderer_class in renderer_classes:
+            raise ValueError(
+                f"Renderer class registered more than once: {renderer.renderer_class!r}"
+            )
+        renderer_classes.add(renderer.renderer_class)
+
+        for model in renderer.models:
+            if not model.modalities <= {"image", "video", "audio"}:
+                raise ValueError(
+                    f"Unknown modalities for {model.model!r}: {model.modalities!r}"
+                )
+            for model_id in model.model_ids:
+                if model_id in model_ids:
+                    raise ValueError(
+                        f"Model ID registered more than once: {model_id!r}"
+                    )
+                model_ids.add(model_id)
+
+
+_validate_specs()
+
+
+RENDERER_SPEC_BY_NAME = {spec.name: spec for spec in RENDERER_SPECS}
+
+# Every mapped ID points to the representative that supplies its parity claim.
+MODEL_PARITY_REPRESENTATIVES = {
+    model_id: model.model
+    for renderer in RENDERER_SPECS
+    for model in renderer.models
+    for model_id in model.model_ids
+}
+
+
+__all__ = [
+    "MODEL_PARITY_REPRESENTATIVES",
+    "ModelSpec",
+    "RENDERER_SPEC_BY_NAME",
+    "RENDERER_SPECS",
+    "RendererSpec",
+]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,81 @@
+"""Structural tests for the declarative renderer registry."""
+
+from __future__ import annotations
+
+import importlib
+from typing import get_args
+
+import renderers
+import renderers.base as base
+from parity import MODEL_CATALOG
+from renderers.configs import (
+    AutoRendererConfig,
+    RendererConfig,
+    _CONFIG_BY_NAME,
+)
+from renderers.registry import MODEL_PARITY_REPRESENTATIVES, RENDERER_SPECS
+
+
+def test_runtime_metadata_is_derived_from_renderer_specs():
+    expected_routes = {
+        model_id: renderer.name
+        for renderer in RENDERER_SPECS
+        for model in renderer.models
+        for model_id in model.model_ids
+    }
+    expected_modalities = {
+        model_id: set(model.modalities)
+        for renderer in RENDERER_SPECS
+        for model in renderer.models
+        if model.modalities
+        for model_id in model.model_ids
+    }
+    expected_lazy_renderers = {
+        renderer.renderer_class: renderer.module for renderer in RENDERER_SPECS
+    }
+
+    assert base.MODEL_RENDERER_MAP == expected_routes
+    assert base.MULTIMODAL_MODELS == expected_modalities
+    assert renderers._LAZY_RENDERERS == expected_lazy_renderers
+
+
+def test_every_mapped_model_has_a_parity_representative():
+    catalog_models = {case.model for case in MODEL_CATALOG}
+
+    assert MODEL_PARITY_REPRESENTATIVES.keys() == base.MODEL_RENDERER_MAP.keys()
+    for model_id, representative in MODEL_PARITY_REPRESENTATIVES.items():
+        assert representative in catalog_models, (
+            f"{model_id!r} routes through {representative!r}, but that "
+            "representative is absent from MODEL_CATALOG"
+        )
+        assert (
+            base.MODEL_RENDERER_MAP[model_id] == base.MODEL_RENDERER_MAP[representative]
+        )
+
+
+def test_config_registry_and_discriminated_union_cover_manifest():
+    expected_configs = {
+        spec.name: getattr(
+            importlib.import_module("renderers.configs"), spec.config_class
+        )
+        for spec in RENDERER_SPECS
+    }
+    assert _CONFIG_BY_NAME == {"auto": AutoRendererConfig, **expected_configs}
+
+    config_union = get_args(RendererConfig)[0]
+    assert set(get_args(config_union)) == {
+        AutoRendererConfig,
+        *expected_configs.values(),
+    }
+
+
+def test_every_renderer_loader_resolves(monkeypatch):
+    monkeypatch.setattr(base, "RENDERER_REGISTRY", {})
+    base._populate_registry()
+
+    assert base.RENDERER_REGISTRY.keys() == {spec.name for spec in RENDERER_SPECS}
+    for spec in RENDERER_SPECS:
+        expected_class = getattr(
+            importlib.import_module(spec.module), spec.renderer_class
+        )
+        assert base.RENDERER_REGISTRY[spec.name] is expected_class


### PR DESCRIPTION
## Summary

- add a declarative `RendererSpec` manifest for renderer names, loaders, config classes, model IDs, aliases, and modalities
- derive runtime registration, auto-routing, multimodal metadata, config lookup, and lazy imports from that manifest
- require every mapped checkpoint to resolve to an explicitly parity-tested representative
- add structural tests preventing registry and config-union drift

`RendererConfig` remains explicit for static typing, with an exact manifest consistency guard. Generated model routing and modality maps are unchanged from `main`.

## Validation

- `9763 passed, 57 skipped` (`tests/test_multimodal.py` excluded because processor loading requires unavailable Hugging Face network access in the local sandbox)
- `ruff check .`
- exact comparison of generated routing and modality maps against `origin/main`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with structural tests and claimed byte-identical routing/modality maps; risk is accidental drift when editing the manifest, not runtime behavior change.
> 
> **Overview**
> Introduces a single declarative manifest in `renderers/registry.py` (`RendererSpec` / `ModelSpec` / `RENDERER_SPECS`) that records renderer names, import paths, config classes, HF model IDs, **aliases**, and multimodal modalities.
> 
> **`renderers.base`**, **`renderers.configs`**, and **`renderers.__init__`** no longer maintain parallel hand-edited maps. **`MODEL_RENDERER_MAP`**, **`MULTIMODAL_MODELS`**, lazy renderer imports, **`_CONFIG_BY_NAME`**, and **`_populate_registry`** are all built from the manifest. Aliases route like their representative checkpoint and inherit modalities; **`MODEL_PARITY_REPRESENTATIVES`** ties every mapped ID to a parity-tested model.
> 
> **`RendererConfig`** pydantic variants stay explicit for typing; **`tests/test_registry.py`** locks manifest ↔ runtime metadata ↔ config union consistency and checks representatives exist in **`MODEL_CATALOG`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88973d546c403c9e0cbdf6584b78ca5d2dd6299a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Centralize renderer metadata into `RENDERER_SPECS` registry
> - Adds [renderers/registry.py](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-f1741b019e6b6bf95b4424a8197aad355869972a5a417acfd3adcd14194f109e) as the single source of truth for renderer metadata, defining `RendererSpec` and `ModelSpec` dataclasses plus the `RENDERER_SPECS` tuple that describes all renderers, their modules, classes, configs, and covered models with aliases and modalities
> - Replaces hardcoded mappings in [`_LAZY_RENDERERS`](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-725479866a1fdfd1bc9e7015505861bc1c43aae3fe5e8cead1942fcdf2556bb7), [`MODEL_RENDERER_MAP`](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf), [`MULTIMODAL_MODELS`](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf), [`_populate_registry`](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf), and [`_CONFIG_BY_NAME`](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-10791887ddad1a2d5da4c3ca89cda9ebb2a9fbb0fe806df97467baf11c546029) with dict comprehensions that derive their entries from `RENDERER_SPECS` at import time
> - `_validate_specs()` runs at import time and raises `ValueError` on duplicate renderer names, classes, or model IDs, or unknown modality values
> - Adds [tests/test_registry.py](https://github.com/PrimeIntellect-ai/renderers/pull/146/files#diff-0abc741bfcebe9debcf5eb70d01e66db1ccb9036877f195680d25bf73e9e9083) asserting that all runtime metadata maps match computations from `RENDERER_SPECS` and that `_populate_registry` loads every declared renderer
> - Risk: importing `renderers.registry` now raises `ValueError` at import time if any spec has a duplicate name, class, or model ID — a previously-silent condition
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 88973d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->