### PR TITLE
feat(deepseek-v4): convert <think> passages in content to reasoning

### DIFF
--- a/renderers/deepseek_v4.py
+++ b/renderers/deepseek_v4.py
@@ -192,6 +192,29 @@ def _reasoning_content(message: Mapping[str, Any]) -> str:
     return ""
 
 
+def _split_inline_reasoning(content: str) -> tuple[str, str]:
+    """Split a ``<think>...</think>`` passage in ``content`` into reasoning.
+
+    Returns ``(reasoning, visible_content)``.  ``<think>`` and ``</think>`` are
+    real tokens, so a passage left in ``content`` collides with the delimiters
+    the renderer emits itself.  Whatever sits between them is kept byte for
+    byte, because the renderer joins reasoning and content with no separator.
+    """
+    if "</think>" not in content:
+        return "", content
+    before, after = content.split("</think>", 1)
+    head, opener, reasoning = before.partition("<think>")
+    if not opener or head.strip():
+        # Without an opener, or with text ahead of it, the message does not say
+        # which part is reasoning.  Guessing would either drop that text or
+        # reclassify it, so leave the content as written: this is a problem
+        # with the data, not one the renderer should decide.
+        return "", content
+    # A whitespace-only prefix has no slot in the rendered stream, which opens
+    # with the renderer's own ``<think>``.  Every sibling strips it likewise.
+    return reasoning, after
+
+
 def _tool_function(tool: Mapping[str, Any]) -> Mapping[str, Any]:
     function = tool.get("function")
     return function if isinstance(function, Mapping) else tool
@@ -263,6 +286,12 @@ def _prepare_messages(messages: list[Message]) -> list[_LogicalMessage]:
         )
         if role == "assistant":
             logical.reasoning_content = _reasoning_content(message)
+            if not logical.reasoning_content and isinstance(
+                message.get("content"), str
+            ):
+                logical.reasoning_content, logical.content = _split_inline_reasoning(
+                    logical.content
+                )
             logical.tool_calls = list(message.get("tool_calls") or [])
         merged.append(logical)
 

--- a/tests/test_deepseek_v4.py
+++ b/tests/test_deepseek_v4.py
@@ -15,6 +15,7 @@ from renderers import (
     create_renderer,
 )
 from renderers.base import MODEL_RENDERER_MAP, load_tokenizer
+from renderers.deepseek_v4 import _split_inline_reasoning
 from tests.reference_rendering import render_reference
 
 
