### PR TITLE
feat: enforce canonical reasoning messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,22 @@ class Renderer(Protocol):
 - `ParsedResponse` is `(content, reasoning_content, tool_calls)`. It scans token ids for special-token boundaries (e.g. id `151657` for `<tool_call>` on Qwen3) — a literal `"<tool_call>"` in user content tokenizes to ordinary text ids and never matches.
 - Round-trip: rendering `[user, assistant(content, reasoning, tool_calls)]`, slicing the assistant completion, and feeding it through `parse_response` returns an equivalent structured message. Tested per-renderer in `tests/test_roundtrip.py`.
 
+### Structured assistant messages
+
+For renderers whose canonical message schema exposes structured reasoning,
+assistant reasoning must be supplied through `reasoning_content` (or the
+model-specific `reasoning` field). String `content` is opaque: renderers do not
+promote inline `<think>...</think>` passages into reasoning. Likewise, tool
+invocations belong in `tool_calls`, not in-band markup. Normalize legacy SFT
+datasets before rendering rather than relying on model-specific delimiter
+guessing.
+
+This restriction applies to render input, not model output. `parse_response`
+still decodes each model's sampled reasoning and tool delimiters into the
+structured `ParsedResponse` fields. Models whose canonical upstream template
+is itself content-only, such as DeepSeek R1 and Kimi K2, continue to follow
+that model-specific format.
+
 ### `bridge_to_next_turn` (the core contract)
 
 Given `(prev_prompt_ids, prev_completion_ids)` and new environment messages, return ids for the next turn's prompt such that the result starts with `prev_prompt_ids + prev_completion_ids` byte-for-byte and continues with the new messages plus the next assistant opener. If that cannot be proven safe, return `None` and the caller falls back to a full render.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Hand-coded renderers ship for `qwen3`, `qwen3-vl`, `qwen3.5`, `qwen3.6`, `qwen3.
 
 ```python
 class Renderer(Protocol):
+    supports_reasoning_content: bool
     def render(messages, *, tools=None, add_generation_prompt=False) -> RenderedTokens: ...
     def render_ids(messages, *, tools=None, add_generation_prompt=False) -> list[int]: ...
     def parse_response(token_ids) -> ParsedResponse: ...
@@ -76,19 +77,25 @@ class Renderer(Protocol):
 
 ### Structured assistant messages
 
-For renderers whose canonical message schema exposes structured reasoning,
-assistant reasoning must be supplied through `reasoning_content` (or the
-model-specific `reasoning` field). String `content` is opaque: renderers do not
-promote inline `<think>...</think>` passages into reasoning. Likewise, tool
-invocations belong in `tool_calls`, not in-band markup. Normalize legacy SFT
-datasets before rendering rather than relying on model-specific delimiter
-guessing.
+Canonical assistant messages use separate `reasoning_content`, `content`, and
+`tool_calls` fields. Reasoning-capable renderers project `reasoning_content`
+into the model's native wire format; they never infer it from `content`.
+Reserved inline `<think>...</think>` markup, the legacy model-specific
+`reasoning` field, and `thinking` content parts are rejected as ambiguous.
+Normalize legacy SFT datasets before rendering.
+
+Not every model has a structured reasoning channel. Each renderer exposes
+`supports_reasoning_content`; non-reasoning renderers (currently DeepSeek V3,
+Qwen3-VL, Llama 3, and the opaque `DefaultRenderer`) reject non-empty
+`reasoning_content` instead of silently discarding it. Explicit native-wire
+passthrough modes remain raw by definition and likewise do not accept
+structured reasoning.
 
 This restriction applies to render input, not model output. `parse_response`
 still decodes each model's sampled reasoning and tool delimiters into the
-structured `ParsedResponse` fields. Models whose canonical upstream template
-is itself content-only, such as DeepSeek R1 and Kimi K2, continue to follow
-that model-specific format.
+structured `ParsedResponse` fields. Content-only upstream templates, such as
+Kimi K2, are adapted internally by projecting canonical reasoning into their
+native assistant content before applying the wire format.
 
 ### `bridge_to_next_turn` (the core contract)
 

--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -24,7 +24,6 @@ from renderers.base import (
     RenderedTrainingSample,
     Renderer,
     TextPart,
-    ThinkingPart,
     Tokenizer,
     ToolCall,
     ToolCallFunction,
@@ -39,6 +38,7 @@ from renderers.base import (
     is_multimodal,
     reject_assistant_in_extension,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.client import MalformedGenerateResponseError, OverlongPromptError
 from renderers.configs import (
@@ -209,7 +209,6 @@ __all__ = [
     "Renderer",
     "RendererConfig",
     "TextPart",
-    "ThinkingPart",
     "Tokenizer",
     "ToolCall",
     "ToolCallFunction",
@@ -226,4 +225,5 @@ __all__ = [
     "is_multimodal",
     "reject_assistant_in_extension",
     "trim_to_turn_close",
+    "validate_canonical_messages",
 ]

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -107,7 +107,11 @@ class Message(TypedDict, total=False):
     """A single turn in a multi-turn conversation.
 
     Required keys: role, content.
-    Optional keys mirror the OpenAI chat format for tool calling.
+    Optional keys mirror the OpenAI chat format for tool calling and
+    structured reasoning. Renderers that support structured reasoning read it
+    only from the model's explicit reasoning field; they do not promote
+    ``<think>...</think>`` text embedded in string ``content``. Legacy datasets
+    must normalize that wire-format markup before rendering.
     """
 
     role: str
@@ -117,6 +121,24 @@ class Message(TypedDict, total=False):
     name: str
     reasoning: str
     reasoning_content: str
+
+
+def get_structured_reasoning(
+    message: Mapping[str, Any],
+    *fields: str,
+) -> str:
+    """Return reasoning from the first explicit string field.
+
+    ``content`` is intentionally never inspected. This helper is for renderers
+    whose canonical message schema separates visible content from reasoning;
+    model-output parsers remain responsible for decoding wire-format reasoning
+    delimiters into ``reasoning_content``.
+    """
+    for field_name in fields or ("reasoning_content",):
+        value = message.get(field_name)
+        if isinstance(value, str):
+            return value
+    return ""
 
 
 def extract_message_tool_names(messages: list[Message]) -> list[str | None]:

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 import logging
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -120,7 +120,7 @@ def validate_canonical_messages(
     *,
     supports_reasoning_content: bool,
     renderer_name: str,
-    allow_inline_reasoning_markup: bool = False,
+    allow_inline_reasoning_markup: bool | Collection[int] = False,
 ) -> None:
     """Validate the canonical message boundary before rendering.
 
@@ -131,7 +131,8 @@ def validate_canonical_messages(
     discarding it.
 
     ``allow_inline_reasoning_markup`` is reserved for explicit raw native-wire
-    passthrough modes. It must not be used to accept legacy dataset records.
+    passthrough modes. Pass a collection of message indices when only specific
+    messages are raw. It must not be used to accept legacy dataset records.
     """
     for message_index, message in enumerate(messages):
         if message.get("role") != "assistant":
@@ -163,6 +164,9 @@ def validate_canonical_messages(
             text_fragments.append(content)
         elif isinstance(content, list):
             for part in content:
+                if isinstance(part, str):
+                    text_fragments.append(part)
+                    continue
                 if not isinstance(part, Mapping):
                     continue
                 if part.get("type") == "thinking":
@@ -171,11 +175,16 @@ def validate_canonical_messages(
                         "uses a non-canonical 'thinking' content part; normalize "
                         "it to 'reasoning_content' before rendering"
                     )
+                part_type = part.get("type")
                 text = part.get("text")
-                if part.get("type") == "text" and isinstance(text, str):
+                if part_type in (None, "text", "input_text") and isinstance(text, str):
                     text_fragments.append(text)
 
-        if not allow_inline_reasoning_markup and any(
+        if isinstance(allow_inline_reasoning_markup, bool):
+            inline_markup_allowed = allow_inline_reasoning_markup
+        else:
+            inline_markup_allowed = message_index in allow_inline_reasoning_markup
+        if not inline_markup_allowed and any(
             "<think>" in fragment or "</think>" in fragment
             for fragment in text_fragments
         ):

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -37,13 +37,6 @@ class TextPart(TypedDict):
     text: str
 
 
-class ThinkingPart(TypedDict):
-    """Model's internal reasoning (chain-of-thought) as a content part."""
-
-    type: Literal["thinking"]
-    thinking: str
-
-
 class ImagePart(TypedDict, total=False):
     """An image attached to a message.
 
@@ -74,7 +67,7 @@ class VideoPart(TypedDict, total=False):
     video_url: dict[str, Any]
 
 
-ContentPart = TextPart | ThinkingPart | ImagePart | VideoPart
+ContentPart = TextPart | ImagePart | VideoPart
 
 # Content is either a plain string or a list of structured parts.
 Content = str | list[ContentPart]
@@ -119,26 +112,93 @@ class Message(TypedDict, total=False):
     tool_calls: list[ToolCall]
     tool_call_id: str
     name: str
-    reasoning: str
     reasoning_content: str
+
+
+def validate_canonical_messages(
+    messages: list[Message],
+    *,
+    supports_reasoning_content: bool,
+    renderer_name: str,
+    allow_inline_reasoning_markup: bool = False,
+) -> None:
+    """Validate the canonical message boundary before rendering.
+
+    Dataset adapters own conversion from legacy/model-native shapes into the
+    canonical schema. Renderers therefore consume assistant reasoning only from
+    ``reasoning_content`` and never infer it from ``content``. A renderer that
+    cannot represent structured reasoning must reject it instead of silently
+    discarding it.
+
+    ``allow_inline_reasoning_markup`` is reserved for explicit raw native-wire
+    passthrough modes. It must not be used to accept legacy dataset records.
+    """
+    for message_index, message in enumerate(messages):
+        if message.get("role") != "assistant":
+            continue
+
+        if "reasoning" in message:
+            raise ValueError(
+                f"{renderer_name}: assistant message {message_index} uses the "
+                "non-canonical 'reasoning' field; normalize it to "
+                "'reasoning_content' before rendering"
+            )
+
+        reasoning = message.get("reasoning_content")
+        if reasoning is not None and not isinstance(reasoning, str):
+            raise TypeError(
+                f"{renderer_name}: assistant message {message_index} has a "
+                "non-string 'reasoning_content'"
+            )
+        if reasoning and not supports_reasoning_content:
+            raise ValueError(
+                f"{renderer_name} does not support structured reasoning; "
+                f"assistant message {message_index} has non-empty "
+                "'reasoning_content'"
+            )
+
+        content = message.get("content")
+        text_fragments: list[str] = []
+        if isinstance(content, str):
+            text_fragments.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if not isinstance(part, Mapping):
+                    continue
+                if part.get("type") == "thinking":
+                    raise ValueError(
+                        f"{renderer_name}: assistant message {message_index} "
+                        "uses a non-canonical 'thinking' content part; normalize "
+                        "it to 'reasoning_content' before rendering"
+                    )
+                text = part.get("text")
+                if part.get("type") == "text" and isinstance(text, str):
+                    text_fragments.append(text)
+
+        if not allow_inline_reasoning_markup and any(
+            "<think>" in fragment or "</think>" in fragment
+            for fragment in text_fragments
+        ):
+            raise ValueError(
+                f"{renderer_name}: assistant message {message_index} contains "
+                "reserved reasoning markup in 'content'; normalize legacy "
+                "'<think>...</think>' data to 'reasoning_content' plus visible "
+                "'content' before rendering"
+            )
 
 
 def get_structured_reasoning(
     message: Mapping[str, Any],
-    *fields: str,
 ) -> str:
-    """Return reasoning from the first explicit string field.
+    """Return canonical assistant reasoning when it is a string.
 
     ``content`` is intentionally never inspected. This helper is for renderers
     whose canonical message schema separates visible content from reasoning;
     model-output parsers remain responsible for decoding wire-format reasoning
     delimiters into ``reasoning_content``.
     """
-    for field_name in fields or ("reasoning_content",):
-        value = message.get(field_name)
-        if isinstance(value, str):
-            return value
-    return ""
+    value = message.get("reasoning_content")
+    return value if isinstance(value, str) else ""
 
 
 def extract_message_tool_names(messages: list[Message]) -> list[str | None]:
@@ -731,6 +791,8 @@ class ChatTemplateTokenizer(Tokenizer, Protocol):
 @runtime_checkable
 class Renderer(Protocol):
     """Owns message ↔ token conversion for a specific model family."""
+
+    supports_reasoning_content: bool
 
     def render(
         self,

--- a/renderers/configs.py
+++ b/renderers/configs.py
@@ -621,10 +621,11 @@ class GptOssRendererConfig(BaseRendererConfig):
 class KimiK2RendererConfig(BaseRendererConfig):
     """Kimi K2 renderer config.
 
-    ``enable_thinking`` is renderer-internal here — Kimi K2's chat
-    template doesn't reference any thinking variable, so it's a no-op
-    against ``apply_chat_template`` parity. The field is kept for
-    protocol uniformity with the rest of the renderer family.
+    Kimi K2's chat template reads assistant content verbatim. The typed
+    renderer projects canonical ``reasoning_content`` into native
+    ``<think>...</think>`` content before applying that wire format.
+    ``enable_thinking`` remains a generation-control no-op because the
+    upstream template has no corresponding variable.
     """
 
     name: Literal["kimi-k2"] = "kimi-k2"
@@ -678,9 +679,9 @@ class LagunaM1RendererConfig(BaseRendererConfig):
     """Laguna M.1 renderer config.
 
     Laguna M.1 shares Laguna XS.2's role and tool-call format, but its
-    official checkpoint has a distinct chat template: it does not inject
-    XS.2's fallback system message and it gives ``message.reasoning``
-    precedence over ``message.reasoning_content``. Served by
+    official checkpoint has a distinct chat template and does not inject
+    XS.2's fallback system message. Canonical inputs always use
+    ``message.reasoning_content``. Served by
     :class:`renderers.laguna_xs2.LagunaM1Renderer`.
     """
 

--- a/renderers/deepseek_r1.py
+++ b/renderers/deepseek_r1.py
@@ -30,6 +30,7 @@ from renderers.deepseek_v3 import DeepSeekV3Renderer
 class DeepSeekR1Renderer(DeepSeekV3Renderer):
     """Deterministic message → token renderer for DeepSeek-R1 models."""
 
+    supports_reasoning_content = True
     _config_cls: type = DeepSeekR1RendererConfig
     _implied_thinking_retention = "template"
     _GEN_THINK_PREFILL: str = "<think>\n"
@@ -38,10 +39,9 @@ class DeepSeekR1Renderer(DeepSeekV3Renderer):
         """Assistant content with the reasoning trace stripped, mirroring the
         R1 template's ``content.split('</think>')[-1]`` on historical turns.
 
-        Structured ``thinking``/``text`` parts are reconstructed inline first
-        so the same ``</think>`` split applies. The separate
-        ``reasoning_content`` field is ignored — the R1 chat template never
-        reads it, and history reasoning is dropped regardless.
+        Canonical ``reasoning_content`` is accepted by this reasoning-capable
+        renderer, but the R1 template intentionally drops historical reasoning.
+        The visible ``content`` is therefore emitted unchanged.
         """
         content = msg.get("content") or ""
         if isinstance(content, list):
@@ -49,11 +49,7 @@ class DeepSeekR1Renderer(DeepSeekV3Renderer):
             for p in content:
                 if not isinstance(p, dict):
                     continue
-                if p.get("type") == "thinking":
-                    parts.append(f"<think>{p.get('thinking', '')}</think>")
-                elif p.get("type") == "text":
+                if p.get("type") == "text":
                     parts.append(p.get("text", ""))
             content = "".join(parts)
-        if "</think>" in content:
-            content = content.split("</think>")[-1]
         return content

--- a/renderers/deepseek_v3.py
+++ b/renderers/deepseek_v3.py
@@ -27,6 +27,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import DeepSeekV3RendererConfig
 from renderers.parsing import parse_deepseek_v3
@@ -53,6 +54,8 @@ class DeepSeekV3Renderer:
     this one. ``thinking_retention`` is a no-op here (no reasoning channel),
     stored for protocol uniformity.
     """
+
+    supports_reasoning_content = False
 
     #: Default typed config; the R1 subclass overrides this.
     _config_cls: type = DeepSeekV3RendererConfig
@@ -123,6 +126,11 @@ class DeepSeekV3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/deepseek_v4.py
+++ b/renderers/deepseek_v4.py
@@ -36,6 +36,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import DeepSeekV4RendererConfig
 from renderers.parsing import parse_deepseek_v4
@@ -178,18 +179,7 @@ def _tool_result_content(value: Any) -> str:
 
 def _reasoning_content(message: Mapping[str, Any]) -> str:
     reasoning = message.get("reasoning_content")
-    if reasoning is None:
-        reasoning = message.get("reasoning")
-    if reasoning is not None:
-        return str(reasoning)
-    content = message.get("content")
-    if isinstance(content, list):
-        return "".join(
-            str(part.get("thinking", ""))
-            for part in content
-            if isinstance(part, Mapping) and part.get("type") == "thinking"
-        )
-    return ""
+    return reasoning if isinstance(reasoning, str) else ""
 
 
 def _tool_function(tool: Mapping[str, Any]) -> Mapping[str, Any]:
@@ -292,6 +282,7 @@ def _prepare_messages(messages: list[Message]) -> list[_LogicalMessage]:
 class DeepSeekV4Renderer:
     """Renderer for ``deepseek-ai/DeepSeek-V4-Flash-0731``."""
 
+    supports_reasoning_content = True
     _implied_thinking_retention = "tool_cycle"
 
     def __init__(
@@ -373,6 +364,11 @@ class DeepSeekV4Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         return self._render(
             messages,
             tools=tools,

--- a/renderers/default.py
+++ b/renderers/default.py
@@ -19,6 +19,7 @@ from renderers.base import (
     ToolSpec,
     extract_message_tool_names,
     resolve_thinking_retention,
+    validate_canonical_messages,
 )
 from renderers.configs import DefaultRendererConfig
 from renderers.parsers import (
@@ -89,6 +90,10 @@ class DefaultRenderer:
     :class:`renderers.DefaultRendererConfig`).
     """
 
+    # An opaque Jinja template cannot promise that it consumes structured
+    # reasoning. Use a typed renderer when ``reasoning_content`` is present.
+    supports_reasoning_content = False
+
     def __init__(
         self,
         tokenizer: ChatTemplateTokenizer,
@@ -150,6 +155,11 @@ class DefaultRenderer:
         )
 
     def _apply(self, messages, *, tools=None, add_generation_prompt=False) -> list[int]:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         kwargs = dict(self.config.model_extra or {})
         kwargs["add_generation_prompt"] = add_generation_prompt
         kwargs["tokenize"] = True

--- a/renderers/gemma4.py
+++ b/renderers/gemma4.py
@@ -42,6 +42,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import Gemma4RendererConfig
 from renderers.qwen3_vl import (
@@ -428,6 +429,7 @@ class _ArgumentParser:
 class Gemma4Renderer:
     """Deterministic renderer for the canonical Gemma 4 instruction models."""
 
+    supports_reasoning_content = True
     _config_cls = Gemma4RendererConfig
 
     def __init__(
@@ -724,6 +726,11 @@ class Gemma4Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -819,7 +826,7 @@ class Gemma4Renderer:
                 em.text(f"{wire_role}\n", is_sampled=False, is_content=False)
 
             is_assistant = role == "assistant"
-            thinking = msg.get("reasoning") or msg.get("reasoning_content")
+            thinking = msg.get("reasoning_content")
             thinking_gate = pos > last_user_pos or (
                 self.config.preserve_thinking and bool(msg.get("tool_calls"))
             )

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -22,6 +22,7 @@ from renderers.base import (
     _content_mask_or_empty,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -467,17 +468,7 @@ class GLM45Renderer:
         emit_text,
         emit_text_segments,
     ):
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        elif "</think>" in content:
-            before, after = content.split("</think>", 1)
-            if "<think>" in before:
-                reasoning_content = before.split("<think>")[-1].lstrip("\n")
-            else:
-                reasoning_content = before.lstrip("\n")
-            reasoning_content = reasoning_content.rstrip("\n")
-            content = after.lstrip("\n")
+        reasoning_content = get_structured_reasoning(msg)
 
         # ``<|assistant|>\n`` is template-injected scaffolding — at
         # inference the chat template emits these as the generation

--- a/renderers/glm45.py
+++ b/renderers/glm45.py
@@ -26,6 +26,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
+    validate_canonical_messages,
 )
 from renderers.configs import GLM45RendererConfig
 from renderers.parsing import parse_glm
@@ -53,6 +54,8 @@ _TOOLS_FOOTER = (
 
 class GLM45Renderer:
     """Deterministic message → token renderer for GLM-4.5 Air models."""
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -124,6 +127,11 @@ class GLM45Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -27,6 +27,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
+    validate_canonical_messages,
 )
 from renderers.configs import GLM5RendererConfig, GLM51RendererConfig
 from renderers.parsing import parse_glm
@@ -51,6 +52,8 @@ _TOOLS_FOOTER = (
 
 class GLM5Renderer:
     """Deterministic message → token renderer for GLM-5 models."""
+
+    supports_reasoning_content = True
 
     # GLM-5.1 flips this on: even when the most-recent assistant has no
     # reasoning content, the template wraps it with ``<think></think>``
@@ -150,6 +153,11 @@ class GLM5Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/glm5.py
+++ b/renderers/glm5.py
@@ -23,6 +23,7 @@ from renderers.base import (
     _content_mask_or_empty,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -484,17 +485,7 @@ class GLM5Renderer:
         emit_text,
         emit_text_segments,
     ):
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        elif "</think>" in content:
-            before, after = content.split("</think>", 1)
-            if "<think>" in before:
-                reasoning_content = before.split("<think>")[-1].lstrip("\n")
-            else:
-                reasoning_content = before.lstrip("\n")
-            reasoning_content = reasoning_content.rstrip("\n")
-            content = after.lstrip("\n")
+        reasoning_content = get_structured_reasoning(msg)
 
         # ``<|assistant|>`` is template-injected: the chat template emits
         # it as the generation prompt at inference, and the model never

--- a/renderers/gpt_oss.py
+++ b/renderers/gpt_oss.py
@@ -61,6 +61,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import GptOssRendererConfig
 from renderers.parsing import parse_gpt_oss
@@ -120,6 +121,8 @@ def _arguments_to_str(arguments: Any) -> str:
 
 class GptOssRenderer:
     """Deterministic message → token renderer for OpenAI gpt-oss (harmony)."""
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -267,6 +270,11 @@ class GptOssRenderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/hy3.py
+++ b/renderers/hy3.py
@@ -306,6 +306,14 @@ class Hy3Renderer:
             messages,
             supports_reasoning_content=self.supports_reasoning_content,
             renderer_name=type(self).__name__,
+            allow_inline_reasoning_markup=(
+                {len(messages) - 1}
+                if self._raw_last_assistant
+                and messages
+                and messages[-1].get("role") == "assistant"
+                and not messages[-1].get("tool_calls")
+                else False
+            ),
         )
         if (
             self._raw_last_assistant

--- a/renderers/hy3.py
+++ b/renderers/hy3.py
@@ -41,6 +41,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
+    validate_canonical_messages,
 )
 from renderers.configs import Hy3RendererConfig, ResolvedThinkingRetention
 from renderers.parsing import parse_hy3
@@ -73,6 +74,8 @@ _TOOL_RESPONSE_END = f"</tool_response{_HYTK}>"
 
 class Hy3Renderer:
     """Deterministic message → token renderer for Tencent Hy3 models."""
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -181,12 +184,7 @@ class Hy3Renderer:
 
     def _reasoning_content(self, msg: Message) -> str | None:
         rc = msg.get("reasoning_content")
-        if isinstance(rc, str):
-            return rc
-        rc = msg.get("reasoning")
-        if isinstance(rc, str):
-            return rc
-        return None
+        return rc if isinstance(rc, str) else None
 
     def _tools_instruction_block(self, tools: list[ToolSpec], has_system: bool) -> str:
         """Build the ``# Tools`` instruction blob (all scaffold).
@@ -304,6 +302,23 @@ class Hy3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
+        if (
+            self._raw_last_assistant
+            and messages
+            and messages[-1].get("role") == "assistant"
+            and not messages[-1].get("tool_calls")
+            and messages[-1].get("reasoning_content")
+        ):
+            raise ValueError(
+                "Hy3Renderer raw_last_assistant cannot represent "
+                "'reasoning_content'; pass raw visible content only or disable "
+                "raw_last_assistant"
+            )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/inkling.py
+++ b/renderers/inkling.py
@@ -55,6 +55,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import INKLING_EFFORT_MAP, InklingRendererConfig
 from renderers.parsing import parse_inkling
@@ -170,6 +171,8 @@ class InklingRenderer:
     the native ``InklingProcessor`` (placeholder expansion included). Satisfies
     the :class:`~renderers.base.MultimodalRenderer` protocol.
     """
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -321,6 +324,11 @@ class InklingRenderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/kimi_k2.py
+++ b/renderers/kimi_k2.py
@@ -28,6 +28,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import KimiK2RendererConfig
 from renderers.parsing import parse_kimi_k2
@@ -38,12 +39,12 @@ _DEFAULT_SYSTEM = "You are Kimi, an AI assistant created by Moonshot AI."
 class KimiK2Renderer:
     """Deterministic message → token renderer for Kimi K2 models.
 
-    Kimi K2's chat template doesn't read any thinking-related variable —
-    ``content`` renders verbatim with no reasoning branch. The
-    ``enable_thinking`` / ``thinking_retention`` fields on the config are
-    stored for protocol uniformity with the rest of the renderer family
-    but have no effect on the byte-level output.
+    Canonical ``reasoning_content`` is projected into Kimi's native
+    ``<think>...</think>`` assistant body before rendering. Dataset records
+    must not carry those tags in ``content`` themselves.
     """
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -120,6 +121,11 @@ class KimiK2Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -221,10 +227,6 @@ class KimiK2Renderer:
                     if isinstance(part, dict):
                         if part.get("type") == "text":
                             parts.append(part.get("text", ""))
-                        elif part.get("type") == "thinking":
-                            parts.append(
-                                "<think>" + part.get("thinking", "") + "</think>"
-                            )
                     elif isinstance(part, str):
                         parts.append(part)
                 content = "".join(parts)
@@ -424,10 +426,6 @@ class KimiK2Renderer:
                     if isinstance(part, dict):
                         if part.get("type") == "text":
                             parts.append(part.get("text", ""))
-                        elif part.get("type") == "thinking":
-                            parts.append(
-                                "<think>" + part.get("thinking", "") + "</think>"
-                            )
                     elif isinstance(part, str):
                         parts.append(part)
                 content = "".join(parts)
@@ -493,15 +491,17 @@ class KimiK2Renderer:
         emit_text("assistant", msg_idx, is_sampled=False, is_content=False)
         emit_special(self._im_middle, msg_idx, is_sampled=False, is_content=False)
 
-        # Kimi K2's Jinja template has no reasoning-content support: the
-        # assistant turn renders its ``content`` verbatim, including any
-        # inline ``<think>...</think>`` tags. The separate
-        # ``reasoning_content`` field is dropped (the template never reads
-        # it). ``is_last_turn`` is unused here for the same reason.
+        # Kimi K2's native template reads only ``content``. Project the
+        # canonical reasoning field into the model's native wire format here;
+        # callers must never pre-encode these delimiters in ``content``.
         # On assistant tokens, ``is_content == sampled_mask`` by construction
         # — every sampled token is body, every scaffold token isn't.
         _ = is_last_turn
-        emit_text(content, msg_idx, is_sampled=True, is_content=True)
+        reasoning = msg.get("reasoning_content")
+        body = content
+        if isinstance(reasoning, str):
+            body = f"<think>{reasoning}</think>{content}"
+        emit_text(body, msg_idx, is_sampled=True, is_content=True)
 
         # Tool calls — model-sampled markup carrying caller / model body.
         tool_calls = msg.get("tool_calls") or []

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -43,6 +43,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import KimiK25RendererConfig
 from renderers.parsing import _reasoning_end_token_index, parse_kimi_k2_section
@@ -592,6 +593,7 @@ class KimiK25Renderer:
     The tokenizer should be ``moonshotai/Kimi-K2-Instruct`` (same as K2).
     """
 
+    supports_reasoning_content = True
     supports_process_multimodal = True
 
     def __init__(
@@ -752,6 +754,11 @@ class KimiK25Renderer:
           - Generation prompt: ``<|im_assistant|>assistant<|im_middle|>``
             + ``<think>`` (or ``<think></think>`` when thinking off)
         """
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -1349,30 +1356,13 @@ class KimiK25Renderer:
         content = msg.get("content")
         reasoning_content: str = ""
 
-        # Read reasoning only from structured fields / content parts. String
-        # content is opaque and never parsed for inline <think> markup.
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = get_structured_reasoning(msg)
-            if isinstance(content, list):
-                text_content = "".join(
-                    p.get("text", "")
-                    for p in content
-                    if isinstance(p, dict) and p.get("type") == "text"
-                )
-            else:
-                text_content = content or ""
-        elif isinstance(content, list):
-            thinking_parts = [
-                p.get("thinking", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "thinking"
-            ]
+        reasoning_content = get_structured_reasoning(msg)
+        if isinstance(content, list):
             text_parts = [
                 p.get("text", "")
                 for p in content
                 if isinstance(p, dict) and p.get("type") == "text"
             ]
-            reasoning_content = "".join(thinking_parts)
             text_content = "".join(text_parts)
         else:
             text_content = content or ""

--- a/renderers/kimi_k25.py
+++ b/renderers/kimi_k25.py
@@ -38,6 +38,7 @@ from renderers.base import (
     _content_mask_or_empty,
     _require_transformers,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -1348,9 +1349,10 @@ class KimiK25Renderer:
         content = msg.get("content")
         reasoning_content: str = ""
 
-        # Extract reasoning from structured content parts or inline <think> tags
+        # Read reasoning only from structured fields / content parts. String
+        # content is opaque and never parsed for inline <think> markup.
         if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
+            reasoning_content = get_structured_reasoning(msg)
             if isinstance(content, list):
                 text_content = "".join(
                     p.get("text", "")
@@ -1372,13 +1374,6 @@ class KimiK25Renderer:
             ]
             reasoning_content = "".join(thinking_parts)
             text_content = "".join(text_parts)
-        elif isinstance(content, str) and "</think>" in content:
-            before, _, after = content.partition("</think>")
-            if "<think>" in before:
-                reasoning_content = before.split("<think>", 1)[-1]
-            else:
-                reasoning_content = before
-            text_content = after.lstrip("\n")
         else:
             text_content = content or ""
 

--- a/renderers/laguna_xs2.py
+++ b/renderers/laguna_xs2.py
@@ -39,8 +39,8 @@ XS-2.1's template (upstream rev ``575f0f28``) is served by the
 
 Laguna M.1's official template (revision ``2bf8a4ab``) is served by
 :class:`LagunaM1Renderer`. It shares XS.2's byte layout, tool syntax, and
-generation prompt, but has no fallback system prompt and reads assistant
-reasoning from ``reasoning`` before falling back to ``reasoning_content``.
+generation prompt, but has no fallback system prompt. Canonical assistant
+reasoning always comes from ``reasoning_content``.
 
 S-2.1 subclasses :class:`LagunaXS21Renderer` from :mod:`renderers.laguna_s21`,
 overriding only the ``_render_history_reasoning`` seam.
@@ -65,6 +65,7 @@ from renderers.base import (
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
+    validate_canonical_messages,
 )
 from renderers.configs import (
     LagunaM1RendererConfig,
@@ -119,6 +120,8 @@ _TOOLS_HEADER_XS21 = (
 
 
 class LagunaXS2Renderer:
+    supports_reasoning_content = True
+
     def __init__(
         self,
         tokenizer: Tokenizer,
@@ -173,22 +176,6 @@ class LagunaXS2Renderer:
             return "".join(parts)
         return ""
 
-    @staticmethod
-    def _thinking_text(content: Content | None) -> str:
-        """Concatenate ``ThinkingPart`` entries from list-form content.
-
-        Used as a reasoning source in ``_render_assistant`` when neither
-        ``reasoning`` nor ``reasoning_content`` is present on the message.
-        Returns ``""`` for any non-list input.
-        """
-        if not isinstance(content, list):
-            return ""
-        parts: list[str] = []
-        for item in content:
-            if isinstance(item, dict) and item.get("type") == "thinking":
-                parts.append(item.get("thinking", ""))
-        return "".join(parts)
-
     def render(
         self,
         messages: list[Message],
@@ -196,6 +183,15 @@ class LagunaXS2Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        raw_passthrough = getattr(self.config, "render_assistant_messages_raw", False)
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=(
+                self.supports_reasoning_content and not raw_passthrough
+            ),
+            renderer_name=type(self).__name__,
+            allow_inline_reasoning_markup=raw_passthrough,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -582,17 +578,7 @@ class LagunaXS2Renderer:
         self, msg: Message, content: str
     ) -> tuple[str, str]:
         """Return the reasoning/body pair used by the XS.2 template."""
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        else:
-            # When the caller stores reasoning as a ``ThinkingPart`` inside
-            # a list-form ``content`` (e.g. after parse_response →
-            # reserialize), pull it out here so it survives the re-render.
-            part_thinking = self._thinking_text(msg.get("content"))
-            if part_thinking:
-                reasoning_content = part_thinking
-        return reasoning_content, content
+        return get_structured_reasoning(msg), content
 
     def _render_assistant_raw(
         self,
@@ -665,10 +651,7 @@ class LagunaM1Renderer(LagunaXS2Renderer):
     def _assistant_reasoning_and_content(
         self, msg: Message, content: str
     ) -> tuple[str, str]:
-        # ``reasoning`` wins whenever it is a string (including the empty
-        # string), then ``reasoning_content`` is considered. String content is
-        # opaque; callers must normalize legacy inline think blocks first.
-        return get_structured_reasoning(msg, "reasoning", "reasoning_content"), content
+        return get_structured_reasoning(msg), content
 
 
 class LagunaXS21Renderer(LagunaXS2Renderer):
@@ -702,6 +685,11 @@ class LagunaXS21Renderer(LagunaXS2Renderer):
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -1007,13 +995,7 @@ class LagunaXS21Renderer(LagunaXS2Renderer):
         emit_text,
         emit_text_segments,
     ) -> None:
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        else:
-            part_thinking = self._thinking_text(msg.get("content"))
-            if part_thinking:
-                reasoning_content = part_thinking
+        reasoning_content = get_structured_reasoning(msg)
 
         # ``<assistant>`` plus the think tag that follows are exactly the
         # generation prompt for the active mode — template-injected

--- a/renderers/laguna_xs2.py
+++ b/renderers/laguna_xs2.py
@@ -61,6 +61,7 @@ from renderers.base import (
     _infer_offsets_from_decode,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -664,23 +665,10 @@ class LagunaM1Renderer(LagunaXS2Renderer):
     def _assistant_reasoning_and_content(
         self, msg: Message, content: str
     ) -> tuple[str, str]:
-        # Match the official Jinja exactly: ``reasoning`` wins whenever it
-        # is a string (including the empty string), then
-        # ``reasoning_content`` is considered. An inline </think> block is
-        # removed from content and becomes the fallback reasoning source.
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning"), str):
-            reasoning_content = msg["reasoning"]
-        elif isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-
-        if "</think>" in content:
-            if not reasoning_content:
-                before_close = content.split("</think>", 1)[0].rstrip("\n")
-                reasoning_content = before_close.split("<think>")[-1].lstrip("\n")
-            content = content.rsplit("</think>", 1)[-1].lstrip("\n")
-
-        return reasoning_content, content
+        # ``reasoning`` wins whenever it is a string (including the empty
+        # string), then ``reasoning_content`` is considered. String content is
+        # opaque; callers must normalize legacy inline think blocks first.
+        return get_structured_reasoning(msg, "reasoning", "reasoning_content"), content
 
 
 class LagunaXS21Renderer(LagunaXS2Renderer):

--- a/renderers/llama_3.py
+++ b/renderers/llama_3.py
@@ -54,6 +54,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import Llama3RendererConfig
 from renderers.parsing import parse_llama_3
@@ -90,6 +91,8 @@ _TOOLS_IN_USER_INTRO = (
 
 class Llama3Renderer:
     """Deterministic message → token renderer for Llama-3.x Instruct models."""
+
+    supports_reasoning_content = False
 
     def __init__(
         self,
@@ -181,6 +184,11 @@ class Llama3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -24,6 +24,7 @@ from renderers.base import (
     _get_offset_tokenizer,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -494,16 +495,7 @@ class MiniMaxM2Renderer:
     ):
         content = self._visible_text(msg.get("content"))
 
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        elif "</think>" in content:
-            before, after = content.split("</think>", 1)
-            if "<think>" in before:
-                reasoning_content = before.split("<think>")[-1].strip("\n")
-            else:
-                reasoning_content = before.strip("\n")
-            content = after.strip("\n")
+        reasoning_content = get_structured_reasoning(msg)
 
         # ``]~b]ai\n`` is template-injected scaffolding — at inference
         # the chat template emits these as the generation prompt and the

--- a/renderers/minimax_m2.py
+++ b/renderers/minimax_m2.py
@@ -29,6 +29,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import MiniMaxM2RendererConfig
 from renderers.parsing import parse_minimax
@@ -56,6 +57,8 @@ _TOOLS_INSTRUCTIONS = (
 
 class MiniMaxM2Renderer:
     """Deterministic message → token renderer for MiniMax M2 / M2.5 models."""
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -112,6 +115,11 @@ class MiniMaxM2Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/nemotron3.py
+++ b/renderers/nemotron3.py
@@ -30,6 +30,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import (
     Nemotron3RendererConfig,
@@ -109,6 +110,8 @@ class Nemotron3Renderer:
     :class:`Nemotron3UltraRenderer` subclass below; both are registered under
     their own discriminator and differ only by the class-level hooks here.
     """
+
+    supports_reasoning_content = True
 
     # Variant hooks (overridden by ``Nemotron3UltraRenderer``): the default
     # config to build when none is passed, and whether to use Ultra's
@@ -283,6 +286,11 @@ class Nemotron3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 
@@ -727,9 +735,8 @@ class Nemotron3Renderer:
 
         # 1. Assemble ``content`` — wrap a ``reasoning_content`` field in
         #    <think> tags (raw, not stripped: interior whitespace is part of
-        #    the reasoning), else prepend an empty <think></think> only when
-        #    the content carries no inline think tags of its own (which are
-        #    passed through verbatim, like the template).
+        #    the reasoning), else prepend an empty <think></think>. Canonical
+        #    validation guarantees raw content cannot contain think tags.
         reasoning = msg.get("reasoning_content")
         if isinstance(reasoning, str) and reasoning.strip():
             if ultra:
@@ -750,9 +757,8 @@ class Nemotron3Renderer:
                     parts.append(content.strip() + "\n")
                 else:
                     # Drop historical thinking: keep only what follows the last
-                    # </think> (or precedes a dangling <think>), then re-stamp
-                    # an empty block. Nano/Super trim the remainder; Ultra glues
-                    # it raw (its template omits the trailing ``| trim``).
+                    # </think>, then re-stamp an empty block. The split operates
+                    # on renderer-generated native markup, never caller content.
                     c = content
                     if "</think>" in c:
                         c = c.split("</think>")[-1]

--- a/renderers/prime_qwen3.py
+++ b/renderers/prime_qwen3.py
@@ -20,6 +20,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import PrimeQwen3RendererConfig
 from renderers.parsing import parse_qwen35
@@ -191,6 +192,8 @@ class _TokenBuilder:
 class PrimeQwen3Renderer:
     """Renderer for PrimeIntellect/Qwen3-0.6B and Qwen3-1.7B."""
 
+    supports_reasoning_content = True
+
     def __init__(
         self,
         tokenizer: Tokenizer,
@@ -236,6 +239,11 @@ class PrimeQwen3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -34,6 +34,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import Qwen3RendererConfig
 from renderers.parsing import parse_qwen3
@@ -57,6 +58,8 @@ _TOOLS_FOOTER = (
 
 class Qwen3Renderer:
     """Deterministic message → token renderer for Qwen3 models."""
+
+    supports_reasoning_content = True
 
     def __init__(
         self,
@@ -129,6 +132,11 @@ class Qwen3Renderer:
         tools: list[ToolSpec] | None = None,
         add_generation_prompt: bool = False,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/qwen3.py
+++ b/renderers/qwen3.py
@@ -29,6 +29,7 @@ from renderers.base import (
     _content_mask_or_empty,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -453,17 +454,7 @@ class Qwen3Renderer:
         emit_text,
         emit_text_segments,
     ):
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        elif "</think>" in content:
-            before, after = content.split("</think>", 1)
-            if "<think>" in before:
-                reasoning_content = before.split("<think>")[-1].lstrip("\n")
-            else:
-                reasoning_content = before.lstrip("\n")
-            reasoning_content = reasoning_content.rstrip("\n")
-            content = after.lstrip("\n")
+        reasoning_content = get_structured_reasoning(msg)
 
         # ``<|im_start|>assistant\n`` is template-injected scaffolding —
         # at inference the chat template emits these as the generation

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -42,6 +42,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import Qwen35RendererConfig
 from renderers.parsing import parse_qwen35
@@ -124,6 +125,7 @@ def _default_enable_thinking(tokenizer) -> bool:
 class Qwen35Renderer:
     """Deterministic message → token renderer for Qwen3.5 models."""
 
+    supports_reasoning_content = True
     supports_process_multimodal = True
     _config_cls: type = Qwen35RendererConfig
 
@@ -343,6 +345,11 @@ class Qwen35Renderer:
         add_generation_prompt: bool = False,
         process_multimodal: bool = True,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -37,6 +37,7 @@ from renderers.base import (
     _require_transformers,
     attribute_text_segments,
     extract_message_tool_names,
+    get_structured_reasoning,
     reject_assistant_in_extension,
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
@@ -325,24 +326,10 @@ class Qwen35Renderer:
     def _extract_assistant_parts(msg: Message, content: str) -> tuple[str, str]:
         """Return ``(reasoning_content, visible_content)`` for an assistant.
 
-        Qwen3.5 and Qwen3.6 accept the legacy inline
-        ``<think>...</think>content`` shape when ``reasoning_content`` is
-        absent. Qwen3.8 removes that compatibility branch and overrides this
-        hook to keep inline markers in visible content.
+        Reasoning is a structured message field. Inline ``<think>`` markup in
+        ``content`` stays visible content and is never promoted implicitly.
         """
-        reasoning_content = ""
-        if isinstance(msg.get("reasoning_content"), str):
-            reasoning_content = msg["reasoning_content"]
-        elif "</think>" in content:
-            before_think_end, after_think_end = content.split("</think>", 1)
-            if "<think>" in before_think_end:
-                reasoning_content = before_think_end.split("<think>")[-1].lstrip("\n")
-            else:
-                reasoning_content = before_think_end.lstrip("\n")
-            reasoning_content = reasoning_content.rstrip("\n")
-            content = after_think_end.lstrip("\n")
-
-        return reasoning_content.strip(), content
+        return get_structured_reasoning(msg).strip(), content
 
     # ------------------------------------------------------------------
     # Core render method

--- a/renderers/qwen38.py
+++ b/renderers/qwen38.py
@@ -1,15 +1,12 @@
 """Qwen3.8 Renderer — mirrors the Qwen3.8 Jinja chat template.
 
 Qwen3.8 retains Qwen3.6's multimodal message grammar and JSON-safe tool
-argument serialization, with three template changes:
+argument serialization, with two template changes:
 
 - ``reasoning_effort`` can be ``xhigh`` (default), ``medium``, or ``low``;
   xhigh/low inject a matching instruction into the system prompt.
 - ``preserve_thinking`` defaults to true, so historical reasoning blocks are
   retained unless explicitly disabled.
-- Legacy inline ``<think>...</think>`` text is no longer split out of
-  assistant ``content``; only ``reasoning_content`` populates the reasoning
-  block.
 """
 
 from __future__ import annotations
@@ -54,13 +51,6 @@ class Qwen38Renderer(Qwen36Renderer):
         if last_query_index == len(messages):
             raise ValueError("No user query found in messages.")
         return last_query_index
-
-    @staticmethod
-    def _extract_assistant_parts(msg: Message, content: str) -> tuple[str, str]:
-        reasoning_content = msg.get("reasoning_content")
-        if not isinstance(reasoning_content, str):
-            reasoning_content = ""
-        return reasoning_content.strip(), content
 
 
 __all__ = ["Qwen38Renderer"]

--- a/renderers/qwen3_vl.py
+++ b/renderers/qwen3_vl.py
@@ -49,6 +49,7 @@ from renderers.base import (
     resolve_thinking_retention,
     should_rerender_for_thinking_retention,
     trim_to_turn_close,
+    validate_canonical_messages,
 )
 from renderers.configs import Qwen3VLRendererConfig
 from renderers.parsing import parse_qwen3
@@ -310,6 +311,7 @@ class Qwen3VLRenderer:
     ``thinking_retention`` still controls whether the bridge is attempted.
     """
 
+    supports_reasoning_content = False
     supports_process_multimodal = True
 
     def __init__(
@@ -411,8 +413,6 @@ class Qwen3VLRenderer:
                         continue
                     if "text" in item:
                         parts.append(item["text"])
-                    elif item.get("type") == "thinking" and "thinking" in item:
-                        parts.append(item["thinking"])
                 else:
                     raise ValueError(f"Unexpected content item: {item}")
             return "".join(parts)
@@ -461,6 +461,11 @@ class Qwen3VLRenderer:
         add_generation_prompt: bool = False,
         process_multimodal: bool = True,
     ) -> RenderedTokens:
+        validate_canonical_messages(
+            messages,
+            supports_reasoning_content=self.supports_reasoning_content,
+            renderer_name=type(self).__name__,
+        )
         if not messages:
             raise ValueError("No messages provided.")
 

--- a/tests/parity.py
+++ b/tests/parity.py
@@ -177,12 +177,10 @@ MODEL_CATALOG = (
     _model(
         "moonshotai/Kimi-K2.5",
         bridge=True,
-        excluded={"inline-thinking-history"},
     ),
     _model(
         "moonshotai/Kimi-K2.6",
         bridge=False,
-        excluded={"inline-thinking-history"},
     ),
     _model(
         "deepseek-ai/DeepSeek-V3",
@@ -374,26 +372,6 @@ SCENARIOS = (
                 "content": "6",
             },
         ],
-    ),
-    _scenario(
-        "inline-thinking-history",
-        [
-            {"role": "user", "content": "First"},
-            {
-                "role": "assistant",
-                "content": "<think>raw reasoning</think>visible answer",
-            },
-            {"role": "user", "content": "Second"},
-        ],
-        only_renderers={
-            "prime-qwen3",
-            "kimi-k2",
-            "nemotron-3",
-            "nemotron-3-ultra",
-            "nemotron-3.5",
-            "deepseek-v3",
-            "deepseek-r1",
-        },
     ),
     _scenario(
         "whitespace",
@@ -735,6 +713,33 @@ def scenario_is_valid(
     if (
         scenario.only_renderers
         and case.resolved_renderer not in scenario.only_renderers
+    ):
+        return False
+
+    if case.resolved_renderer in {"deepseek-v3", "qwen3-vl", "llama-3", "default"}:
+        if any(
+            message.get("role") == "assistant"
+            and bool(message.get("reasoning_content"))
+            for message in scenario.messages
+        ):
+            return False
+
+    has_reasoning = any(
+        message.get("role") == "assistant" and bool(message.get("reasoning_content"))
+        for message in scenario.messages
+    )
+    if (
+        has_reasoning
+        and case.resolved_renderer in {"laguna-xs.2", "laguna-m.1"}
+        and kwargs.get("render_assistant_messages_raw") is True
+    ):
+        return False
+    if (
+        has_reasoning
+        and case.resolved_renderer == "hy3"
+        and kwargs.get("raw_last_assistant") is True
+        and scenario.messages[-1].get("role") == "assistant"
+        and not scenario.messages[-1].get("tool_calls")
     ):
         return False
 

--- a/tests/reference_rendering.py
+++ b/tests/reference_rendering.py
@@ -1,9 +1,10 @@
 """Reference-oracle registry for the shared test barrage.
 
 The oracle is selected from the resolved renderer, not assumed to be Hugging
-Face ``apply_chat_template``. Most checkpoints currently route to that adapter,
-DeepSeek V4 routes to its shipped Python-encoder contract, and GPT-OSS routes to
-Harmony. ``render_reference`` is the single invocation path for all three.
+Face ``apply_chat_template``. Most checkpoints currently route to that adapter.
+Kimi K2 first projects canonical reasoning into its content-only native
+template, DeepSeek V4 routes to its shipped Python-encoder contract, and
+GPT-OSS routes to Harmony. ``render_reference`` is the single invocation path.
 
 The compact DSV4 implementation below is deliberately test-side and independent
 of ``renderers.deepseek_v4``.  It mirrors the public chat/tool branches of the
@@ -419,6 +420,23 @@ def _render_hugging_face(
     return list(result)
 
 
+def _render_kimi_k2(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    **kwargs: Any,
+) -> list[int]:
+    """Project canonical reasoning into Kimi K2's content-only Jinja input."""
+    projected = copy.deepcopy(messages)
+    for message in projected:
+        if message.get("role") != "assistant":
+            continue
+        reasoning = message.pop("reasoning_content", None)
+        if isinstance(reasoning, str):
+            content = message.get("content") or ""
+            message["content"] = f"<think>{reasoning}</think>{content}"
+    return _render_hugging_face(tokenizer, projected, **kwargs)
+
+
 def _render_deepseek_v4(
     tokenizer: Any,
     messages: list[dict[str, Any]],
@@ -605,6 +623,7 @@ def _render_harmony(
 REFERENCE_ORACLES: Mapping[str, ReferenceOracle] = MappingProxyType(
     {
         "hugging-face": ReferenceOracle("hugging-face", _render_hugging_face),
+        "kimi-k2": ReferenceOracle("kimi-k2", _render_kimi_k2),
         "deepseek-v4": ReferenceOracle("deepseek-v4", _render_deepseek_v4),
         "harmony": ReferenceOracle("harmony", _render_harmony),
     }
@@ -617,6 +636,7 @@ RENDERER_ORACLE_ROUTES: Mapping[str, str] = MappingProxyType(
     {
         "deepseek-v4": "deepseek-v4",
         "gpt-oss": "harmony",
+        "kimi-k2": "kimi-k2",
     }
 )
 """Renderer families whose canonical reference is not a Jinja template."""

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -233,7 +233,15 @@ def test_bridge_declines_across_user_query_when_template_drops_thinking():
     p, comp = prior(r, think)
     assert r.bridge_to_next_turn(p, comp, [u2]) is None
     # ...and the caller's faithful re-render matches the chat template
-    hist = [u1, {"role": "assistant", "content": think}, u2]
+    hist = [
+        u1,
+        {
+            "role": "assistant",
+            "reasoning_content": "2 plus 2 is 4.",
+            "content": "4",
+        },
+        u2,
+    ]
     rendered = tok.decode(r.render_ids(hist, add_generation_prompt=True))
     assert rendered == tok.apply_chat_template(
         hist, tokenize=False, add_generation_prompt=True

--- a/tests/test_deepseek_r1.py
+++ b/tests/test_deepseek_r1.py
@@ -7,6 +7,8 @@ stripping of ``</think>`` from historical assistant turns.
 
 from functools import lru_cache
 
+import pytest
+
 from renderers import (
     DeepSeekR1Renderer,
     DeepSeekV3Renderer,
@@ -52,14 +54,15 @@ def test_generation_prompt_differs():
 
 
 def test_r1_strips_reasoning_from_history():
-    """A historical assistant turn carrying an inline ``<think>…</think>``
-    trace renders only the post-``</think>`` answer, byte-identical to the R1
-    chat template's ``content.split('</think>')[-1]``.
-    """
+    """R1 accepts canonical reasoning but its template drops it from history."""
     tok, r1 = _r1()
     msgs = [
         {"role": "user", "content": "q"},
-        {"role": "assistant", "content": "<think>private reasoning</think>The answer."},
+        {
+            "role": "assistant",
+            "reasoning_content": "private reasoning",
+            "content": "The answer.",
+        },
         {"role": "user", "content": "q2"},
     ]
     got = r1.render_ids(msgs)
@@ -70,16 +73,12 @@ def test_r1_strips_reasoning_from_history():
     assert "private reasoning" not in tok.decode(got)
 
 
-def test_v3_emits_content_verbatim_ignoring_reasoning():
-    """V3 (non-reasoning) ignores ``reasoning_content`` — matching its
-    template, which only reads ``content``."""
-    tok, v3 = _v3()
+def test_v3_rejects_structured_reasoning():
+    """V3 must not silently discard canonical reasoning."""
+    _, v3 = _v3()
     msgs = [
         {"role": "user", "content": "x"},
         {"role": "assistant", "reasoning_content": "should be ignored", "content": "4"},
     ]
-    got = v3.render_ids(msgs)
-    expected = list(tok.apply_chat_template(msgs, tokenize=True, return_dict=False))
-
-    assert got == expected
-    assert "should be ignored" not in tok.decode(got)
+    with pytest.raises(ValueError, match="does not support structured reasoning"):
+        v3.render_ids(msgs)

--- a/tests/test_hy3.py
+++ b/tests/test_hy3.py
@@ -348,6 +348,25 @@ def test_raw_last_assistant_rejects_structured_reasoning():
         _renderer(raw_last_assistant=True).render_ids(convo)
 
 
+def test_raw_last_assistant_allows_inline_native_markup_only_on_raw_turn():
+    raw_content = "<think>prefix reasoning</think>answer prefix"
+    convo = [
+        {"role": "user", "content": "Q"},
+        {"role": "assistant", "content": raw_content},
+    ]
+    rendered = _decode(_renderer(raw_last_assistant=True).render_ids(convo))
+    assert rendered.endswith(_ASSISTANT + raw_content)
+
+    historical_inline = [
+        {"role": "user", "content": "Q1"},
+        {"role": "assistant", "content": raw_content},
+        {"role": "user", "content": "Q2"},
+        {"role": "assistant", "content": "answer prefix"},
+    ]
+    with pytest.raises(ValueError, match="normalize legacy.*reasoning_content"):
+        _renderer(raw_last_assistant=True).render_ids(historical_inline)
+
+
 def test_fallback_strategy_forces_high_and_no_gen_prompt():
     """``reasoning_toolcall_retry`` forces high effort and suppresses the gen
     prompt even when the caller asks for it."""

--- a/tests/test_hy3.py
+++ b/tests/test_hy3.py
@@ -332,11 +332,20 @@ def test_raw_last_assistant_drops_wrap_and_eos():
     """A trailing non-tool assistant renders as bare visible content."""
     convo = [
         {"role": "user", "content": "Q"},
-        {"role": "assistant", "reasoning_content": "R", "content": "the answer"},
+        {"role": "assistant", "content": "the answer"},
     ]
     raw = _decode(_renderer(raw_last_assistant=True).render_ids(convo))
     assert raw.endswith(_ASSISTANT + "the answer")  # no think wrap, no eos
     assert _THINK not in raw.split(_ASSISTANT)[-1]
+
+
+def test_raw_last_assistant_rejects_structured_reasoning():
+    convo = [
+        {"role": "user", "content": "Q"},
+        {"role": "assistant", "reasoning_content": "R", "content": "answer"},
+    ]
+    with pytest.raises(ValueError, match="raw_last_assistant cannot represent"):
+        _renderer(raw_last_assistant=True).render_ids(convo)
 
 
 def test_fallback_strategy_forces_high_and_no_gen_prompt():

--- a/tests/test_laguna_m1.py
+++ b/tests/test_laguna_m1.py
@@ -71,7 +71,7 @@ def test_auto_selection_and_typed_config():
     assert parsed.enable_thinking is True
 
 
-def test_reasoning_field_precedence_and_inline_think_extraction():
+def test_reasoning_field_precedence():
     precedence = [
         {"role": "user", "content": "Compute."},
         {
@@ -99,15 +99,6 @@ def test_reasoning_field_precedence_and_inline_think_extraction():
     got = _renderer(enable_thinking=True).render_ids(empty_reasoning_wins)
     assert got == _expected(empty_reasoning_wins, enable_thinking=True)
     assert "also ignored" not in _tok().decode(got)
-
-    inline = [
-        {"role": "user", "content": "Compute."},
-        {
-            "role": "assistant",
-            "content": "<think>\ninline reason\n</think>\nvisible answer",
-        },
-    ]
-    assert _renderer().render_ids(inline) == _expected(inline)
 
 
 def test_reasoning_content_and_tool_call_round_trip():

--- a/tests/test_laguna_m1.py
+++ b/tests/test_laguna_m1.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import lru_cache
 
+import pytest
 from pydantic import TypeAdapter
 
 from renderers import (
@@ -71,34 +72,17 @@ def test_auto_selection_and_typed_config():
     assert parsed.enable_thinking is True
 
 
-def test_reasoning_field_precedence():
-    precedence = [
+def test_legacy_reasoning_field_is_rejected():
+    messages = [
         {"role": "user", "content": "Compute."},
         {
             "role": "assistant",
-            "reasoning": "preferred",
-            "reasoning_content": "ignored",
+            "reasoning": "legacy",
             "content": "answer",
         },
     ]
-    got = _renderer(enable_thinking=True).render_ids(precedence)
-    assert got == _expected(precedence, enable_thinking=True)
-    text = _tok().decode(got)
-    assert "preferred" in text
-    assert "ignored" not in text
-
-    empty_reasoning_wins = [
-        {"role": "user", "content": "Compute."},
-        {
-            "role": "assistant",
-            "reasoning": "",
-            "reasoning_content": "also ignored",
-            "content": "answer",
-        },
-    ]
-    got = _renderer(enable_thinking=True).render_ids(empty_reasoning_wins)
-    assert got == _expected(empty_reasoning_wins, enable_thinking=True)
-    assert "also ignored" not in _tok().decode(got)
+    with pytest.raises(ValueError, match="non-canonical 'reasoning' field"):
+        _renderer(enable_thinking=True).render_ids(messages)
 
 
 def test_reasoning_content_and_tool_call_round_trip():
@@ -106,7 +90,7 @@ def test_reasoning_content_and_tool_call_round_trip():
     prompt = [{"role": "user", "content": "Inspect the machine."}]
     assistant = {
         "role": "assistant",
-        "reasoning": "Need a command.",
+        "reasoning_content": "Need a command.",
         "content": "Running it.",
         "tool_calls": [
             {

--- a/tests/test_llama_3.py
+++ b/tests/test_llama_3.py
@@ -87,11 +87,7 @@ def test_preserve_thinking_flags_are_noops(llama_pair):
     _, _, tok, _ = llama_pair
     msgs = [
         {"role": "user", "content": "Hi."},
-        {
-            "role": "assistant",
-            "reasoning_content": "internal musings",
-            "content": "Hello!",
-        },
+        {"role": "assistant", "content": "Hello!"},
     ]
     base = Llama3Renderer(tok).render_ids(msgs)
     for level in ("tool_cycle", "all"):

--- a/tests/test_offsetless_tokenizers.py
+++ b/tests/test_offsetless_tokenizers.py
@@ -136,6 +136,11 @@ def test_offsetless_contract_across_renderer_matrix(
 ) -> None:
     """Every configured renderer preserves tokens and non-content metadata."""
 
+    if not renderer.supports_reasoning_content and any(
+        message.get("reasoning_content") for message in messages
+    ):
+        pytest.skip(f"{model_name}: renderer has no structured reasoning channel")
+
     expected = renderer.render(
         messages,
         tools=tools,

--- a/tests/test_preserve_thinking.py
+++ b/tests/test_preserve_thinking.py
@@ -53,6 +53,8 @@ def test_generic_thinking_retention_does_not_change_full_render(
 
     if isinstance(renderer, DefaultRenderer):
         pytest.skip("DefaultRenderer raises on explicit retention — covered separately")
+    if not renderer.supports_reasoning_content:
+        pytest.skip(f"{model_name}: renderer has no structured reasoning channel")
 
     default = renderer.render_ids(CONVERSATION)
     for retention in ("tool_cycle", "all"):

--- a/tests/test_qwen38.py
+++ b/tests/test_qwen38.py
@@ -157,8 +157,8 @@ def test_qwen38_text_and_tool_parity(config_kwargs, qwen38_model):
 
 
 @pytest.mark.parametrize("qwen38_model", QWEN38_MODELS)
-def test_qwen38_keeps_inline_think_markup_in_visible_content(qwen38_model):
-    tokenizer, renderer = _qwen38(qwen38_model)
+def test_qwen38_rejects_inline_think_markup(qwen38_model):
+    _, renderer = _qwen38(qwen38_model)
     messages = [
         {"role": "user", "content": "Echo this."},
         {
@@ -167,7 +167,8 @@ def test_qwen38_keeps_inline_think_markup_in_visible_content(qwen38_model):
         },
     ]
 
-    assert renderer.render_ids(messages) == _expected(tokenizer, messages)
+    with pytest.raises(ValueError, match="normalize legacy.*reasoning_content"):
+        renderer.render_ids(messages)
 
 
 @pytest.mark.parametrize("qwen38_model", QWEN38_MODELS)

--- a/tests/test_roundtrip.py
+++ b/tests/test_roundtrip.py
@@ -121,6 +121,10 @@ def test_roundtrip_reasoning_and_content(rt_model, rt_tokenizer, rt_renderer):
         "content": "The answer is four.",
         "reasoning_content": "Two plus two equals four.",
     }
+    if not rt_renderer.supports_reasoning_content:
+        with pytest.raises(ValueError, match="does not support structured reasoning"):
+            _extract_assistant_tokens(rt_renderer, PROMPT, msg)
+        return
     completion_ids = _extract_assistant_tokens(rt_renderer, PROMPT, msg)
     parsed = rt_renderer.parse_response(completion_ids)
 

--- a/tests/test_structured_reasoning.py
+++ b/tests/test_structured_reasoning.py
@@ -114,3 +114,20 @@ def test_non_canonical_structured_shapes_are_rejected(message, match):
             supports_reasoning_content=True,
             renderer_name="TestRenderer",
         )
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        ["<think>legacy</think>answer"],
+        [{"text": "<think>legacy</think>answer"}],
+        [{"type": "input_text", "text": "<think>legacy</think>answer"}],
+    ],
+)
+def test_inline_markup_is_rejected_in_every_text_list_shape(content):
+    with pytest.raises(ValueError, match="normalize legacy.*reasoning_content"):
+        validate_canonical_messages(
+            [{"role": "assistant", "content": content}],
+            supports_reasoning_content=True,
+            renderer_name="TestRenderer",
+        )

--- a/tests/test_structured_reasoning.py
+++ b/tests/test_structured_reasoning.py
@@ -7,7 +7,11 @@ from functools import lru_cache
 import pytest
 
 from renderers import create_renderer
-from renderers.base import get_structured_reasoning, load_tokenizer
+from renderers.base import (
+    get_structured_reasoning,
+    load_tokenizer,
+    validate_canonical_messages,
+)
 
 
 _INLINE_CONTENT = "<think>INLINE_REASONING_SENTINEL</think>VISIBLE_ANSWER_SENTINEL"
@@ -16,7 +20,7 @@ _INLINE_CONTENT = "<think>INLINE_REASONING_SENTINEL</think>VISIBLE_ANSWER_SENTIN
 # implementation that previously promoted inline string content into its
 # structured reasoning channel. Inherited variants (Qwen3.6, GLM-5.1, Kimi
 # K2.6) use the same implementation.
-_MODELS = (
+_REASONING_MODELS = (
     "Qwen/Qwen3-8B",
     "Qwen/Qwen3.5-9B",
     "THUDM/GLM-4.5-Air",
@@ -25,6 +29,13 @@ _MODELS = (
     "moonshotai/Kimi-K2.5",
     "poolside/Laguna-M.1",
     "deepseek-ai/DeepSeek-V4-Flash-0731",
+)
+
+_UNSUPPORTED_MODELS = (
+    "deepseek-ai/DeepSeek-V3",
+    "Qwen/Qwen3-VL-4B-Instruct",
+    "meta-llama/Llama-3.2-1B-Instruct",
+    "Qwen/Qwen2.5-0.5B-Instruct",
 )
 
 
@@ -46,41 +57,60 @@ def test_structured_reasoning_helper_never_reads_content():
         == "structured reasoning"
     )
 
-    # Model-specific field precedence includes an explicit empty string.
-    assert (
-        get_structured_reasoning(
+
+@pytest.mark.parametrize("model", _REASONING_MODELS)
+def test_inline_think_markup_is_rejected(model: str):
+    _, renderer = _load(model)
+    assert renderer.supports_reasoning_content is True
+    with pytest.raises(ValueError, match="normalize legacy.*reasoning_content"):
+        renderer.render(
+            [
+                {"role": "user", "content": "First question."},
+                {"role": "assistant", "content": _INLINE_CONTENT},
+            ]
+        )
+
+
+@pytest.mark.parametrize("model", _UNSUPPORTED_MODELS)
+def test_non_reasoning_renderers_reject_structured_reasoning(model: str):
+    _, renderer = _load(model)
+    assert renderer.supports_reasoning_content is False
+    with pytest.raises(ValueError, match="does not support structured reasoning"):
+        renderer.render(
+            [
+                {"role": "user", "content": "Question."},
+                {
+                    "role": "assistant",
+                    "reasoning_content": "private",
+                    "content": "Answer.",
+                },
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "message,match",
+    [
+        (
+            {"role": "assistant", "reasoning": "legacy", "content": "answer"},
+            "non-canonical 'reasoning' field",
+        ),
+        (
             {
-                "reasoning": "",
-                "reasoning_content": "lower-priority reasoning",
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "legacy"},
+                    {"type": "text", "text": "answer"},
+                ],
             },
-            "reasoning",
-            "reasoning_content",
+            "non-canonical 'thinking' content part",
+        ),
+    ],
+)
+def test_non_canonical_structured_shapes_are_rejected(message, match):
+    with pytest.raises(ValueError, match=match):
+        validate_canonical_messages(
+            [message],
+            supports_reasoning_content=True,
+            renderer_name="TestRenderer",
         )
-        == ""
-    )
-
-
-@pytest.mark.parametrize("model", _MODELS)
-def test_inline_think_markup_stays_in_assistant_content(model: str):
-    tokenizer, renderer = _load(model)
-    rendered = renderer.render(
-        [
-            {"role": "user", "content": "First question."},
-            {"role": "assistant", "content": _INLINE_CONTENT},
-            {"role": "user", "content": "Second question."},
-        ]
-    )
-
-    assistant_ids = [
-        token_id
-        for token_id, message_index in zip(
-            rendered.token_ids, rendered.message_indices, strict=True
-        )
-        if message_index == 1
-    ]
-    assistant_text = tokenizer.decode(assistant_ids, skip_special_tokens=False)
-
-    assert _INLINE_CONTENT in assistant_text, (
-        f"{model} promoted or removed inline think markup instead of keeping "
-        f"content opaque: {assistant_text!r}"
-    )

--- a/tests/test_structured_reasoning.py
+++ b/tests/test_structured_reasoning.py
@@ -1,0 +1,86 @@
+"""Structured reasoning is an input-schema field, not inline content markup."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import pytest
+
+from renderers import create_renderer
+from renderers.base import get_structured_reasoning, load_tokenizer
+
+
+_INLINE_CONTENT = "<think>INLINE_REASONING_SENTINEL</think>VISIBLE_ANSWER_SENTINEL"
+
+# The DeepSeek V4 PR target plus one checkpoint for every renderer
+# implementation that previously promoted inline string content into its
+# structured reasoning channel. Inherited variants (Qwen3.6, GLM-5.1, Kimi
+# K2.6) use the same implementation.
+_MODELS = (
+    "Qwen/Qwen3-8B",
+    "Qwen/Qwen3.5-9B",
+    "THUDM/GLM-4.5-Air",
+    "zai-org/GLM-5",
+    "MiniMaxAI/MiniMax-M2.5",
+    "moonshotai/Kimi-K2.5",
+    "poolside/Laguna-M.1",
+    "deepseek-ai/DeepSeek-V4-Flash-0731",
+)
+
+
+@lru_cache(maxsize=None)
+def _load(model: str):
+    tokenizer = load_tokenizer(model)
+    return tokenizer, create_renderer(tokenizer)
+
+
+def test_structured_reasoning_helper_never_reads_content():
+    assert get_structured_reasoning({"content": _INLINE_CONTENT}) == ""
+    assert (
+        get_structured_reasoning(
+            {
+                "content": _INLINE_CONTENT,
+                "reasoning_content": "structured reasoning",
+            }
+        )
+        == "structured reasoning"
+    )
+
+    # Model-specific field precedence includes an explicit empty string.
+    assert (
+        get_structured_reasoning(
+            {
+                "reasoning": "",
+                "reasoning_content": "lower-priority reasoning",
+            },
+            "reasoning",
+            "reasoning_content",
+        )
+        == ""
+    )
+
+
+@pytest.mark.parametrize("model", _MODELS)
+def test_inline_think_markup_stays_in_assistant_content(model: str):
+    tokenizer, renderer = _load(model)
+    rendered = renderer.render(
+        [
+            {"role": "user", "content": "First question."},
+            {"role": "assistant", "content": _INLINE_CONTENT},
+            {"role": "user", "content": "Second question."},
+        ]
+    )
+
+    assistant_ids = [
+        token_id
+        for token_id, message_index in zip(
+            rendered.token_ids, rendered.message_indices, strict=True
+        )
+        if message_index == 1
+    ]
+    assistant_text = tokenizer.decode(assistant_ids, skip_special_tokens=False)
+
+    assert _INLINE_CONTENT in assistant_text, (
+        f"{model} promoted or removed inline think markup instead of keeping "
+        f"content opaque: {assistant_text!r}"
+    )


### PR DESCRIPTION
## Summary

- define one canonical assistant-message schema: `reasoning_content`, `content`, and `tool_calls`
- validate that schema at every renderer boundary; reject legacy `reasoning`, `thinking` content parts, and inline `<think>...</think>` markup with normalization guidance
- expose `supports_reasoning_content` on every renderer and make DeepSeek V3, Qwen3-VL, Llama 3, and the opaque default renderer reject non-empty structured reasoning instead of silently dropping it
- project canonical reasoning into model-native wire formats inside reasoning-capable renderers, including Kimi K2's content-only Jinja template
- keep explicit raw native-wire modes raw: inline tags remain allowed there, while structured reasoning is rejected when that mode cannot represent it
- preserve output parsing as the inverse transformation from model-native delimiters to canonical `ParsedResponse` fields

## Rationale

Legacy datasets should be normalized before they reach a renderer. Renderers should not guess whether `<think>` text inside assistant content is reasoning or literal visible content, and non-reasoning templates should never discard a populated `reasoning_content` field without telling the caller.

This intentionally declines backward compatibility with inline reasoning input, including the approach proposed in #147. Dataset adapters own legacy-to-canonical conversion; typed renderers own canonical-to-native serialization.

## Tests

- full offline suite: 9,695 passed, 76 skipped
- review-focused canonical-validation and Hy3 parity suite: 1,399 passed
- all 7,206 shared byte-parity cases pass
- Ruff and `git diff --check` pass


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce canonical reasoning messages across all renderers
> - Adds `validate_canonical_messages()` in [base.py](https://github.com/PrimeIntellect-ai/renderers/pull/148/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) that rejects legacy `reasoning` fields, `thinking` content parts, unsupported `reasoning_content`, and inline `<think>` markup in assistant message history.
> - Adds `get_structured_reasoning()` helper that reads only `reasoning_content`; all renderers replace ad-hoc inline `<think>` parsing and legacy field fallbacks with this single call.
> - Adds `supports_reasoning_content: bool` to the `Renderer` protocol; non-reasoning renderers (DeepSeek V3, Qwen3-VL, Llama 3, `DefaultRenderer`) now raise `ValueError` when given `reasoning_content`.
> - Removes the `ThinkingPart` type and `reasoning` field from the `Message` schema; `ContentPart` now only accepts `TextPart | ImagePart | VideoPart`.
> - Introduces [tests/test_structured_reasoning.py](https://github.com/PrimeIntellect-ai/renderers/pull/148/files#diff-970951374b0abc093ce789fbf49d746b524b99c29df1f752b1cc047b798cb568) with a parametrized suite covering all enforcement rules across renderer families.
> - Risk: any caller passing legacy `reasoning` fields, `thinking` content parts, or inline `<think>` markup in historical assistant turns will now receive a `ValueError` at render time.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6afbd78.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking input contract for legacy datasets and any caller relying on inline think tags or silent dropping of `reasoning_content`; behavior is intentional but will fail fast at render time across many model families.
> 
> **Overview**
> This PR **tightens the assistant-message contract** so render input must use `reasoning_content`, `content`, and `tool_calls` only—no guessing from wire-format text in `content`.
> 
> **Validation and API:** Adds `validate_canonical_messages` (called from each renderer’s `render` path) and `get_structured_reasoning`, which reads only `reasoning_content`. The `Renderer` protocol gains `supports_reasoning_content`. Legacy `reasoning`, `thinking` content parts, and inline `<think>` markup in `content` raise with normalization guidance; `ThinkingPart` and the `reasoning` field are removed from the public message types.
> 
> **Behavior:** Reasoning-capable renderers project `reasoning_content` into native wire formats (including **Kimi K2**, which previously ignored structured reasoning). DeepSeek V3, Qwen3-VL, Llama 3, and `DefaultRenderer` set `supports_reasoning_content = False` and **error** on non-empty `reasoning_content` instead of dropping it. Explicit raw passthrough modes (e.g. Laguna `render_assistant_messages_raw`, Hy3 `raw_last_assistant`) still allow inline markup on raw turns but reject structured reasoning when the mode cannot represent it.
> 
> **Tests/docs:** Parity drops the inline-thinking-history scenario, adds Kimi K2 reference projection, and introduces `test_structured_reasoning.py` plus updates across bridge, roundtrip, and model-specific tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6afbd78c6d653a6fe38f2b210a181a96bf894777. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->