### PR TITLE
fix: preserve generate endpoint usage metadata

### DIFF
--- a/renderers/client.py
+++ b/renderers/client.py
@@ -391,6 +391,7 @@ async def generate(
 
     return {
         "request_id": data.get("request_id") or "",
+        "usage": data.get("usage"),
         "prompt_ids": list(effective_prompt_ids or prompt_ids),
         "renderer_prompt_ids": list(prompt_ids) if content_parts else None,
         "mm_placeholders": mm_placeholders,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -68,6 +68,7 @@ class _FakeClient:
     def __init__(self):
         self.calls = []
         self.base_url = "http://fake-host:8000/v1"
+        self.usage = None
         routed_experts = np.array([[[1]], [[2]]], dtype=np.uint8)
         self.choice = {
             "index": 0,
@@ -93,6 +94,8 @@ class _FakeClient:
             "request_id": "gen-test",
             "choices": [self.choice],
         }
+        if self.usage is not None:
+            payload["usage"] = self.usage
         if body and body.get("content_parts"):
             payload["prompt_token_ids"] = [1, 2, 2, 3]
             payload["mm_placeholders"] = {"image": [{"offset": 1, "length": 2}]}
@@ -114,8 +117,22 @@ def _run_generate(client, renderer=None):
     )
 
 
-def test_generate_builds_request_body_and_parses_response():
+@pytest.mark.parametrize(
+    "usage",
+    [
+        None,
+        {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+            "prompt_tokens_details": {"cached_tokens": 2},
+            "completion_tokens_details": {"reasoning_tokens": 1},
+        },
+    ],
+)
+def test_generate_builds_request_body_and_parses_response(usage):
     client = _FakeClient()
+    client.usage = usage
     renderer = _FakeRenderer()
 
     result = asyncio.run(
@@ -167,6 +184,7 @@ def test_generate_builds_request_body_and_parses_response():
     assert result["routed_experts"]["data"].tobytes() == base64.b64encode(b"\x01\x02")
     assert result["multi_modal_data"] is None
     assert result["request_id"] == "gen-test"
+    assert result["usage"] == usage
     # Per-token attribution from the renderer surfaces on the result so
     # downstream consumers (verifiers RendererClient → prime-rl) can
     # build selective loss masks without a second render pass.


### PR DESCRIPTION
## Change

Forward the generate endpoint's optional usage dictionary alongside parsed tokens and content.
This preserves prompt-cache and reasoning-token details for downstream clients without changing
rendering, sampling, token evidence, or existing responses that omit usage.

Observed on the running Laguna/vLLM endpoint: an identical 1,045-token prompt reports 1,040 cached
tokens on its second request. Dropping this field makes downstream uncached-input budgets charge
the whole prompt again. The corresponding verifier change consumes the metadata through its
existing Usage.from_openai conversion.

## Validation

- 27 renderer client tests passed, including parametrized present/absent usage forwarding.
- Native changed-file lint and format hooks passed.
- Six model-free TrainClient/SDK accounting cases passed with the paired verifier change.
- Two tiny live synthetic TrainClient requests verified cache details survive to the SDK boundary:
  the second request charges 5 uncached prompt + 3 output = 8 new tokens, not 1,048.
- Type checking was attempted, but `ty` is not installed in the active research environment.
  No environment or serving deployment was modified to run these checks.

Tests used isolated worktrees; running frozen evaluations remain unchanged. Unsigned commit.


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve vLLM `usage` in `generate` client result
> Adds the upstream response's `usage` value to the result dict returned by the async `generate` client function in [client.py](https://github.com/PrimeIntellect-ai/renderers/pull/151/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33), passing it through without transformation or defaulting. Test coverage in [test_client.py](https://github.com/PrimeIntellect-ai/renderers/pull/151/files#diff-0d92063e88430a02df61616c5f16b148b64ac4539d9cb9b8d883d5a23351b110) is now parameterized to cover both responses without usage and responses with token, cached-token, and reasoning-token details.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0b00a91.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an optional passthrough field on the generate result with no changes to rendering, sampling, or token parsing.
> 
> **Overview**
> **`generate`** now includes the upstream **`/inference/v1/generate`** response’s optional **`usage`** object on its result dict (`data.get("usage")`), passed through unchanged so callers can see prompt/completion totals and details like **`cached_tokens`** and **`reasoning_tokens`**. When the engine omits usage, the field is **`None`**, matching prior behavior for consumers that ignored it.
> 
> Tests mock usage on **`_FakeClient`** and parameterize the main generate test to assert forwarding for both absent and full usage payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b00a91fef5422adc2d8940d14f9bbd02f15fd10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->