@@ -562,4 +563,208 @@ def test_bridge_extends_developer_query_when_preserving_all_thinking():
     assert bridged.token_ids == renderer.render_ids(
         [*prior_messages, answer, *new_messages],
         add_generation_prompt=True,
+    )
+
+
+def test_thinking_in_content_is_converted_to_reasoning():
+    """Reasoning carried inline in ``content`` becomes the turn's reasoning.
+
+    Deliberate divergence from ``_render_deepseek_v4_reference``: the reference
+    encoder reads only ``reasoning_content``, so it emits the renderer's own
+    ``<think>`` delimiter *and* the data's, producing an unmatched pair.  Here
+    ``<think>``/``</think>`` are real tokens, so that stream is always
+    malformed; widening the accepted input domain past upstream lets raw SFT
+    rows render.  ``tests/reference_rendering.py`` stays a faithful mirror, and
+    ``deepseek-v4`` is left out of the parity suite's ``inline-thinking-history``
+    scenario.
+    """
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "<think>reasoning</think>answer"},
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think>reasoning</think>answer{EOS}"
+    )
+
+
+def test_inline_think_split_keeps_every_byte():
+    """The split is verbatim.  DeepSeek V4 concatenates reasoning, ``</think>``
+    and content with no separator, so preserving whitespace on both sides of
+    the delimiters is what makes a re-render reproduce the original stream."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "<think>\nreason\n</think>\n\nanswer"},
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think>\nreason\n</think>\n\nanswer{EOS}"
+    )
+
+
+def test_inline_think_is_dropped_when_thinking_disabled():
+    """Under the default config the converted reasoning is dropped like any other,
+    leaving the generation prompt's ``</think>`` and no stray opener."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "<think>reasoning</think>answer"},
+    ]
+
+    text = _decode(_renderer(), messages)
+
+    assert text == f"{BOS}{USER}hi{ASSISTANT}</think>answer{EOS}"
+    assert "<think>" not in text
+
+
+def test_inline_think_history_follows_drop_thinking():
+    messages = [
+        {"role": "user", "content": "First"},
+        {"role": "assistant", "content": "<think>old secret</think>First answer"},
+        {"role": "user", "content": "Second"},
+        {
+            "role": "assistant",
+            "content": "<think>current thought</think>Second answer",
+        },
+    ]
+
+    dropped = _decode(_renderer(enable_thinking=True), messages)
+    assert dropped == (
+        f"{BOS}{USER}First{ASSISTANT}</think>First answer{EOS}"
+        f"{USER}Second{ASSISTANT}<think>current thought</think>Second answer{EOS}"
+    )
+    assert "old secret" not in dropped
+
+    assert _decode(_renderer(enable_thinking=True, drop_thinking=False), messages) == (
+        f"{BOS}{USER}First{ASSISTANT}<think>old secret</think>First answer{EOS}"
+        f"{USER}Second{ASSISTANT}<think>current thought</think>Second answer{EOS}"
+    )
+
+
+def test_tools_retain_converted_reasoning_on_history():
+    messages = [
+        {"role": "user", "content": "First"},
+        {"role": "assistant", "content": "<think>old secret</think>First answer"},
+        {"role": "user", "content": "Second"},
+        {
+            "role": "assistant",
+            "content": "<think>current thought</think>Second answer",
+        },
+    ]
+
+    text = _decode(_renderer(enable_thinking=True), messages, tools=TOOLS)
+
+    assert f"{USER}First{ASSISTANT}<think>old secret</think>First answer{EOS}" in text
+    assert (
+        f"{USER}Second{ASSISTANT}<think>current thought</think>Second answer{EOS}"
+    ) in text
+
+
+def test_explicit_reasoning_content_takes_precedence_over_the_split():
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "reasoning_content": "structured reasoning",
+            "content": "answer",
+        },
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think>structured reasoning</think>answer{EOS}"
+    )
+
+
+def test_converted_reasoning_survives_parse_and_rerender():
+    """The verbatim split is an identity: parsing the rendered
+    completion and rebuilding the message from the parsed halves re-renders to
+    the same token ids."""
+    renderer = _renderer(enable_thinking=True)
+    query = {"role": "user", "content": "hi"}
+    messages = [
+        query,
+        {"role": "assistant", "content": "<think>\nreason\n</think>\n\nanswer"},
+    ]
+    rendered = renderer.render_ids(messages)
+    assistant_id = _tokenizer().encode(ASSISTANT, add_special_tokens=False)[0]
+    completion_start = rendered.index(assistant_id) + 2  # skip Assistant + <think>
+
+    parsed = renderer.parse_response(rendered[completion_start:])
+
+    assert parsed.reasoning_content == "\nreason\n"
+    assert parsed.content == "\n\nanswer"
+    rebuilt = [
+        query,
+        {
+            "role": "assistant",
+            "reasoning_content": parsed.reasoning_content,
+            "content": parsed.content,
+        },
+    ]
+    assert renderer.render_ids(rebuilt) == rendered
+
+
+def test_thinking_is_converted_through_a_whitespace_prefix():
+    """Models routinely emit a newline before the opener.  The rendered stream
+    starts with the renderer's own ``<think>``, so there is no slot for that
+    prefix and no split can preserve it; normalizing it away is what every
+    sibling renderer does, and it beats falling back to a stray delimiter."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "\n<think>\nreason\n</think>\n\nanswer"},
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think>\nreason\n</think>\n\nanswer{EOS}"
+    )
+
+
+def test_inline_think_after_real_text_is_left_alone():
+    """Text before the opener has nowhere to go, and dropping it would delete
+    model output.  The turn keeps the pre-change rendering instead."""
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "Sure!<think>reason</think>answer"},
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think></think>Sure!<think>reason</think>answer{EOS}"
+    )
+
+
+def test_bare_closing_think_tag_is_left_alone():
+    """A closer with no opener does not say which part is reasoning.  Reading
+    the prefix as reasoning would reclassify text the message never marked, and
+    on a historical turn ``drop_thinking`` would then delete it.  The renderer
+    does not guess: this is a problem with the data.
+    """
+    messages = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "reason</think>answer"},
+    ]
+
+    assert _decode(_renderer(enable_thinking=True), messages) == (
+        f"{BOS}{USER}hi{ASSISTANT}<think></think>reason</think>answer{EOS}"
+    )
+
+
+def test_split_inline_reasoning_branches():
+    """The full branch table.  Anything the message does not mark clearly is
+    returned unchanged rather than guessed at."""
+    assert _split_inline_reasoning("plain answer") == ("", "plain answer")
+    assert _split_inline_reasoning("<think>r</think>a") == ("r", "a")
+    assert _split_inline_reasoning("\n <think>r</think>a") == ("r", "a")
+    assert _split_inline_reasoning("r</think>a") == ("", "r</think>a")
+    assert _split_inline_reasoning("r</think>a<think>r2</think>a2") == (
+        "",
+        "r</think>a<think>r2</think>a2",
+    )
+    # A doubled opener splits at the first one, keeping the inner marker inside
+    # the reasoning rather than dropping the text between them.  Known gap.
+    assert _split_inline_reasoning("<think>outer <think>inner</think>a") == (
+        "outer <think>inner",
+        "a",
+    )
+    assert _split_inline_reasoning("Sure!<think>r</think>a") == (
+        "",
+        "Sure!<think>r</think>a",
     )


### PR DESCRIPTION
# feat(deepseek-v4): convert `<think>` passages in assistant content to reasoning

`DeepSeekV4Renderer` doesn't convert inline reasoning, a `<think>...</think>` passage at the start of `content`, to properly rendered reasoning, as it solely looks for  a separate `reasoning_content` field. This PR gives support for this type of rendering, which is a necessity for various datasets such as `PrimeIntellect/INTELLECT-3-SFT-10K`

Current behavior:

```
messages = [{"role": "user", "content": "hi"},
            {"role": "assistant", "content": "<think>reasoning</think>answer"}]

before, enable_thinking=True    <|Assistant|><think></think><think>reasoning</think>answer<eos>
                                             ^^^^^^^^^^^^^^^^ empty block, then the data's real one
before, enable_thinking=False   <|Assistant|></think><think>reasoning</think>answer<eos>
                                             ^^^^^^^^ closes a block that never opened
after,  enable_thinking=True    <|Assistant|><think>reasoning</think>answer<eos>
after,  enable_thinking=False   <|Assistant|></think>answer<eos>
```

No combination of `enable_thinking` and `drop_thinking` avoids it, so it cannot be worked around in
configuration. `qwen3`, `qwen3.5`, `glm-4.5`, `glm-5`, `minimax-m2`, `kimi-k2.5`, and `laguna-xs.2`
already accept this shape in their own assistant-render hooks; this brings DeepSeek V4 in line.

## Divergence from the reference encoder, on purpose

Upstream `encoding_dsv4.py` reads only `reasoning_content` and silently emits the unmatched delimiter, and `tests/reference_rendering.py` mirrors that faithfully, so this input is now the one place the renderer does not match its reference. That file and `tests/parity.py` are left untouched, and `deepseek-v4` stays out of the `inline-thinking-history` scenario, matching `qwen3`.

## Notes

- Bytes between the delimiters are kept verbatim, since DeepSeek V4 joins them with no separator.
- Whitespace before the opener is dropped: the stream opens with the renderer's own `<think>`.
- Only a passage opening with `<think>` converts, so `"Sure!<think>r</think>a"` and `"reason</think>answer"` are left untouched rather than guessed at. The latter leaves `parse_deepseek_v4` disagreeing with the renderer, since it reads everything before `think_end_id` as reasoning.
- A doubled opener splits at the first one, leaving the inner marker inside the reasoning; an unclosed `<think>` in a `wo_eos` prefill turn is untouched, and already broken through `reasoning_content` too, upstream included.
- A non-empty `reasoning_content` wins, and structured list content keeps its existing path.
- With `enable_thinking=False` (the default) the passage is dropped rather than passed through.
- The `prime-rl` bump (submodule pointer and version pin) is a separate PR.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Convert inline `<think>` passages in assistant message content to reasoning in DeepSeek V4 renderer
> - Adds `_split_inline_reasoning` in [deepseek_v4.py](https://github.com/PrimeIntellect-ai/renderers/pull/147/files#diff-2b0e8e3fed0ce308b759b25c1dc30d12c73b6ef9be7fcf3442758a19d2434503) to extract a leading `<think>...</think>` block from assistant message content, returning the reasoning and remaining visible content as a tuple.
> - In `_prepare_messages`, if an assistant message has no explicit `reasoning_content` but its content contains an inline `<think>` block, the block is split out and treated as reasoning.
> - The split only fires when the `<think>` opener appears at the start of content (ignoring leading whitespace) and a closing tag exists; otherwise content is left unchanged.
> - Behavioral Change: assistant messages with inline `<think>` blocks will now have that segment removed from visible content and promoted to `reasoning_content`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 00968f6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->