### PR TITLE
feat: expose structural completion status from parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ parsed = r.parse_response(completion_ids)
 # ParsedResponse(content=..., reasoning_content=..., tool_calls=...)
 ```
 
+`ParsedResponse.completion_status` reports structural validity: `complete`, `incomplete`,
+`invalid`, or `unknown`. The version-1 record includes a machine-readable `reason`.
+Laguna parsers account for reasoning opened by the generation prompt; Qwen3.5 also accepts
+that initial state explicitly. Parsers that cannot prove completion report `unknown`.
+This is not a claim about factual correctness or successful task completion.
+
+`renderers.client.generate()` combines this evidence with the engine's termination reason
+and malformed tool attempts, returning a `completion_status` dictionary. A length-limited
+generation is incomplete even if some final text exists; EOS inside reasoning is incomplete
+even when the engine reports `stop`. Tokens, logprobs, and the original finish reason are
+preserved. Consumers must not interpret `unknown` as verified completion.
+
 For the next turn, extend the previous sampled stream instead of re-rendering history:
 
 ```python

--- a/renderers/__init__.py
+++ b/renderers/__init__.py
@@ -8,6 +8,7 @@ except ImportError:
 
 from renderers.base import (
     ChatTemplateTokenizer,
+    CompletionStatus,
     Content,
     ContentPart,
     ImagePart,
@@ -189,6 +190,7 @@ __all__ = [
     "OffsetTokenizer",
     "OverlongPromptError",
     "ParsedResponse",
+    "CompletionStatus",
     "ParsedToolCall",
     "PlaceholderRange",
     "PrimeQwen3Renderer",

--- a/renderers/base.py
+++ b/renderers/base.py
@@ -617,6 +617,19 @@ class ParsedToolCall:
     id: str | None = None  # native tool-call id when the format carries one (Kimi K2)
 
 
+@dataclass(frozen=True)
+class CompletionStatus:
+    """Structural output validity, independent of generation termination or task success.
+
+    Parsers report what their grammar proves; unaudited parsers remain unknown.
+    The generate client also checks termination before exposing this on the wire.
+    """
+
+    status: Literal["complete", "incomplete", "invalid", "unknown"] = "unknown"
+    reason: str | None = "parser_unavailable"
+    version: Literal[1] = 1
+
+
 @dataclass
 class ParsedResponse:
     """Result of parsing completion tokens back into a structured message.
@@ -632,6 +645,27 @@ class ParsedResponse:
     content: str
     reasoning_content: str | None = None
     tool_calls: list[ParsedToolCall] = field(default_factory=list)
+    completion_status: CompletionStatus = field(default_factory=CompletionStatus)
+
+
+def classify_completion(
+    parsed: ParsedResponse, finish_reason: str | None
+) -> CompletionStatus:
+    """Combine parser evidence with termination without changing sampled output."""
+    status = parsed.completion_status
+    if status.status in {"incomplete", "invalid"}:
+        return status
+    if any(tc.status != ToolCallParseStatus.OK for tc in parsed.tool_calls):
+        return CompletionStatus("invalid", "malformed_tool_call")
+    if finish_reason == "length":
+        return CompletionStatus("incomplete", "output_truncated")
+    if finish_reason == "content_filter":
+        return CompletionStatus("invalid", "content_filtered")
+    if finish_reason not in {"stop", "tool_calls"}:
+        return CompletionStatus("unknown", "unknown_termination")
+    if not parsed.content.strip() and not parsed.tool_calls:
+        return CompletionStatus("incomplete", "missing_final_output")
+    return status
 
 
 @dataclass

--- a/renderers/client.py
+++ b/renderers/client.py
@@ -11,6 +11,7 @@ import json
 import logging
 import math
 from collections.abc import Mapping
+from dataclasses import asdict
 from typing import Any, cast
 
 import httpx
@@ -24,6 +25,7 @@ from renderers.base import (
     ToolCallParseStatus,
     ToolSpec,
     _require_transformers,
+    classify_completion,
 )
 
 _request_logger = logging.getLogger("renderers.client")
@@ -401,6 +403,9 @@ async def generate(
         "reasoning_content": parsed.reasoning_content,
         "tool_calls": parsed.tool_calls,
         "finish_reason": finish_reason,
+        "completion_status": asdict(
+            classify_completion(parsed, choice.get("finish_reason"))
+        ),
         "routed_experts": routed_experts,
         "sampling_mask": sampling_mask,
         # The mm sidecar consumed on the request side, surfaced back so

--- a/renderers/parsing.py
+++ b/renderers/parsing.py
@@ -19,7 +19,13 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from renderers.base import ParsedResponse, ParsedToolCall, ToolCallParseStatus, ToolSpec
+from renderers.base import (
+    CompletionStatus,
+    ParsedResponse,
+    ParsedToolCall,
+    ToolCallParseStatus,
+    ToolSpec,
+)
 
 
 # ── Schema-aware argument coercion ──────────────────────────────────
@@ -305,6 +311,7 @@ def parse_qwen35(
     tool_call_id: int,
     tool_call_end_id: int,
     tools: list[ToolSpec] | None = None,
+    prefilled_thinking: bool | None = None,
 ) -> ParsedResponse:
     """Parse Qwen3.5 completion tokens. XML-style tool calls, token-level thinking.
 
@@ -314,6 +321,9 @@ def parse_qwen35(
     semantics (PrimeQwen3Renderer): a sampled ``<think></think>`` must
     round-trip parse → message → render back to the same tokens, so an
     empty-but-present block is ``""``, never ``None``.
+
+    ``prefilled_thinking`` declares whether the generation prompt opened reasoning.
+    None leaves a delimiter-free completion's structural state unknown.
     """
     ids = _strip_stop_tokens(token_ids, stop_ids)
 
@@ -327,13 +337,21 @@ def parse_qwen35(
         reasoning = _decode(tokenizer, reasoning_ids).strip()
         ids = ids[think_end + 1 :]
         parse_offset = think_end + 1
-    elif think_id in set(ids):
+    elif think_id in set(ids) or prefilled_thinking:
         # <think> present but no </think> — truncated reasoning. Block
         # present ⇒ string (see docstring), even when nothing follows the
         # opening tag.
         think_start = _find(ids, think_id)
-        reasoning = _decode(tokenizer, ids[think_start + 1 :]).strip()
-        return ParsedResponse(content="", reasoning_content=reasoning, tool_calls=[])
+        reasoning_ids = ids if prefilled_thinking else ids[think_start + 1 :]
+        reasoning = _decode(
+            tokenizer, [t for t in reasoning_ids if t != think_id]
+        ).strip()
+        return ParsedResponse(
+            content="",
+            reasoning_content=reasoning,
+            tool_calls=[],
+            completion_status=CompletionStatus("incomplete", "unfinished_reasoning"),
+        )
 
     tc_start = _find(ids, tool_call_id)
     tool_calls: list[ParsedToolCall] = []
@@ -359,6 +377,9 @@ def parse_qwen35(
         content=content_text,
         reasoning_content=reasoning,
         tool_calls=tool_calls,
+        completion_status=CompletionStatus("complete", None)
+        if think_end != -1 or prefilled_thinking is False
+        else CompletionStatus(),
     )
 
 
@@ -868,7 +889,10 @@ def parse_laguna_xs2(
         reasoning_ids = ids if prefilled_thinking else ids[think_start + 1 :]
         reasoning = _segment([t for t in reasoning_ids if t != think_id])
         return ParsedResponse(
-            content="", reasoning_content=reasoning or None, tool_calls=[]
+            content="",
+            reasoning_content=reasoning or None,
+            tool_calls=[],
+            completion_status=CompletionStatus("incomplete", "unfinished_reasoning"),
         )
 
     tc_start = _find(ids, tool_call_id)
@@ -890,6 +914,7 @@ def parse_laguna_xs2(
         content=content_text,
         reasoning_content=reasoning or None,
         tool_calls=tool_calls,
+        completion_status=CompletionStatus("complete", None),
     )
 
 

--- a/renderers/qwen35.py
+++ b/renderers/qwen35.py
@@ -680,6 +680,7 @@ class Qwen35Renderer:
             tool_call_id=self._tool_call,
             tool_call_end_id=self._tool_call_end,
             tools=tools,
+            prefilled_thinking=self.config.enable_thinking,
         )
 
     def get_stop_token_ids(self) -> list[int]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,10 +7,12 @@ import numpy as np
 import pytest
 from renderers import MalformedGenerateResponseError
 from renderers.base import (
+    CompletionStatus,
     ParsedResponse,
     ParsedToolCall,
     RenderedTokens,
     ToolCallParseStatus,
+    classify_completion,
 )
 from renderers.client import generate
 
@@ -114,6 +116,111 @@ def _run_generate(client, renderer=None):
             model="test-model",
             tools=[{"type": "function", "function": {"name": "echo"}}],
         )
+    )
+
+
+@pytest.mark.parametrize(
+    "state,finish,content,expected,reason",
+    [
+        (CompletionStatus("complete", None), "stop", "summary", "complete", None),
+        (
+            CompletionStatus("complete", None),
+            "length",
+            "partial",
+            "incomplete",
+            "output_truncated",
+        ),
+        (
+            CompletionStatus("incomplete", "unfinished_reasoning"),
+            "stop",
+            "",
+            "incomplete",
+            "unfinished_reasoning",
+        ),
+        (
+            CompletionStatus("complete", None),
+            "stop",
+            "",
+            "incomplete",
+            "missing_final_output",
+        ),
+        (
+            CompletionStatus("complete", None),
+            None,
+            "summary",
+            "unknown",
+            "unknown_termination",
+        ),
+        (CompletionStatus(), "stop", "summary", "unknown", "parser_unavailable"),
+        (
+            CompletionStatus("complete", None),
+            "content_filter",
+            "partial",
+            "invalid",
+            "content_filtered",
+        ),
+    ],
+)
+def test_generate_completion_status(state, finish, content, expected, reason):
+    class Renderer(_FakeRenderer):
+        def parse_response(self, completion_ids, *, tools=None):
+            return ParsedResponse(content=content, completion_status=state)
+
+    client = _FakeClient()
+    client.choice["finish_reason"] = finish
+    result = _run_generate(client, Renderer())
+    assert result["completion_status"] == {
+        "version": 1,
+        "status": expected,
+        "reason": reason,
+    }
+    assert result["finish_reason"] == finish
+    assert result["completion_ids"] == [7, 8]
+    assert result["completion_logprobs"] == [-0.1, -0.2]
+
+
+@pytest.mark.parametrize(
+    "status", [s for s in ToolCallParseStatus if s != ToolCallParseStatus.OK]
+)
+def test_completion_status_keeps_malformed_tool_attempts(status):
+    parsed = ParsedResponse(
+        content="looks like a summary",
+        tool_calls=[ParsedToolCall(raw="partial", status=status)],
+        completion_status=CompletionStatus("complete", None),
+    )
+    assert classify_completion(parsed, "stop") == CompletionStatus(
+        "invalid", "malformed_tool_call"
+    )
+
+
+@pytest.mark.parametrize("family", ["laguna", "qwen35"])
+@pytest.mark.parametrize("closed", [False, True])
+@pytest.mark.parametrize("prefilled", [False, True])
+def test_reasoning_boundary_status_across_parsers(family, closed, prefilled):
+    from renderers.parsing import parse_laguna_xs2, parse_qwen35
+
+    class Tokenizer:
+        def decode(self, ids, **kwargs):
+            return "".join({3: "reason", 4: "summary"}.get(i, "") for i in ids)
+
+    parser = parse_laguna_xs2 if family == "laguna" else parse_qwen35
+    ids = ([] if prefilled else [1]) + ([3, 2, 4, 9] if closed else [3, 9])
+    parsed = parser(
+        Tokenizer(),
+        ids,
+        stop_ids={9},
+        think_id=1,
+        think_end_id=2,
+        tool_call_id=5,
+        tool_call_end_id=6,
+        prefilled_thinking=prefilled,
+    )
+    assert parsed.reasoning_content == "reason"
+    assert parsed.content == ("summary" if closed else "")
+    assert parsed.completion_status == (
+        CompletionStatus("complete", None)
+        if closed
+        else CompletionStatus("incomplete", "unfinished_reasoning")
     )
 
 

--- a/tests/test_laguna_xs21.py
+++ b/tests/test_laguna_xs21.py
@@ -252,6 +252,7 @@ def test_parse_no_think_completion():
     completion is pure content up to ``</assistant>``."""
     parsed = _renderer().parse_response(_completion_ids("Four.</assistant>"))
     assert parsed.content == "Four."
+    assert parsed.completion_status.status == "complete"
     assert parsed.reasoning_content is None
     assert not parsed.tool_calls
 
@@ -276,12 +277,15 @@ def test_parse_unclosed_prefilled_thinking(renderer_name, explicit_open, stop):
     assert parsed.reasoning_content == text
     assert parsed.content == ""
     assert parsed.tool_calls == []
+    assert parsed.completion_status.status == "incomplete"
+    assert parsed.completion_status.reason == "unfinished_reasoning"
 
     closed = renderer.parse_response(
         _completion_ids("Thought</think>Answer.</assistant>")
     )
     assert closed.reasoning_content == "Thought"
     assert closed.content == "Answer."
+    assert closed.completion_status.status == "complete"
 
 
 def test_parse_preserves_newlines_verbatim():


### PR DESCRIPTION
## Summary
Stacked on #152. Adds versioned structural completion evidence (complete, incomplete, invalid, unknown), separate from engine finish reason and task success. Detected unfinished reasoning stays in reasoning_content with empty final content. Laguna and Qwen3.5 account for prefilled reasoning; unaudited parsers stay unknown. No synthetic closing tokens or changes to sampled tokens/logprobs.

The generate client combines parser evidence, malformed tool attempts and termination. Companion verifiers and nano-rlm PRs transport and consume this metadata to reject failed compactions. Links will be added after creation.

Related to #139, but does not fix bridge_to_next_turn or close that issue. #151 is merged; this branch retains its tested ancestry via #152.

## Validation
80 focused renderer tests passed. Cross-library offline propagation checks and two synthetic local Laguna requests passed (unfinished reasoning rejected, completed response accepted). No full all-renderer coverage claim.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expose structural `CompletionStatus` from parsers and client results
> - Added a frozen `CompletionStatus` dataclass to [renderers/base.py](https://github.com/PrimeIntellect-ai/renderers/pull/153/files#diff-a9eeb77ff01d40ec84231f7891fffe7f7ca78885038b46c8468436a9436a5fbf) with a constrained status (`complete`, `incomplete`, `invalid`, `unknown`) and optional reason. `ParsedResponse` now defaults to `unknown` with `parser_unavailable`.
> - Added `classify_completion` to map parser evidence, malformed tool-call states, finish reasons, and presence of final output into the new status.
> - Updated `parse_qwen35` and `parse_laguna_xs2` to detect unclosed reasoning blocks and report `incomplete` with an `unfinished_reasoning` reason.
> - [renderers/client.py](https://github.com/PrimeIntellect-ai/renderers/pull/153/files#diff-4eceef280041aa5c33da06241f0ca20ad18ca3b7a395767ebc916e9a46ff2f33) `generate()` now includes a `completion_status` dictionary derived from the parsed response and finish reason.
> - Behavioral Change: `ParsedResponse` and generation results include the new `completion_status` field. Existing termination, token, and logprob fields remain unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea0e896.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

## Cross-repository companions
- Renderer producer: https://github.com/PrimeIntellect-ai/renderers/pull/153
- Verifiers transport/trace: https://github.com/PrimeIntellect-ai/verifiers/pull/2543
- Nano-RLM compaction consumer: https://github.com/PrimeIntellect-ai/nano-rlm/pull/175
Deploy the three together before enabling strict completion verification. Each PR is stacked on the preceding change in its own repository.
